### PR TITLE
Make AutoApproveCompilationUnit configurable

### DIFF
--- a/src/DependencyModules.SourceGenerator.Impl/BaseSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/BaseSourceGenerator.cs
@@ -89,10 +89,12 @@ public abstract class BaseSourceGenerator : IIncrementalGenerator {
     protected virtual void SetupRootGenerator(IncrementalGeneratorInitializationContext context,
         IncrementalValueProvider<ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)>> valuesProvider) { }
 
+    protected virtual bool ShouldAutoApproveCompilationUnit => true;
+
     private IncrementalValuesProvider<ModuleEntryPointModel> CreateSourceValueProvider(IncrementalGeneratorInitializationContext context) {
         var classSelector = new SyntaxSelector<ClassDeclarationSyntax, RecordDeclarationSyntax, CompilationUnitSyntax>(
             ModuleAttributeTypes()) {
-            AutoApproveCompilationUnit = true,
+            AutoApproveCompilationUnit = ShouldAutoApproveCompilationUnit,
             ApproveFilter = "Program.cs",
         };
 


### PR DESCRIPTION
## Summary
- Adds virtual `ShouldAutoApproveCompilationUnit` property to `BaseSourceGenerator`
- Allows derived generators to disable auto-approval of `CompilationUnitSyntax` (Program.cs)
- Prevents duplicate `ApplicationModule` generation when multiple DM-based generators are present in a consumer project

## Context
When `Hardened.DependencyModules.SourceGenerator` (which derives from `BaseSourceGenerator`) is bundled alongside the standalone `DependencyModules.SourceGenerator`, both generators auto-approve Program.cs and generate duplicate `ApplicationModule` code. This change lets the Hardened generator set `ShouldAutoApproveCompilationUnit => false` to avoid the conflict.

## Test plan
- [x] Existing tests pass (no behavior change for default `true` value)
- [ ] Hardened.Framework integration: override to `false` in `HardenedSourceGenerator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)