### PR TITLE
Fix [ModuleTest] cases colliding across test classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ fixes packaging and generated-code defects and commits to the API surface going 
   `DependencyModules_RegistrationType` silently stopped reaching the generator.
 - **`DependencyModules_LogOutputDirectory` is now honoured.** Generator diagnostic logs were
   written to the compiler's working directory instead of the configured folder.
+- **`[ModuleTest]` cases no longer collide across test classes.** The test case unique ID was the
+  bare method name, so two test classes each declaring a same-named test produced colliding IDs and
+  xUnit silently dropped one — a green run with tests quietly not executing. Discovery now defers to
+  xUnit's own `TestIntrospectionHelper`, which derives the ID through the assembly, collection,
+  class, and method chain, and also picks up display name formatting, skip and explicit attributes,
+  and timeouts consistently with `[Fact]` and `[Theory]`. Test case display names are now
+  fully qualified, matching xUnit's convention.
+- **Data-driven `[ModuleTest]` rows are named individually.** Every row of an `[InlineData]` module
+  test shared one display name, so rows were indistinguishable in test explorers and result files.
+  Each row is now named after its own arguments. Parameters injected from the container show as
+  `???`, which is xUnit's rendering for a parameter with no discovery-time value.
 - **Nested service classes generate valid code.** A service declared inside another type was
   emitted without its containing type — `Namespace.Inner` instead of `Namespace.Outer.Inner` —
   so the generated registration failed to compile with `CS0234`. Note that modules themselves
@@ -61,7 +72,8 @@ fixes packaging and generated-code defects and commits to the API surface going 
   MSBuild property flow. Runs in CI.
 - `scripts/coverage.sh`: runs every suite with coverage collection, merges the results across the
   shipping libraries, and fails below a threshold. CI publishes the summary to the run summary and
-  a coverage badge to the `badges` branch.
+  a coverage badge to the `badges` branch. It also fails the build if xUnit reports a
+  skipped test case with a duplicate unique ID, so silently dropped tests can never pass unnoticed.
 - A tag-driven release workflow publishing to nuget.org and GitHub Packages.
 
 [1.0.0]: https://github.com/ipjohnson/DependencyModules/releases/tag/v1.0.0

--- a/integ-tests/SutProject.Tests/DataTests/InlineDataTests.cs
+++ b/integ-tests/SutProject.Tests/DataTests/InlineDataTests.cs
@@ -13,3 +13,16 @@ public class InlineDataTests {
         Assert.NotNull(one);
     }
 }
+
+public class MultiRowDataTests {
+
+    [ModuleTest]
+    [InlineData("one")]
+    [InlineData("two")]
+    [InlineData("three")]
+    [SutModule]
+    public void MultipleRows(string value, IDependencyOne one) {
+        Assert.NotNull(value);
+        Assert.NotNull(one);
+    }
+}

--- a/integ-tests/SutProject.Tests/DuplicateNames/FirstDuplicateNameTests.cs
+++ b/integ-tests/SutProject.Tests/DuplicateNames/FirstDuplicateNameTests.cs
@@ -1,0 +1,17 @@
+using DependencyModules.xUnit.Attributes;
+using Xunit;
+
+namespace SutProject.Tests.DuplicateNames;
+
+/// <summary>
+/// Paired with <see cref="SecondDuplicateNameTests"/>: both declare a [ModuleTest] method with the
+/// same name. A test case unique ID built from the bare method name collides across classes, and
+/// xUnit silently drops the duplicate, so both of these must still run.
+/// </summary>
+public class FirstDuplicateNameTests {
+    [ModuleTest]
+    [SutModule]
+    public void SharedMethodName(IDependencyOne dependency) {
+        Assert.NotNull(dependency);
+    }
+}

--- a/integ-tests/SutProject.Tests/DuplicateNames/SecondDuplicateNameTests.cs
+++ b/integ-tests/SutProject.Tests/DuplicateNames/SecondDuplicateNameTests.cs
@@ -1,0 +1,15 @@
+using DependencyModules.xUnit.Attributes;
+using Xunit;
+
+namespace SutProject.Tests.DuplicateNames;
+
+/// <summary>
+/// See <see cref="FirstDuplicateNameTests"/>.
+/// </summary>
+public class SecondDuplicateNameTests {
+    [ModuleTest]
+    [SutModule]
+    public void SharedMethodName(IDependencyOne dependency) {
+        Assert.NotNull(dependency);
+    }
+}

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -30,6 +30,8 @@ PROJECTS=(
     "integ-tests/web/WebApiApp.Tests/WebApiApp.Tests.csproj"
 )
 
+TEST_LOG="${RAW}/test-output.log"
+
 for project in "${PROJECTS[@]}"; do
     echo "==> ${project}"
     dotnet test "${REPO_ROOT}/${project}" \
@@ -37,8 +39,22 @@ for project in "${PROJECTS[@]}"; do
         --collect:"XPlat Code Coverage" \
         --settings "${REPO_ROOT}/tests/coverlet.runsettings" \
         --results-directory "${RAW}" \
-        --nologo
+        --nologo | tee -a "${TEST_LOG}"
+
+    # tee masks the exit status, so consult the pipeline's first element.
+    status="${PIPESTATUS[0]}"
+    [ "${status}" -eq 0 ] || exit "${status}"
 done
+
+# xUnit drops a test case whose unique ID collides with one already discovered, and it does so
+# without failing the run: the suite stays green while tests quietly stop executing. Promote that
+# warning to a build failure so it can never pass unnoticed.
+if grep -q "duplicate ID" "${TEST_LOG}"; then
+    echo >&2
+    echo "FAIL: xUnit skipped a test case with a duplicate unique ID. Tests were silently dropped." >&2
+    grep "duplicate ID" "${TEST_LOG}" >&2
+    exit 1
+fi
 
 if ! command -v reportgenerator >/dev/null 2>&1; then
     echo "==> Installing reportgenerator"

--- a/src/DependencyModules.xUnit/Impl/ModuleTestCase.cs
+++ b/src/DependencyModules.xUnit/Impl/ModuleTestCase.cs
@@ -5,6 +5,7 @@ using DependencyModules.xUnit.Attributes;
 using DependencyModules.xUnit.Attributes.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit.Internal;
+using Xunit.Sdk;
 using Xunit.v3;
 
 namespace DependencyModules.xUnit.Impl;
@@ -193,7 +194,7 @@ public class ModuleTestCase : XunitTestCase {
                         TestMethod,
                         Explicit,
                         theoryDataRow.Skip ?? SkipReason,
-                        TestCaseDisplayName,
+                        GetRowDisplayName(theoryDataRow, data),
                         unitTests.Count,
                         theoryDataRow.Traits?.ToReadOnly() ?? Traits.ToReadOnly(),
                         theoryDataRow.Timeout ?? Timeout,
@@ -204,6 +205,22 @@ public class ModuleTestCase : XunitTestCase {
         }
 
         return unitTests;
+    }
+
+    /// <summary>
+    /// Names a data row after its own arguments, the way [Theory] does. Without this every row of
+    /// a data-driven module test carries the same display name and the rows cannot be told apart
+    /// in test explorers or result files.
+    /// </summary>
+    /// <remarks>
+    /// Only the row's own data is used. The remaining parameters are resolved from the container
+    /// at execution time, and naming a test after a service instance would be neither readable
+    /// nor stable between runs.
+    /// </remarks>
+    private string GetRowDisplayName(Xunit.ITheoryDataRow theoryDataRow, object?[] data) {
+        var baseDisplayName = theoryDataRow.TestDisplayName ?? TestCaseDisplayName;
+
+        return TestMethod.GetDisplayName(baseDisplayName, data, null);
     }
 
     private async Task<IReadOnlyCollection<IXunitTest>> UnitTestWithNoDataAttributes() {

--- a/src/DependencyModules.xUnit/Impl/ModuleTestDiscoverer.cs
+++ b/src/DependencyModules.xUnit/Impl/ModuleTestDiscoverer.cs
@@ -1,4 +1,5 @@
 using DependencyModules.xUnit.Attributes;
+using Xunit.Internal;
 using Xunit.Sdk;
 using Xunit.v3;
 
@@ -35,13 +36,25 @@ public class ModuleTestDiscoverer : IXunitTestCaseDiscoverer {
     public ValueTask<IReadOnlyCollection<IXunitTestCase>> Discover(
         ITestFrameworkDiscoveryOptions discoveryOptions, IXunitTestMethod testMethod, IFactAttribute factAttribute) {
 
+        // Delegate to xUnit's own introspection rather than deriving these by hand. The bare method
+        // name is not unique across test classes, and xUnit silently drops a test case whose ID
+        // collides with one already discovered. This also picks up display name formatting, the
+        // skip and explicit attributes, and the timeout, consistently with [Fact] and [Theory].
+        var details = TestIntrospectionHelper.GetTestCaseDetails(discoveryOptions, testMethod, factAttribute);
+
         return new ValueTask<IReadOnlyCollection<IXunitTestCase>>(
             new[] {
                 new ModuleTestCase(
-                    testMethod,
-                    testMethod.MethodName,
-                    testMethod.MethodName,
-                    false
+                    details.ResolvedTestMethod,
+                    details.TestCaseDisplayName,
+                    details.UniqueID,
+                    details.Explicit,
+                    details.SkipReason,
+                    details.SkipType,
+                    details.SkipUnless,
+                    details.SkipWhen,
+                    testMethod.Traits.ToReadWrite(StringComparer.OrdinalIgnoreCase),
+                    timeout: details.Timeout
                 )
             }
         );


### PR DESCRIPTION
Reported from a downstream consumer: `Hardened.Commands.Tests` declared 6 `[HardenedTest]` methods and executed 2, with xUnit logging `Skipping test case with duplicate ID 'ParseSimpleCommand'`.

## The bug

`ModuleTestDiscoverer` passed the bare method name as the test case unique ID:

```csharp
new ModuleTestCase(testMethod, testMethod.MethodName, testMethod.MethodName, false)
//                                                    ^^^^^^^^^^^^^^^^^^^^^^ uniqueID
```

Two test classes each declaring a same-named `[ModuleTest]` produce colliding IDs, and xUnit drops the duplicate **without failing the run**. The suite stays green while tests quietly stop executing.

Reproduced here before fixing — two classes with a `SharedMethodName` test discovered **58** cases instead of 59:

```
Skipping test case with duplicate ID 'SharedMethodName' ('SharedMethodName' and 'SharedMethodName')
Failed: 0, Passed: 57, Total: 58
```

## The fix

Discovery now defers to xUnit's own `TestIntrospectionHelper.GetTestCaseDetails` instead of deriving these by hand. That derives the ID through the assembly → collection → class → method chain, so IDs are assembly-scoped without inventing a scheme we would be stuck with after a stable release. It also picks up display name formatting, the skip and explicit attributes, and timeouts consistently with `[Fact]` and `[Theory]`.

After: **62** cases, no skipping, both same-named tests execute. Display names are now fully qualified, e.g. `SutProject.Tests.DuplicateNames.FirstDuplicateNameTests.SharedMethodName`.

## Data-driven tests had a related problem

Every row of an `[InlineData]` module test shared one display name, so rows were indistinguishable in test explorers and result files. Each row is now named after its own arguments:

```
MultipleRows(value: "one", one: ???)
MultipleRows(value: "two", one: ???)
MultipleRows(value: "three", one: ???)
```

`???` is xUnit's own rendering for a parameter with no discovery-time value, which DI-injected parameters genuinely have none of. Naming a test after a service instance would be neither readable nor stable between runs.

## A dropped test case is a warning, not a failure

Regression tests cannot catch this, because the symptom is silence. `scripts/coverage.sh` now fails the build when xUnit reports a skipped duplicate ID. Verified both ways — reverting only the discoverer makes the guard exit 1:

```
FAIL: xUnit skipped a test case with a duplicate unique ID. Tests were silently dropped.
```

## Why before 1.0.0

Test case IDs appear in result files, filters, and tooling, and are much harder to change after a stable release than before one.

334 tests passing (270 unit/generator + 62 integration + 2 web), coverage 86.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPG3s4DPZZ6E4qJ6q8kSs