### PR TITLE
Add ExcludeGeneratedCodeFromCoverage support

### DIFF
--- a/src/DependencyModules.SourceGenerator.Impl/BaseSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/BaseSourceGenerator.cs
@@ -73,16 +73,22 @@ public abstract class BaseSourceGenerator : IIncrementalGenerator {
             if (options.GlobalOptions.TryGetValue("build_property.DependencyModules_GenerateFactories", out var generateFactoriesString)) {
                 generateFactories = generateFactoriesString.Equals("true", StringComparison.OrdinalIgnoreCase);
             }
-            
+
+            var excludeGeneratedCodeFromCoverage = true;
+            if (options.GlobalOptions.TryGetValue("build_property.ExcludeGeneratedCodeFromCoverage", out var excludeCoverageString)) {
+                excludeGeneratedCodeFromCoverage = !excludeCoverageString.Equals("false", StringComparison.OrdinalIgnoreCase);
+            }
+
             return new DependencyModuleConfigurationModel(
-                defaultRegistrationType, 
-                registerSourceGenerator, 
+                defaultRegistrationType,
+                registerSourceGenerator,
                 rootNamespace,
                 projectDirectory,
                 autoGenerateEntry,
                 logOutputFolder,
                 LogOutputLevel.Debug,
-                generateFactories);
+                generateFactories,
+                excludeGeneratedCodeFromCoverage);
         }).WithComparer(new DependencyModuleConfigurationModelComparer());
     }
 

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyFileWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyFileWriter.cs
@@ -63,6 +63,11 @@ public class DependencyFileWriter {
 
         classDefinition.Modifiers |= ComponentModifier.Partial;
 
+        if (configurationModel.ExcludeGeneratedCodeFromCoverage) {
+            classDefinition.AddAttribute(
+                TypeDefinition.Get("System.Diagnostics.CodeAnalysis", "ExcludeFromCodeCoverage"));
+        }
+
         var methodName =
             GenerateDependencyMethod(entryPointModel, configurationModel, serviceModels, classDefinition, uniqueId);
 

--- a/src/DependencyModules.SourceGenerator.Impl/Models/DependencyModuleConfigurationModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/DependencyModuleConfigurationModel.cs
@@ -20,7 +20,8 @@ public record DependencyModuleConfigurationModel(
     bool AutoGenerateEntry,
     string LogOutputFolder,
     LogOutputLevel LogOutputLevel,
-    bool GenerateFactories
+    bool GenerateFactories,
+    bool ExcludeGeneratedCodeFromCoverage = true
 );
 
 public class DependencyModuleConfigurationModelComparer :
@@ -31,14 +32,15 @@ public class DependencyModuleConfigurationModelComparer :
         if (x is null) return false;
         if (y is null) return false;
         if (x.GetType() != y.GetType()) return false;
-        return x.RegistrationType == y.RegistrationType && 
+        return x.RegistrationType == y.RegistrationType &&
                x.RegisterSourceGenerator == y.RegisterSourceGenerator &&
                x.RootNamespace == y.RootNamespace &&
                x.ProjectDir == y.ProjectDir &&
                x.LogOutputFolder == y.LogOutputFolder &&
                x.AutoGenerateEntry == y.AutoGenerateEntry &&
                x.LogOutputLevel == y.LogOutputLevel &&
-               x.GenerateFactories == y.GenerateFactories;
+               x.GenerateFactories == y.GenerateFactories &&
+               x.ExcludeGeneratedCodeFromCoverage == y.ExcludeGeneratedCodeFromCoverage;
     }
 
     public int GetHashCode(DependencyModuleConfigurationModel obj) {

--- a/src/DependencyModules.SourceGenerator/Package/DependencyModules.SourceGenerator.targets
+++ b/src/DependencyModules.SourceGenerator/Package/DependencyModules.SourceGenerator.targets
@@ -1,5 +1,9 @@
 <Project>
+    <PropertyGroup>
+        <ExcludeGeneratedCodeFromCoverage Condition="'$(ExcludeGeneratedCodeFromCoverage)' == ''">true</ExcludeGeneratedCodeFromCoverage>
+    </PropertyGroup>
     <ItemGroup>
         <CompilerVisibleProperty Include="DependencyModules_RegistrationType"/>
+        <CompilerVisibleProperty Include="ExcludeGeneratedCodeFromCoverage"/>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Add `ExcludeGeneratedCodeFromCoverage` MSBuild property (defaults to `true`)
- Generated partial classes now emit `[ExcludeFromCodeCoverage]` attribute
- Property declared as `CompilerVisibleProperty` in `.targets` for automatic NuGet consumer support
- Consumers opt out by setting `<ExcludeGeneratedCodeFromCoverage>false</ExcludeGeneratedCodeFromCoverage>`

## Test plan
- [x] `dotnet build` compiles
- [x] All 59 existing tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)