### PR TITLE
Add DynamicDependency to static DI registration field

### DIFF
--- a/src/DependencyModules.SourceGenerator.Impl/DependencyFileWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyFileWriter.cs
@@ -75,6 +75,7 @@ public class DependencyFileWriter {
         var field = classDefinition.AddField(typeof(int), lowerName);
 
         field.Modifiers |= ComponentModifier.Private | ComponentModifier.Static;
+        field.AddAttribute(TypeDefinition.Get("System.Diagnostics.CodeAnalysis", "DynamicDependency"), $"nameof({methodName})");
 
         var closedType = new GenericTypeDefinition(
             TypeDefinitionEnum.ClassDefinition, KnownTypes.DependencyModules.Helpers.Namespace, "DependencyRegistry", new[] {


### PR DESCRIPTION
## Summary
- Adds `[DynamicDependency(nameof({methodName}))]` to the generated static DI registration field in `DependencyFileWriter`
- Prevents the AOT trimmer from removing the field whose `DependencyRegistry.Add()` side-effect registers services

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` passes (53/53)
- [ ] Verify generated output includes `[DynamicDependency]` on static fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)