### PR TITLE
Add IModuleEnvironment and source generator extensibility

### DIFF
--- a/integ-tests/SutProject.Tests/EnvironmentTests/EnvironmentConfigurationTests.cs
+++ b/integ-tests/SutProject.Tests/EnvironmentTests/EnvironmentConfigurationTests.cs
@@ -1,0 +1,140 @@
+using DependencyModules.Runtime;
+using DependencyModules.Runtime.Attributes;
+using DependencyModules.Runtime.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace SutProject.Tests.EnvironmentTests;
+
+public class TestEnvironment : IModuleEnvironment {
+    public string EnvironmentName { get; }
+
+    private readonly Dictionary<string, string> _values;
+
+    public TestEnvironment(string environmentName, Dictionary<string, string>? values = null) {
+        EnvironmentName = environmentName;
+        _values = values ?? new Dictionary<string, string>();
+    }
+
+    public string? Value(string name) {
+        return _values.TryGetValue(name, out var value) ? value : null;
+    }
+}
+
+public interface IEnvironmentDependency {
+    string EnvironmentName { get; }
+}
+
+public class EnvironmentDependency(string environmentName) : IEnvironmentDependency {
+    public string EnvironmentName { get; } = environmentName;
+}
+
+[DependencyModule]
+public partial class EnvironmentAwareModule : IEnvironmentServiceCollectionConfiguration {
+    public void ConfigureServices(IServiceCollection services, IModuleEnvironment? environment) {
+        var envName = environment?.EnvironmentName ?? "Unknown";
+        services.AddSingleton<IEnvironmentDependency>(new EnvironmentDependency(envName));
+    }
+}
+
+[DependencyModule]
+public partial class DualConfigModule : IServiceCollectionConfiguration, IEnvironmentServiceCollectionConfiguration {
+    public void ConfigureServices(IServiceCollection services) {
+        services.AddSingleton(new StringMarker("from-configure"));
+    }
+
+    public void ConfigureServices(IServiceCollection services, IModuleEnvironment? environment) {
+        var envName = environment?.EnvironmentName ?? "Unknown";
+        services.AddSingleton<IEnvironmentDependency>(new EnvironmentDependency(envName));
+    }
+}
+
+public class StringMarker(string value) {
+    public string Value { get; } = value;
+}
+
+public class EnvironmentConfigurationTests {
+    [Fact]
+    public void EnvironmentPassedToModule_WhenRegistered() {
+        var serviceCollection = new ServiceCollection();
+        var environment = new TestEnvironment("Production");
+
+        serviceCollection.AddModules(environment, new EnvironmentAwareModule());
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var dependency = serviceProvider.GetRequiredService<IEnvironmentDependency>();
+
+        Assert.Equal("Production", dependency.EnvironmentName);
+    }
+
+    [Fact]
+    public void NullEnvironment_WhenNotRegistered() {
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection.AddModules(new EnvironmentAwareModule());
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var dependency = serviceProvider.GetRequiredService<IEnvironmentDependency>();
+
+        Assert.Equal("Unknown", dependency.EnvironmentName);
+    }
+
+    [Fact]
+    public void EnvironmentRegisteredAsSingleton_WhenProvided() {
+        var serviceCollection = new ServiceCollection();
+        var environment = new TestEnvironment("Development");
+
+        serviceCollection.AddModules(environment, new EnvironmentAwareModule());
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var resolved = serviceProvider.GetRequiredService<IModuleEnvironment>();
+
+        Assert.Same(environment, resolved);
+    }
+
+    [Fact]
+    public void EnvironmentValues_AccessibleInModule() {
+        var serviceCollection = new ServiceCollection();
+        var values = new Dictionary<string, string> {
+            { "Region", "us-east-1" },
+            { "Feature.NewUI", "true" }
+        };
+        var environment = new TestEnvironment("Staging", values);
+
+        serviceCollection.AddModules(environment, new EnvironmentAwareModule());
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var resolved = serviceProvider.GetRequiredService<IModuleEnvironment>();
+
+        Assert.Equal("us-east-1", resolved.Value("Region"));
+        Assert.Equal("true", resolved.Value("Feature.NewUI"));
+        Assert.Null(resolved.Value("NonExistent"));
+    }
+
+    [Fact]
+    public void BothConfigurationInterfaces_CalledCorrectly() {
+        var serviceCollection = new ServiceCollection();
+        var environment = new TestEnvironment("Test");
+
+        serviceCollection.AddModules(environment, new DualConfigModule());
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var envDep = serviceProvider.GetRequiredService<IEnvironmentDependency>();
+        var marker = serviceProvider.GetRequiredService<StringMarker>();
+
+        Assert.Equal("Test", envDep.EnvironmentName);
+        Assert.Equal("from-configure", marker.Value);
+    }
+
+    [Fact]
+    public void NullEnvironmentParameter_DoesNotRegisterSingleton() {
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection.AddModules((IModuleEnvironment?)null, new EnvironmentAwareModule());
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var resolved = serviceProvider.GetService<IModuleEnvironment>();
+
+        Assert.Null(resolved);
+    }
+}

--- a/src/DependencyModules.Runtime/Helpers/DependencyRegistry.cs
+++ b/src/DependencyModules.Runtime/Helpers/DependencyRegistry.cs
@@ -182,6 +182,20 @@ public class DependencyRegistry<T> {
     }
 
     private static void ApplyServices(IServiceCollection serviceCollection, IReadOnlyList<IDependencyModule> modules) {
+        IModuleEnvironment? environment = null;
+        var hasEnvironmentModules = false;
+
+        for (var i = 0; i < modules.Count; i++) {
+            if (modules[i] is IEnvironmentServiceCollectionConfiguration) {
+                hasEnvironmentModules = true;
+                break;
+            }
+        }
+
+        if (hasEnvironmentModules) {
+            environment = FindModuleEnvironment(serviceCollection);
+        }
+
         for (var i = 0; i < modules.Count; i++) {
             var module = modules[i];
             module.InternalApplyServices(serviceCollection);
@@ -189,7 +203,24 @@ public class DependencyRegistry<T> {
             if (module is IServiceCollectionConfiguration serviceCollectionConfigure) {
                 serviceCollectionConfigure.ConfigureServices(serviceCollection);
             }
+
+            if (module is IEnvironmentServiceCollectionConfiguration environmentConfigure) {
+                environmentConfigure.ConfigureServices(serviceCollection, environment);
+            }
         }
+    }
+
+    private static IModuleEnvironment? FindModuleEnvironment(IServiceCollection serviceCollection) {
+        for (var i = serviceCollection.Count - 1; i >= 0; i--) {
+            var descriptor = serviceCollection[i];
+            if (descriptor.ServiceType == typeof(IModuleEnvironment) &&
+                descriptor.Lifetime == ServiceLifetime.Singleton &&
+                descriptor.ImplementationInstance is IModuleEnvironment environment) {
+                return environment;
+            }
+        }
+
+        return null;
     }
 
     private static void ApplyFeatures(IServiceCollection serviceCollection, IReadOnlyList<IDependencyModule> modules) {

--- a/src/DependencyModules.Runtime/Interfaces/IModuleEnvironment.cs
+++ b/src/DependencyModules.Runtime/Interfaces/IModuleEnvironment.cs
@@ -1,0 +1,18 @@
+namespace DependencyModules.Runtime.Interfaces;
+
+/// <summary>
+///     Minimal environment interface for conditional service registration.
+/// </summary>
+public interface IModuleEnvironment {
+    /// <summary>
+    /// The name of the current environment (e.g. "Development", "Production").
+    /// </summary>
+    string EnvironmentName { get; }
+
+    /// <summary>
+    /// Retrieve an environment value by name, returning null if not found.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    string? Value(string name);
+}

--- a/src/DependencyModules.Runtime/Interfaces/IServiceCollectionConfiguration.cs
+++ b/src/DependencyModules.Runtime/Interfaces/IServiceCollectionConfiguration.cs
@@ -18,3 +18,15 @@ public interface IServiceCollectionConfiguration {
     /// <param name="services"></param>
     void ConfigureDecorators(IServiceCollection services) { }
 }
+
+/// <summary>
+///     DependencyModules that need access to the environment during registration should implement this interface.
+/// </summary>
+public interface IEnvironmentServiceCollectionConfiguration {
+    /// <summary>
+    /// Configure services with access to the module environment.
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="environment"></param>
+    void ConfigureServices(IServiceCollection services, IModuleEnvironment? environment);
+}

--- a/src/DependencyModules.Runtime/ServiceCollectionExtensions.cs
+++ b/src/DependencyModules.Runtime/ServiceCollectionExtensions.cs
@@ -40,7 +40,24 @@ public static class ServiceCollectionExtensions {
     /// <returns></returns>
     public static IServiceCollection AddModules(this IServiceCollection services, params IDependencyModule[] modules) {
         DependencyRegistry<object>.LoadModules(services, modules);
-        
+
+        return services;
+    }
+
+    /// <summary>
+    ///     Add dependency modules to service collection with an environment for conditional registration
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="environment"></param>
+    /// <param name="modules"></param>
+    /// <returns></returns>
+    public static IServiceCollection AddModules(this IServiceCollection services, IModuleEnvironment? environment, params IDependencyModule[] modules) {
+        if (environment != null) {
+            services.AddSingleton(environment);
+        }
+
+        DependencyRegistry<object>.LoadModules(services, modules);
+
         return services;
     }
 }

--- a/src/DependencyModules.SourceGenerator.Impl/BaseSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/BaseSourceGenerator.cs
@@ -25,6 +25,14 @@ public abstract class BaseSourceGenerator : IIncrementalGenerator {
 
     protected abstract IEnumerable<IDependencyModuleSourceGenerator> AttributeSourceGenerators();
 
+    /// <summary>
+    /// Returns the attribute types that trigger module source generation.
+    /// Override to support custom trigger attributes (e.g. for framework-specific module attributes).
+    /// </summary>
+    protected virtual ITypeDefinition[] ModuleAttributeTypes() {
+        return new[] { KnownTypes.DependencyModules.Attributes.DependencyModuleAttribute };
+    }
+
     private IncrementalValueProvider<DependencyModuleConfigurationModel> CreateConfigurationValueProvider(IncrementalGeneratorInitializationContext context) {
         return context.AnalyzerConfigOptionsProvider.Select((options, _) => {
             RegistrationType defaultRegistrationType = RegistrationType.Add;
@@ -83,7 +91,7 @@ public abstract class BaseSourceGenerator : IIncrementalGenerator {
 
     private IncrementalValuesProvider<ModuleEntryPointModel> CreateSourceValueProvider(IncrementalGeneratorInitializationContext context) {
         var classSelector = new SyntaxSelector<ClassDeclarationSyntax, RecordDeclarationSyntax, CompilationUnitSyntax>(
-            KnownTypes.DependencyModules.Attributes.DependencyModuleAttribute) {
+            ModuleAttributeTypes()) {
             AutoApproveCompilationUnit = true,
             ApproveFilter = "Program.cs",
         };


### PR DESCRIPTION
## Summary
- Add `IModuleEnvironment` interface and `IEnvironmentServiceCollectionConfiguration` for environment-aware conditional service registration
- Wire environment discovery through `DependencyRegistry` via `ServiceCollection` singleton lookup, with a new `AddModules(IModuleEnvironment?, params IDependencyModule[])` overload
- Extract `ModuleAttributeTypes()` as a `protected virtual` method in `BaseSourceGenerator` so subclasses can trigger on custom attributes (e.g. framework-specific module attributes)
- Add 6 integration tests covering environment configuration, null handling, and dual-interface modules

## Test plan
- [x] All 57 existing SutProject.Tests pass
- [x] All 2 WebApiApp.Tests pass
- [x] 6 new EnvironmentConfigurationTests pass
- [x] Solution builds with no errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)