### PR TITLE
Verify generated code by executing it, and make the generator diagnosable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ fixes packaging and generated-code defects and commits to the API surface going 
   `DependencyModules_RegistrationType` silently stopped reaching the generator.
 - **`DependencyModules_LogOutputDirectory` is now honoured.** Generator diagnostic logs were
   written to the compiler's working directory instead of the configured folder.
+- **`[CrossWireService(Lifetime = ...)]` is honoured.** The lifetime arrived as the source text
+  `"ServiceLifetime.Scoped"`, `Enum.TryParse` failed on the qualified name, and the silent fallback
+  registered every cross-wired service as a singleton no matter what was asked for. The existing
+  test for this could not detect it: it asserted `Assert.Same(interface1, interface1)`, comparing a
+  value to itself.
 - **`[ModuleTest]` cases no longer collide across test classes.** The test case unique ID was the
   bare method name, so two test classes each declaring a same-named test produced colliding IDs and
   xUnit silently dropped one — a green run with tests quietly not executing. Discovery now defers to
@@ -74,6 +79,17 @@ fixes packaging and generated-code defects and commits to the API surface going 
   shipping libraries, and fails below a threshold. CI publishes the summary to the run summary and
   a coverage badge to the `badges` branch. It also fails the build if xUnit reports a
   skipped test case with a duplicate unique ID, so silently dropped tests can never pass unnoticed.
+- Public API approval tests pinning the surface of every package that ships a referenceable
+  assembly, so an accidental breaking change after 1.0.0 fails the build instead of shipping.
+- Behavioural verification of generated code: tests compile with the real compiler, load the
+  emitted assembly, and assert on resolved instances and lifetimes rather than on the shape of the
+  generated text.
+- Direct tests for `ModuleTestDiscoverer`, written as plain `[Fact]` tests. Every integration test
+  runs through `[ModuleTest]`, so a discoverer fault makes that suite quietly smaller rather than
+  red; testing it from outside the framework is what makes such faults visible.
+- Lifetime semantics tests that cross scope boundaries. Resolving twice from one provider cannot
+  tell a singleton from a scoped service, which is why registering singletons as scoped previously
+  went unnoticed by the integration suite.
 - A tag-driven release workflow publishing to nuget.org and GitHub Packages.
 
 [1.0.0]: https://github.com/ipjohnson/DependencyModules/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ fixes packaging and generated-code defects and commits to the API surface going 
   `DependencyModules_RegistrationType` silently stopped reaching the generator.
 - **`DependencyModules_LogOutputDirectory` is now honoured.** Generator diagnostic logs were
   written to the compiler's working directory instead of the configured folder.
+- **The generator's configuration properties are reachable from a package.** The packaged
+  `build/*.targets` declared only two of the properties the generator reads, so
+  `DependencyModules_LogOutputDirectory`, `DependencyModules_RegisterGenerator`,
+  `DependencyModules_AutoGenerateModule`, and `DependencyModules_GenerateFactories` silently took
+  their defaults for anyone consuming the NuGet package. The diagnostic log in particular could not
+  be switched on at all. This went unnoticed because the integration tests reference the generator
+  as a project rather than a package, which bypasses `build/*.targets` entirely.
+- **A failing generator no longer fails silently.** Exceptions were caught and, with no log
+  directory configured, discarded — which also stopped Roslyn reporting its own CS8785. The build
+  succeeded, no registrations were produced, and nothing said so. The generator now reports DM0001.
 - **`[CrossWireService(Lifetime = ...)]` is honoured.** The lifetime arrived as the source text
   `"ServiceLifetime.Scoped"`, `Enum.TryParse` failed on the qualified name, and the silent fallback
   registered every cross-wired service as a singleton no matter what was asked for. The existing
@@ -90,6 +100,13 @@ fixes packaging and generated-code defects and commits to the API surface going 
 - Lifetime semantics tests that cross scope boundaries. Resolving twice from one provider cannot
   tell a singleton from a scoped service, which is why registering singletons as scoped previously
   went unnoticed by the integration suite.
+- Diagnostics, so mistakes surface at build time rather than when the container is built:
+  DM0001 for a generator failure, DM0002 for a service that cannot be constructed (an abstract or
+  static type, which previously produced a registration that threw at `BuildServiceProvider`), and
+  DM0003 for a module that is not `partial`.
+- A generator log worth reading. It now records the effective configuration, every module and
+  service discovered with its lifetime, key, and realm, and anything skipped along with the reason.
+  Enable it with `<DependencyModules_LogOutputDirectory>`.
 - A tag-driven release workflow publishing to nuget.org and GitHub Packages.
 
 [1.0.0]: https://github.com/ipjohnson/DependencyModules/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ dotnet add package DependencyModules.SourceGenerator
 
 Requires .NET 8.0 or later. See [CHANGELOG.md](CHANGELOG.md) for release notes.
 
+## Reporting a problem
+
+If services are not being registered as you expect, these three steps produce almost everything
+needed to diagnose it:
+
+1. **Look at the generated code.** Set `<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>`
+   and read the files under `obj/`. The registrations the generator produced are the ground truth.
+2. **Turn on the generator log**, which records the configuration in effect, every module and
+   service discovered, and anything skipped along with the reason:
+   ```xml
+   <PropertyGroup>
+     <DependencyModules_LogOutputDirectory>$(MSBuildProjectDirectory)/dmlogs</DependencyModules_LogOutputDirectory>
+   </PropertyGroup>
+   ```
+3. **Check for `DM####` warnings** in the build output. The generator reports these for mistakes it
+   can detect, such as a service type that cannot be constructed or a module missing `partial`.
+
+Please include the log and the generated file in any [issue](https://github.com/ipjohnson/DependencyModules/issues).
+
 ## Service Attributes 
 
 * `[DependencyModule]` - used to attribute class that will become dependency module (must be partial)

--- a/integ-tests/SutProject.Tests/CrossWire/CrossWireTests.cs
+++ b/integ-tests/SutProject.Tests/CrossWire/CrossWireTests.cs
@@ -1,3 +1,4 @@
+using DependencyModules.Runtime;
 using DependencyModules.Runtime.Attributes;
 using DependencyModules.xUnit.Attributes;
 using Microsoft.Extensions.DependencyInjection;
@@ -7,38 +8,91 @@ namespace SutProject.Tests.CrossWire;
 
 [DependencyModule(OnlyRealm = true)]
 public partial class CrossWireModule {
-    
+
 }
 
 [DependencyModule(OnlyRealm = true)]
-public partial class CrossWireModuleScoped {
-    public static string Test => "Test";
+public partial class CrossWireScopedModule {
+
 }
 
 public interface IInterface1 {
-    
+
 }
 
 public interface IInterface2 {
-    
+
 }
 
 [CrossWireService(Realm = typeof(CrossWireModule))]
-[CrossWireService(Lifetime = ServiceLifetime.Scoped, Realm = typeof(CrossWireModule))]
 public class CrossWireService : IInterface1, IInterface2 {
-    
+
 }
 
+[CrossWireService(Lifetime = ServiceLifetime.Scoped, Realm = typeof(CrossWireScopedModule))]
+public class ScopedCrossWireService : IInterface1, IInterface2 {
+
+}
+
+/// <summary>
+/// The contract of [CrossWireService] is that one instance is reachable through the implementation
+/// type and through every interface it implements. Asserting that a resolved service equals itself
+/// would pass no matter what the generator emitted, so each test here compares the instances
+/// obtained through different service types.
+/// </summary>
 public class CrossWireTests {
+
     [ModuleTest]
     [CrossWireModule]
-    public void SingletonCrossWireTest(IInterface1 interface1, IInterface2 interface2) {
-        Assert.Same(interface1, interface1);
+    public void CrossWire_SharesOneInstanceAcrossItsInterfaces(IInterface1 interface1, IInterface2 interface2) {
+        Assert.NotNull(interface1);
+        Assert.NotNull(interface2);
+        Assert.Same(interface1, interface2);
     }
-    
+
     [ModuleTest]
     [CrossWireModule]
-    public void ScopedCrossWireTest(IInterface1 interface1, IInterface2 interface2) {
-        Assert.Same(interface1, interface1);
+    public void CrossWire_ResolvesTheImplementationType(
+        IInterface1 interface1, CrossWireService implementation) {
+
+        Assert.NotNull(implementation);
+        Assert.Same(interface1, implementation);
+    }
+
+    [ModuleTest]
+    [CrossWireModule]
+    public void CrossWire_DefaultsToASingleInstanceAcrossScopes(IServiceProvider provider) {
+        using var first = provider.CreateScope();
+        using var second = provider.CreateScope();
+
+        Assert.Same(
+            first.ServiceProvider.GetService<IInterface1>(),
+            second.ServiceProvider.GetService<IInterface1>());
+    }
+
+    [ModuleTest]
+    [CrossWireScopedModule]
+    public void ScopedCrossWire_SharesOneInstanceWithinAScope(IServiceProvider provider) {
+        using var scope = provider.CreateScope();
+
+        var asInterface1 = scope.ServiceProvider.GetService<IInterface1>();
+        var asInterface2 = scope.ServiceProvider.GetService<IInterface2>();
+
+        Assert.NotNull(asInterface1);
+        Assert.Same(asInterface1, asInterface2);
+    }
+
+    /// <summary>
+    /// The assertion that makes the scoped variant meaningfully different from the singleton one.
+    /// </summary>
+    [ModuleTest]
+    [CrossWireScopedModule]
+    public void ScopedCrossWire_DiffersBetweenScopes(IServiceProvider provider) {
+        using var first = provider.CreateScope();
+        using var second = provider.CreateScope();
+
+        Assert.NotSame(
+            first.ServiceProvider.GetService<IInterface1>(),
+            second.ServiceProvider.GetService<IInterface1>());
     }
 }

--- a/integ-tests/SutProject.Tests/StandardTests/LifetimeSemanticsTests.cs
+++ b/integ-tests/SutProject.Tests/StandardTests/LifetimeSemanticsTests.cs
@@ -1,0 +1,116 @@
+using DependencyModules.Runtime;
+using DependencyModules.xUnit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace SutProject.Tests.StandardTests;
+
+/// <summary>
+/// Verifies the lifetimes the generator registers, against a real container built from real
+/// generated code.
+///
+/// Resolving twice from one provider is not enough to tell a singleton from a scoped service:
+/// inside a single scope both return the same instance, so an assertion like
+/// <c>Assert.Same(a, b)</c> passes either way. Distinguishing them requires crossing a scope
+/// boundary, which is what these tests do.
+/// </summary>
+public class LifetimeSemanticsTests {
+
+    [ModuleTest]
+    [SutModule]
+    public void Singleton_IsTheSameInstanceAcrossScopes(IServiceProvider provider) {
+        using var first = provider.CreateScope();
+        using var second = provider.CreateScope();
+
+        var fromFirst = first.ServiceProvider.GetService<ISingletonService>();
+        var fromSecond = second.ServiceProvider.GetService<ISingletonService>();
+
+        Assert.NotNull(fromFirst);
+        Assert.Same(fromFirst, fromSecond);
+    }
+
+    [ModuleTest]
+    [SutModule]
+    public void Singleton_IsTheSameInstanceAsTheRootProviders(IServiceProvider provider) {
+        var fromRoot = provider.GetService<ISingletonService>();
+
+        using var scope = provider.CreateScope();
+
+        Assert.Same(fromRoot, scope.ServiceProvider.GetService<ISingletonService>());
+    }
+
+    [ModuleTest]
+    [SutModule]
+    public void Scoped_IsSharedWithinAScope(IServiceProvider provider) {
+        using var scope = provider.CreateScope();
+
+        var first = scope.ServiceProvider.GetService<IScopedService>();
+        var second = scope.ServiceProvider.GetService<IScopedService>();
+
+        Assert.NotNull(first);
+        Assert.Same(first, second);
+    }
+
+    /// <summary>
+    /// The assertion that separates scoped from singleton. If the generator registered scoped
+    /// services as singletons, this is the test that fails.
+    /// </summary>
+    [ModuleTest]
+    [SutModule]
+    public void Scoped_DiffersBetweenScopes(IServiceProvider provider) {
+        using var first = provider.CreateScope();
+        using var second = provider.CreateScope();
+
+        var fromFirst = first.ServiceProvider.GetService<IScopedService>();
+        var fromSecond = second.ServiceProvider.GetService<IScopedService>();
+
+        Assert.NotNull(fromFirst);
+        Assert.NotNull(fromSecond);
+        Assert.NotSame(fromFirst, fromSecond);
+    }
+
+    /// <summary>
+    /// The assertion that separates transient from both of the others.
+    /// </summary>
+    [ModuleTest]
+    [SutModule]
+    public void Transient_IsANewInstanceEveryResolution(IServiceProvider provider) {
+        var first = provider.GetService<IDependencyOne>();
+        var second = provider.GetService<IDependencyOne>();
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.NotSame(first, second);
+    }
+
+    [ModuleTest]
+    [SutModule]
+    public void Transient_IsANewInstanceWithinASingleScope(IServiceProvider provider) {
+        using var scope = provider.CreateScope();
+
+        var first = scope.ServiceProvider.GetService<IDependencyOne>();
+        var second = scope.ServiceProvider.GetService<IDependencyOne>();
+
+        Assert.NotSame(first, second);
+    }
+
+    [ModuleTest]
+    [SutModule]
+    public void RegisteredLifetimes_MatchTheirAttributes(IServiceProvider provider) {
+        // Resolving proves the wiring; the descriptors prove the lifetime the generator chose.
+        var collection = new ServiceCollection();
+        collection.AddModule<SutModule>();
+
+        Assert.Equal(
+            ServiceLifetime.Singleton,
+            Assert.Single(collection, d => d.ServiceType == typeof(ISingletonService)).Lifetime);
+
+        Assert.Equal(
+            ServiceLifetime.Scoped,
+            Assert.Single(collection, d => d.ServiceType == typeof(IScopedService)).Lifetime);
+
+        Assert.Equal(
+            ServiceLifetime.Transient,
+            Assert.Single(collection, d => d.ServiceType == typeof(IDependencyOne)).Lifetime);
+    }
+}

--- a/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Shipped.md
+++ b/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Shipped.md
@@ -1,0 +1,2 @@
+; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md

--- a/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
+++ b/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,10 @@
+; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+DM0001 | DependencyModules | Error | The generator failed; registrations may be missing.
+DM0002 | DependencyModules | Warning | A service type cannot be constructed and was not registered.
+DM0003 | DependencyModules | Error | A module marked with [DependencyModule] is not partial.

--- a/src/DependencyModules.SourceGenerator.Impl/BaseAttributeSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/BaseAttributeSourceGenerator.cs
@@ -38,7 +38,17 @@ public abstract class BaseAttributeSourceGenerator<T> : IDependencyModuleSourceG
 
         if (config != null) {
             FileLogger.Wrap(
-                LoggerName, config,logger => GenerateSourceOutput(context, data,logger));
+                LoggerName,
+                config,
+                logger => GenerateSourceOutput(context, data, logger),
+                // Surfaced as a build error rather than discarded. A generator that fails quietly
+                // produces a green build with no registrations, which is far harder to diagnose
+                // than a failed one.
+                exception => context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        DependencyModuleDiagnostics.GeneratorFailure,
+                        Location.None,
+                        $"{exception.GetType().Name}: {exception.Message}")));
         }
     }
 

--- a/src/DependencyModules.SourceGenerator.Impl/BaseSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/BaseSourceGenerator.cs
@@ -3,6 +3,7 @@ using CSharpAuthor;
 using DependencyModules.SourceGenerator.Impl.Models;
 using DependencyModules.SourceGenerator.Impl.Utilities;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -53,9 +54,8 @@ public abstract class BaseSourceGenerator : IIncrementalGenerator {
                 logOutputFolder = logOutputFolderValue;
             }
             
-            if (options.GlobalOptions.TryGetValue(
-                    "build_property.DependencyModules_RegisterGenerator", out var generator)) {
-                registerSourceGenerator = generator.Equals("true", StringComparison.OrdinalIgnoreCase);
+            if (TryGetBoolean(options, "DependencyModules_RegisterGenerator", out var generator)) {
+                registerSourceGenerator = generator;
             }
 
             if (options.GlobalOptions.TryGetValue("build_property.RootNamespace", out var rootNamespaceString)) {
@@ -66,17 +66,17 @@ public abstract class BaseSourceGenerator : IIncrementalGenerator {
                 projectDirectory = projectDirString;
             }
             
-            if (options.GlobalOptions.TryGetValue("build_property.DependencyModules_AutoGenerateModule", out var autoGenerateEntryString)) {
-                autoGenerateEntry = autoGenerateEntryString.Equals("true", StringComparison.OrdinalIgnoreCase);
+            if (TryGetBoolean(options, "DependencyModules_AutoGenerateModule", out var autoGenerateEntryValue)) {
+                autoGenerateEntry = autoGenerateEntryValue;
             }
             
-            if (options.GlobalOptions.TryGetValue("build_property.DependencyModules_GenerateFactories", out var generateFactoriesString)) {
-                generateFactories = generateFactoriesString.Equals("true", StringComparison.OrdinalIgnoreCase);
+            if (TryGetBoolean(options, "DependencyModules_GenerateFactories", out var generateFactoriesValue)) {
+                generateFactories = generateFactoriesValue;
             }
 
             var excludeGeneratedCodeFromCoverage = true;
-            if (options.GlobalOptions.TryGetValue("build_property.ExcludeGeneratedCodeFromCoverage", out var excludeCoverageString)) {
-                excludeGeneratedCodeFromCoverage = !excludeCoverageString.Equals("false", StringComparison.OrdinalIgnoreCase);
+            if (TryGetBoolean(options, "ExcludeGeneratedCodeFromCoverage", out var excludeCoverageValue)) {
+                excludeGeneratedCodeFromCoverage = excludeCoverageValue;
             }
 
             return new DependencyModuleConfigurationModel(
@@ -90,6 +90,27 @@ public abstract class BaseSourceGenerator : IIncrementalGenerator {
                 generateFactories,
                 excludeGeneratedCodeFromCoverage);
         }).WithComparer(new DependencyModuleConfigurationModelComparer());
+    }
+
+    /// <summary>
+    /// Reads a boolean build property, treating an unset or blank value as "not specified".
+    /// </summary>
+    /// <remarks>
+    /// A property listed as CompilerVisibleProperty is always delivered, as an empty string when
+    /// the developer has not set it. Without this check every boolean default would be overwritten
+    /// with false the moment the property was made visible.
+    /// </remarks>
+    private static bool TryGetBoolean(AnalyzerConfigOptionsProvider options, string propertyName, out bool value) {
+        value = false;
+
+        if (!options.GlobalOptions.TryGetValue("build_property." + propertyName, out var raw) ||
+            string.IsNullOrWhiteSpace(raw)) {
+            return false;
+        }
+
+        value = raw.Trim().Equals("true", StringComparison.OrdinalIgnoreCase);
+
+        return true;
     }
 
     protected virtual void SetupRootGenerator(IncrementalGeneratorInitializationContext context,
@@ -152,6 +173,10 @@ public abstract class BaseSourceGenerator : IIncrementalGenerator {
         }
         else if (!implementsEqualsFlag) {
             features |= ModuleEntryPointFeatures.ShouldImplementEquals;
+        }
+
+        if (!typeDeclarationSyntax.Modifiers.Any(m => m.IsKind(SyntaxKind.PartialKeyword))) {
+            features |= ModuleEntryPointFeatures.NotPartial;
         }
         
         return new ModuleEntryPointModel(

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
@@ -1,0 +1,58 @@
+using Microsoft.CodeAnalysis;
+
+namespace DependencyModules.SourceGenerator.Impl;
+
+/// <summary>
+/// Diagnostics reported by the generator.
+///
+/// A source generator that stays quiet when something is wrong leaves the developer with a build
+/// that succeeds and an application that misbehaves at run time. Everything here exists to move a
+/// failure from run time to build time, or at minimum to make it visible.
+/// </summary>
+public static class DependencyModuleDiagnostics {
+    private const string Category = "DependencyModules";
+
+    /// <summary>
+    /// Raised when the generator itself throws. Previously the exception was caught and, unless a
+    /// log directory happened to be configured, discarded — the build succeeded, no registrations
+    /// were produced, and nothing said so.
+    /// </summary>
+    public static readonly DiagnosticDescriptor GeneratorFailure = new(
+        id: "DM0001",
+        title: "DependencyModules generator failed",
+        messageFormat:
+        "The DependencyModules generator failed and registrations may be missing or incomplete: {0}. " +
+        "Set DependencyModules_LogOutputDirectory to capture a log, and report the issue at " +
+        "https://github.com/ipjohnson/DependencyModules/issues with that log attached.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Raised for a service the container could never construct. Without this the generator emits a
+    /// registration that throws when the provider is built, far from the declaration that caused it.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ServiceCannotBeConstructed = new(
+        id: "DM0002",
+        title: "Service type cannot be constructed",
+        messageFormat:
+        "'{0}' is {1} and cannot be instantiated, so it was not registered. " +
+        "Apply the service attribute to a concrete class, or register it with a static factory method.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Raised for a module that is not partial. The compiler also reports CS0260 once the generated
+    /// half arrives, but that message describes the symptom rather than what to do about it.
+    /// </summary>
+    public static readonly DiagnosticDescriptor ModuleMustBePartial = new(
+        id: "DM0003",
+        title: "Dependency module must be partial",
+        messageFormat:
+        "'{0}' is marked with [DependencyModule] but is not declared partial. " +
+        "The generator completes the type with a second partial declaration, so add the partial modifier.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+}

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleWriter.cs
@@ -38,6 +38,19 @@ public class DependencyModuleWriter {
         ModuleEntryPointModel entryPointModel, 
         DependencyModuleConfigurationModel configurationModel) {
 
+        // Generating into a non-partial type produces CS0260 against the developer's own
+        // declaration, which describes the symptom rather than the fix. Report it directly and
+        // generate nothing, so the only error they see is the actionable one.
+        if (entryPointModel.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.NotPartial)) {
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    DependencyModuleDiagnostics.ModuleMustBePartial,
+                    Location.None,
+                    entryPointModel.EntryPointType.Name));
+
+            return;
+        }
+
         entryPointModel = EntryModelUtil.EnsureNamespace(entryPointModel,configurationModel);
 
         var csharpFile = new CSharpFileDefinition(entryPointModel.EntryPointType.Namespace);

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModules.SourceGenerator.Impl.csproj
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModules.SourceGenerator.Impl.csproj
@@ -56,4 +56,9 @@
         </PackageReference>
     </ItemGroup>
 
+    <!-- Release tracking for the DM#### diagnostics (RS2008). -->
+    <ItemGroup>
+        <AdditionalFiles Include="AnalyzerReleases.Shipped.md"/>
+        <AdditionalFiles Include="AnalyzerReleases.Unshipped.md"/>
+    </ItemGroup>
 </Project>

--- a/src/DependencyModules.SourceGenerator.Impl/Models/ModuleEntryPointModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/ModuleEntryPointModel.cs
@@ -9,6 +9,11 @@ public enum ModuleEntryPointFeatures {
     OnlyRealm = 2,
     ShouldImplementEquals = 4,
     IsRecord = 8,
+
+    /// <summary>
+    /// The module was declared without the partial modifier, so the generator cannot complete it.
+    /// </summary>
+    NotPartial = 16,
 }
 
 public record ModuleEntryPointModel(

--- a/src/DependencyModules.SourceGenerator.Impl/Models/ServiceModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/ServiceModel.cs
@@ -19,6 +19,17 @@ public enum RegistrationType {
 public enum RegistrationFeature {
     None= 0,
     AutoRegisterSourceGenerator = 1,
+
+    /// <summary>
+    /// The implementation is abstract. The container cannot construct it, so registering it would
+    /// fail when the provider is built rather than when the code is compiled.
+    /// </summary>
+    AbstractImplementation = 2,
+
+    /// <summary>
+    /// The implementation is a static class, which likewise cannot be constructed.
+    /// </summary>
+    StaticImplementation = 4,
 }
 
 public record ServiceFactoryModel(

--- a/src/DependencyModules.SourceGenerator.Impl/Package/DependencyModules.SourceGenerator.Impl.targets
+++ b/src/DependencyModules.SourceGenerator.Impl/Package/DependencyModules.SourceGenerator.Impl.targets
@@ -1,4 +1,22 @@
 <Project>
+    <PropertyGroup>
+        <ExcludeGeneratedCodeFromCoverage Condition="'$(ExcludeGeneratedCodeFromCoverage)' == ''">true</ExcludeGeneratedCodeFromCoverage>
+    </PropertyGroup>
+
+    <!--
+        Every property the generator reads has to be listed here, or it is invisible to the
+        compiler and silently takes its default. ProjectDir and RootNamespace are omitted
+        deliberately: the .NET SDK already declares those.
+    -->
+    <ItemGroup>
+        <CompilerVisibleProperty Include="DependencyModules_RegistrationType"/>
+        <CompilerVisibleProperty Include="DependencyModules_LogOutputDirectory"/>
+        <CompilerVisibleProperty Include="DependencyModules_RegisterGenerator"/>
+        <CompilerVisibleProperty Include="DependencyModules_AutoGenerateModule"/>
+        <CompilerVisibleProperty Include="DependencyModules_GenerateFactories"/>
+        <CompilerVisibleProperty Include="ExcludeGeneratedCodeFromCoverage"/>
+    </ItemGroup>
+
     <ItemGroup Condition="'$(PackageDependencyModuleIncludeSource)' == 'true'">
         <Compile Include="$(MSBuildThisFileDirectory)../src/**/*.cs" Visible="false"/>
     </ItemGroup>

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/FileLogger.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/FileLogger.cs
@@ -8,13 +8,33 @@ public class FileLogger : IDisposable {
     private readonly string _outputFolder;
     private StringBuilder? _sb;
 
-    public static void Wrap(string loggerName, DependencyModuleConfigurationModel configurationModel, Action<FileLogger> logger) {
+    /// <summary>
+    /// Runs <paramref name="logger"/>, recording any failure to the log and reporting it through
+    /// <paramref name="reportFailure"/>.
+    /// </summary>
+    /// <remarks>
+    /// The exception must not be swallowed. Catching it here also stops Roslyn from reporting its
+    /// own CS8785, so without <paramref name="reportFailure"/> a crashing generator produced a
+    /// successful build, no registrations, and no message of any kind.
+    /// </remarks>
+    public static void Wrap(
+        string loggerName,
+        DependencyModuleConfigurationModel configurationModel,
+        Action<FileLogger> logger,
+        Action<Exception>? reportFailure = null) {
+
         var fileLogger = new FileLogger(configurationModel, loggerName);
         try {
             logger(fileLogger);
         }
         catch (Exception e) {
             fileLogger.Error($"{e.Message}\n{e.StackTrace}");
+
+            if (reportFailure == null) {
+                throw;
+            }
+
+            reportFailure(e);
         }
         finally {
             fileLogger.Dispose();

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
@@ -81,6 +81,27 @@ public class ServiceModelUtility {
             methodDeclarationSyntax.GetMethodParameters(context, cancellationToken));
     }
 
+    /// <summary>
+    /// Flags describing why the container could never construct this type, so the generator can
+    /// report it instead of emitting a registration that fails when the provider is built.
+    /// </summary>
+    private static RegistrationFeature GetConstructionFeatures(SyntaxNode node) {
+        if (node is not TypeDeclarationSyntax typeDeclarationSyntax) {
+            return RegistrationFeature.None;
+        }
+
+        var features = RegistrationFeature.None;
+
+        if (typeDeclarationSyntax.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword))) {
+            features |= RegistrationFeature.StaticImplementation;
+        }
+        else if (typeDeclarationSyntax.Modifiers.Any(m => m.IsKind(SyntaxKind.AbstractKeyword))) {
+            features |= RegistrationFeature.AbstractImplementation;
+        }
+
+        return features;
+    }
+
     private static ServiceModel? GetClassDeclarationServiceModel(GeneratorSyntaxContext context, CancellationToken cancellationToken) {
         var classDefinition = GetClassDefinition(context);
 
@@ -121,7 +142,7 @@ public class ServiceModelUtility {
             null,
             factoryOutput,
             registrations,
-            RegistrationFeature.None);
+            GetConstructionFeatures(context.Node));
     }
 
     public static ConstructorInfoModel? GetConstructorInfo(GeneratorSyntaxContext context, SyntaxNode node, CancellationToken cancellationToken) {

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
@@ -309,7 +309,16 @@ public class ServiceModelUtility {
     }
 
     private static ServiceLifestyle GetLifestyle(string toString) {
-        if (Enum.TryParse(toString, out ServiceLifestyle lifestyle)) {
+        // The value arrives as written in source, normally qualified: "ServiceLifetime.Scoped".
+        // Parsing that whole string fails, and the silent fallback below then registered every
+        // cross-wired service as a singleton regardless of the lifetime the developer asked for.
+        var separatorIndex = toString.LastIndexOf('.');
+
+        var value = separatorIndex >= 0
+            ? toString.Substring(separatorIndex + 1).Trim()
+            : toString.Trim();
+
+        if (Enum.TryParse(value, out ServiceLifestyle lifestyle)) {
             return lifestyle;
         }
 

--- a/src/DependencyModules.SourceGenerator/DependencyModules.SourceGenerator.csproj
+++ b/src/DependencyModules.SourceGenerator/DependencyModules.SourceGenerator.csproj
@@ -55,4 +55,10 @@
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Compile>
     </ItemGroup>
+
+    <!-- Release tracking for the DM#### diagnostics (RS2008). -->
+    <ItemGroup>
+        <AdditionalFiles Include="../DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Shipped.md"/>
+        <AdditionalFiles Include="../DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md"/>
+    </ItemGroup>
 </Project>

--- a/src/DependencyModules.SourceGenerator/Package/DependencyModules.SourceGenerator.targets
+++ b/src/DependencyModules.SourceGenerator/Package/DependencyModules.SourceGenerator.targets
@@ -2,8 +2,18 @@
     <PropertyGroup>
         <ExcludeGeneratedCodeFromCoverage Condition="'$(ExcludeGeneratedCodeFromCoverage)' == ''">true</ExcludeGeneratedCodeFromCoverage>
     </PropertyGroup>
+
+    <!--
+        Every property the generator reads has to be listed here, or it is invisible to the
+        compiler and silently takes its default. ProjectDir and RootNamespace are omitted
+        deliberately: the .NET SDK already declares those.
+    -->
     <ItemGroup>
         <CompilerVisibleProperty Include="DependencyModules_RegistrationType"/>
+        <CompilerVisibleProperty Include="DependencyModules_LogOutputDirectory"/>
+        <CompilerVisibleProperty Include="DependencyModules_RegisterGenerator"/>
+        <CompilerVisibleProperty Include="DependencyModules_AutoGenerateModule"/>
+        <CompilerVisibleProperty Include="DependencyModules_GenerateFactories"/>
         <CompilerVisibleProperty Include="ExcludeGeneratedCodeFromCoverage"/>
     </ItemGroup>
 </Project>

--- a/src/DependencyModules.SourceGenerator/ServiceSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/ServiceSourceGenerator.cs
@@ -30,15 +30,26 @@ public class ServiceSourceGenerator : BaseAttributeSourceGenerator<ServiceModel>
         (ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Left, ImmutableArray<ServiceModel> Right) inputData, 
         FileLogger logger) {
         if (inputData.Left.Length == 0 || inputData.Right.Length == 0) {
+            logger.Info(
+                $"Nothing to generate: {inputData.Left.Length} module(s) and " +
+                $"{inputData.Right.Length} service(s) were discovered.");
             return;
         }
-        
-        var (entryPointList, configurationModel) = 
+
+        LogDiscovery(inputData, logger);
+
+        var serviceModels = ReportUnconstructableServices(context, inputData.Right, logger);
+
+        if (serviceModels.Length == 0) {
+            return;
+        }
+
+        var (entryPointList, configurationModel) =
             EntryModelUtil.ConsolidateEntryPointModels(inputData.Left);
-        
+
         foreach (var entryPointModel in entryPointList) {
             context.CancellationToken.ThrowIfCancellationRequested();
-            GenerateSourceOutput(context, entryPointModel, configurationModel, inputData.Right, logger);
+            GenerateSourceOutput(context, entryPointModel, configurationModel, serviceModels, logger);
         }
     }
 
@@ -62,6 +73,96 @@ public class ServiceSourceGenerator : BaseAttributeSourceGenerator<ServiceModel>
             entryPointModel.EntryPointType.GetFileNameHint(
                 configurationModel.RootNamespace,"Dependencies"), output);
     }
+
+    /// <summary>
+    /// Records what the generator saw and how it was configured.
+    /// </summary>
+    /// <remarks>
+    /// This is what someone reporting a problem attaches. "My service is not registered" is
+    /// answered by whether the service was discovered at all, which module realm it landed in, and
+    /// what configuration was in effect — none of which is visible from the generated output alone.
+    /// </remarks>
+    private static void LogDiscovery(
+        (ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Left,
+            ImmutableArray<ServiceModel> Right) inputData,
+        FileLogger logger) {
+
+        var configuration = inputData.Left.First().Right;
+
+        logger.Info(
+            "Configuration: " +
+            $"RootNamespace='{configuration.RootNamespace}', " +
+            $"ProjectDir='{configuration.ProjectDir}', " +
+            $"RegistrationType={configuration.RegistrationType}, " +
+            $"AutoGenerateModule={configuration.AutoGenerateEntry}, " +
+            $"GenerateFactories={configuration.GenerateFactories}, " +
+            $"ExcludeGeneratedCodeFromCoverage={configuration.ExcludeGeneratedCodeFromCoverage}");
+
+        logger.Info($"Discovered {inputData.Left.Length} module(s):");
+        foreach (var (entryPoint, _) in inputData.Left) {
+            logger.Info(
+                $"  {entryPoint.EntryPointType.Namespace}.{entryPoint.EntryPointType.Name} " +
+                $"[{entryPoint.ModuleFeatures}] from '{entryPoint.FileLocation}'");
+        }
+
+        logger.Info($"Discovered {inputData.Right.Length} service(s):");
+        foreach (var serviceModel in inputData.Right) {
+            foreach (var registration in serviceModel.Registrations) {
+                logger.Info(
+                    $"  {serviceModel.ImplementationType.Name} -> {registration.ServiceType.Name} " +
+                    $"({registration.Lifestyle}" +
+                    (registration.Key != null ? $", key={registration.Key}" : "") +
+                    (registration.Realm != null ? $", realm={registration.Realm.Name}" : "") +
+                    (registration.RegistrationType != null ? $", using={registration.RegistrationType}" : "") +
+                    ")");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reports the services the container could never construct and removes them from generation.
+    /// Emitting a registration for an abstract or static type produces code that throws when the
+    /// provider is built, a long way from the declaration responsible.
+    /// </summary>
+    private static ImmutableArray<ServiceModel> ReportUnconstructableServices(
+        SourceProductionContext context, ImmutableArray<ServiceModel> serviceModels, FileLogger logger) {
+
+        if (!serviceModels.Any(IsUnconstructable)) {
+            return serviceModels;
+        }
+
+        var builder = ImmutableArray.CreateBuilder<ServiceModel>(serviceModels.Length);
+
+        foreach (var serviceModel in serviceModels) {
+            if (!IsUnconstructable(serviceModel)) {
+                builder.Add(serviceModel);
+                continue;
+            }
+
+            var reason = serviceModel.Features.HasFlag(RegistrationFeature.StaticImplementation)
+                ? "a static class"
+                : "abstract";
+
+            var typeName = serviceModel.ImplementationType.Name;
+
+            logger.Error($"Skipping '{typeName}' because it is {reason}.");
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    DependencyModuleDiagnostics.ServiceCannotBeConstructed,
+                    Location.None,
+                    typeName,
+                    reason));
+        }
+
+        return builder.ToImmutable();
+    }
+
+    private static bool IsUnconstructable(ServiceModel serviceModel) =>
+        // A factory supplies the instance, so the declaring type never has to be constructed.
+        serviceModel.Factory == null &&
+        (serviceModel.Features.HasFlag(RegistrationFeature.AbstractImplementation) ||
+         serviceModel.Features.HasFlag(RegistrationFeature.StaticImplementation));
 
     protected override IEqualityComparer<ServiceModel> GetComparer() {
         return _serviceEqualityComparer;

--- a/tests/DependencyModules.Tests/ApiTests/PublicApiTests.cs
+++ b/tests/DependencyModules.Tests/ApiTests/PublicApiTests.cs
@@ -1,0 +1,63 @@
+using DependencyModules.Runtime.Attributes;
+using DependencyModules.Tests.Infrastructure;
+using DependencyModules.xUnit.Attributes;
+using PublicApiGenerator;
+using Xunit;
+
+namespace DependencyModules.Tests.ApiTests;
+
+/// <summary>
+/// Pins the public surface of every package that ships a referenceable assembly.
+///
+/// After 1.0.0 the public API is a compatibility promise. Nothing else in the suite notices if a
+/// member is removed, a signature changes, or a type's accessibility narrows — the library still
+/// builds, and its own tests still pass, because they are compiled together. These snapshots turn
+/// any such change into a reviewable diff.
+///
+/// A failure here is not automatically a bug. It means the surface moved, and someone has to decide
+/// whether that is intended and whether it warrants a major version. To accept a change:
+///     UPDATE_SNAPSHOTS=1 dotnet test tests/DependencyModules.Tests
+/// then read the diff carefully before committing it.
+/// </summary>
+public class PublicApiTests {
+
+    [Fact]
+    public void RuntimeApi() {
+        Snapshot.Match(ApiOf(typeof(DependencyModuleAttribute)));
+    }
+
+    [Fact]
+    public void XUnitApi() {
+        Snapshot.Match(ApiOf(typeof(ModuleTestAttribute)));
+    }
+
+    [Fact]
+    public void XUnitNSubstituteApi() {
+        Snapshot.Match(ApiOf(typeof(xUnit.NSubstitute.NSubstituteSupportAttribute)));
+    }
+
+    /// <summary>
+    /// The generator ships as an analyzer rather than a reference assembly, so consumers never bind
+    /// against its types. Its surface still matters, because the source-only
+    /// DependencyModules.SourceGenerator.Impl package invites developers to build their own
+    /// generators on top of these base classes.
+    /// </summary>
+    [Fact]
+    public void SourceGeneratorApi() {
+        Snapshot.Match(ApiOf(typeof(SourceGenerator.SourceGenerator)));
+    }
+
+    private static string ApiOf(Type typeFromAssembly) =>
+        typeFromAssembly.Assembly.GeneratePublicApi(
+            new ApiGeneratorOptions {
+                // Assembly-level attributes are build metadata, not API, and several of them
+                // (SourceLink, InternalsVisibleTo, TFM) change with build configuration.
+                ExcludeAttributes = [
+                    "System.Runtime.Versioning.TargetFrameworkAttribute",
+                    "System.Reflection.AssemblyMetadataAttribute",
+                    "System.Runtime.CompilerServices.InternalsVisibleToAttribute",
+                    "System.Diagnostics.DebuggableAttribute",
+                    "System.Runtime.CompilerServices.CompilationRelaxationsAttribute"
+                ]
+            });
+}

--- a/tests/DependencyModules.Tests/DependencyModules.Tests.csproj
+++ b/tests/DependencyModules.Tests/DependencyModules.Tests.csproj
@@ -21,6 +21,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <PackageReference Include="PublicApiGenerator" Version="11.5.4"/>
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>

--- a/tests/DependencyModules.Tests/GeneratorTests/DiagnosticsTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/DiagnosticsTests.cs
@@ -1,0 +1,174 @@
+using DependencyModules.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// The generator's job is to move failures from run time to build time. Each of these covers a
+/// mistake that previously produced either a crash when the container was built or, worse, a
+/// successful build that quietly registered nothing.
+/// </summary>
+public class DiagnosticsTests {
+
+    /// <summary>
+    /// An abstract implementation used to be registered anyway, and the resulting
+    /// AddSingleton(typeof(IThing), typeof(AbstractThing)) threw when the provider was built,
+    /// a long way from the declaration responsible.
+    /// </summary>
+    [Fact]
+    public void AbstractService_ReportsDM0002() {
+        var result = GeneratorTestHarness.Run(Module("[SingletonService] public abstract class Thing : IThing;"));
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0002");
+
+        Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+        Assert.Contains("Thing", diagnostic.GetMessage());
+        Assert.Contains("abstract", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void AbstractService_IsNotRegistered() {
+        var result = GeneratorTestHarness.Run(Module("[SingletonService] public abstract class Thing : IThing;"));
+
+        Assert.DoesNotContain(result.GeneratedSources.Keys, key => key.Contains("Dependencies"));
+    }
+
+    [Fact]
+    public void StaticService_ReportsDM0002() {
+        var result = GeneratorTestHarness.Run(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            [SingletonService]
+            public static class StaticThing;
+
+            [DependencyModule]
+            public partial class TestModule;
+            """);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0002");
+
+        Assert.Contains("static", diagnostic.GetMessage());
+    }
+
+    /// <summary>
+    /// A concrete service alongside an unconstructable one must still be registered; reporting the
+    /// bad one should not discard the good ones.
+    /// </summary>
+    [Fact]
+    public void ConcreteServices_AreStillRegisteredAlongsideARejectedOne() {
+        var generated = GeneratedAssembly.Create(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            public interface IThing;
+            public interface IAbstract;
+
+            [SingletonService] public class Thing : IThing;
+
+            [SingletonService] public abstract class AbstractThing : IAbstract;
+
+            [DependencyModule]
+            public partial class TestModule;
+            """);
+
+        var provider = generated.BuildProvider();
+
+        Assert.NotNull(provider.GetService(generated.Type("IThing")));
+        Assert.Null(provider.GetService(generated.Type("IAbstract")));
+    }
+
+    /// <summary>
+    /// The compiler reports CS0260 once the generated half arrives, but that describes the symptom.
+    /// DM0003 names the fix, and generation is skipped so it is the only error shown.
+    /// </summary>
+    [Fact]
+    public void NonPartialModule_ReportsDM0003() {
+        var result = GeneratorTestHarness.Run(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            public interface IThing;
+
+            [SingletonService] public class Thing : IThing;
+
+            [DependencyModule]
+            public class NotPartialModule;
+            """);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0003");
+
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("NotPartialModule", diagnostic.GetMessage());
+        Assert.Contains("partial", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void NonPartialModule_DoesNotGenerateAConflictingDeclaration() {
+        var result = GeneratorTestHarness.Run(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            [DependencyModule]
+            public class NotPartialModule;
+            """);
+
+        // Emitting the module half would add CS0260 on top of DM0003 and point at the wrong thing.
+        Assert.DoesNotContain(result.GeneratedSources.Keys, key => key.Contains("NotPartialModule.Module"));
+        Assert.DoesNotContain(result.CompilationDiagnostics, d => d.Id == "CS0260");
+    }
+
+    [Fact]
+    public void PartialModule_ReportsNothing() {
+        var result = GeneratorTestHarness.Run(Module("[SingletonService] public class Thing : IThing;"));
+
+        result.AssertNoErrors();
+        Assert.Empty(result.GeneratorDiagnostics);
+    }
+
+    [Fact]
+    public void AbstractFactoryHost_IsAllowedBecauseTheFactorySuppliesTheInstance() {
+        // The declaring type is never constructed, so an abstract host is legitimate here.
+        var result = GeneratorTestHarness.Run(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            public interface IThing;
+
+            public abstract class Factories {
+                [SingletonService]
+                public static IThing Create() => null!;
+            }
+
+            [DependencyModule]
+            public partial class TestModule;
+            """);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0002");
+    }
+
+    private static string Module(string body) =>
+        $$"""
+          using DependencyModules.Runtime.Attributes;
+
+          namespace TestNamespace;
+
+          public interface IThing;
+
+          {{body}}
+
+          [DependencyModule]
+          public partial class TestModule;
+          """;
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/FileLoggerTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/FileLoggerTests.cs
@@ -68,11 +68,42 @@ public class FileLoggerTests : IDisposable {
         Assert.Contains("the data", content);
     }
 
+    /// <summary>
+    /// With no reporter the exception must escape, so Roslyn reports its own generator failure.
+    /// Swallowing it produced a successful build with no registrations and no message at all.
+    /// </summary>
     [Fact]
-    public void Wrap_RecordsAnExceptionRatherThanPropagatingIt() {
-        var exception = new InvalidOperationException("generator blew up");
+    public void Wrap_WithoutAReporter_RethrowsSoTheFailureIsVisible() {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => FileLogger.Wrap(
+                "generator",
+                Configuration(_outputFolder),
+                _ => throw new InvalidOperationException("generator blew up")));
 
-        FileLogger.Wrap("generator", Configuration(_outputFolder), _ => throw exception);
+        Assert.Equal("generator blew up", exception.Message);
+    }
+
+    [Fact]
+    public void Wrap_WithAReporter_HandsItTheExceptionInsteadOfPropagating() {
+        Exception? reported = null;
+
+        FileLogger.Wrap(
+            "generator",
+            Configuration(_outputFolder),
+            _ => throw new InvalidOperationException("generator blew up"),
+            exception => reported = exception);
+
+        Assert.NotNull(reported);
+        Assert.Equal("generator blew up", reported!.Message);
+    }
+
+    [Fact]
+    public void Wrap_RecordsTheExceptionInTheLog() {
+        FileLogger.Wrap(
+            "generator",
+            Configuration(_outputFolder),
+            _ => throw new InvalidOperationException("generator blew up"),
+            _ => { });
 
         var content = File.ReadAllText(Directory.GetFiles(_outputFolder).Single());
 

--- a/tests/DependencyModules.Tests/GeneratorTests/GeneratedBehaviourTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/GeneratedBehaviourTests.cs
@@ -1,0 +1,402 @@
+using DependencyModules.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// Compiles source with the generator, loads the emitted assembly, and asserts on what the
+/// registrations actually do at run time: which implementation is resolved, with which lifetime,
+/// and whether instances are shared.
+///
+/// These are the tests that would fail if the generator emitted well-formed code that registered
+/// the wrong thing. Asserting on the shape of generated text cannot catch that.
+/// </summary>
+public class GeneratedBehaviourTests {
+
+    [Fact]
+    public void SingletonService_ResolvesTheImplementation() {
+        var generated = GeneratedAssembly.Create(Module("[SingletonService] public class Thing : IThing;"));
+
+        var resolved = generated.ResolveRequired("IThing");
+
+        Assert.Equal(generated.Type("Thing"), resolved.GetType());
+    }
+
+    [Fact]
+    public void SingletonService_ReturnsTheSameInstanceEveryTime() {
+        var generated = GeneratedAssembly.Create(Module("[SingletonService] public class Thing : IThing;"));
+        var provider = generated.BuildProvider();
+        var serviceType = generated.Type("IThing");
+
+        Assert.Same(provider.GetService(serviceType), provider.GetService(serviceType));
+    }
+
+    [Fact]
+    public void TransientService_ReturnsANewInstanceEveryTime() {
+        var generated = GeneratedAssembly.Create(Module("[TransientService] public class Thing : IThing;"));
+        var provider = generated.BuildProvider();
+        var serviceType = generated.Type("IThing");
+
+        Assert.NotSame(provider.GetService(serviceType), provider.GetService(serviceType));
+    }
+
+    [Fact]
+    public void ScopedService_IsSharedWithinAScopeAndDiffersAcrossScopes() {
+        var generated = GeneratedAssembly.Create(Module("[ScopedService] public class Thing : IThing;"));
+        var provider = generated.BuildProvider();
+        var serviceType = generated.Type("IThing");
+
+        using var first = provider.CreateScope();
+        using var second = provider.CreateScope();
+
+        var firstA = first.ServiceProvider.GetService(serviceType);
+        var firstB = first.ServiceProvider.GetService(serviceType);
+        var secondA = second.ServiceProvider.GetService(serviceType);
+
+        Assert.Same(firstA, firstB);
+        Assert.NotSame(firstA, secondA);
+    }
+
+    [Theory]
+    [InlineData("SingletonService", ServiceLifetime.Singleton)]
+    [InlineData("ScopedService", ServiceLifetime.Scoped)]
+    [InlineData("TransientService", ServiceLifetime.Transient)]
+    public void ServiceAttribute_RegistersTheMatchingLifetime(string attribute, ServiceLifetime expected) {
+        var generated = GeneratedAssembly.Create(Module($"[{attribute}] public class Thing : IThing;"));
+
+        Assert.Equal(expected, generated.Descriptor("IThing").Lifetime);
+    }
+
+    [Fact]
+    public void AsProperty_ResolvesUnderTheRequestedServiceTypeOnly() {
+        var generated = GeneratedAssembly.Create(Module(
+            """
+            public interface IOther;
+            [SingletonService(As = typeof(IOther))] public class Thing : IThing, IOther;
+            """));
+
+        var provider = generated.BuildProvider();
+
+        Assert.NotNull(provider.GetService(generated.Type("IOther")));
+        Assert.Null(provider.GetService(generated.Type("IThing")));
+    }
+
+    [Fact]
+    public void KeyedService_ResolvesOnlyThroughItsKey() {
+        var generated = GeneratedAssembly.Create(Module(
+            """[SingletonService(Key = "the-key")] public class Thing : IThing;"""));
+
+        var provider = generated.BuildProvider();
+        var serviceType = generated.Type("IThing");
+
+        Assert.NotNull(provider.GetKeyedService(serviceType, "the-key"));
+        Assert.Null(provider.GetService(serviceType));
+    }
+
+    [Fact]
+    public void KeyedServices_WithDifferentKeysResolveDifferentImplementations() {
+        var generated = GeneratedAssembly.Create(Module(
+            """
+            [SingletonService(Key = "first")] public class FirstThing : IThing;
+            [SingletonService(Key = "second")] public class SecondThing : IThing;
+            """));
+
+        var provider = generated.BuildProvider();
+        var serviceType = generated.Type("IThing");
+
+        Assert.Equal(generated.Type("FirstThing"), provider.GetKeyedService(serviceType, "first")!.GetType());
+        Assert.Equal(generated.Type("SecondThing"), provider.GetKeyedService(serviceType, "second")!.GetType());
+    }
+
+    /// <summary>
+    /// The contract of [CrossWireService]: one instance, reachable through the implementation type
+    /// and through every interface it implements.
+    /// </summary>
+    [Fact]
+    public void CrossWireService_SharesOneInstanceAcrossAllItsInterfaces() {
+        var generated = GeneratedAssembly.Create(Module(
+            """
+            public interface IOther;
+            [CrossWireService(Lifetime = ServiceLifetime.Singleton)]
+            public class Thing : IThing, IOther;
+            """,
+            extraUsings: "using Microsoft.Extensions.DependencyInjection;"));
+
+        var provider = generated.BuildProvider();
+
+        var asThing = provider.GetService(generated.Type("IThing"));
+        var asOther = provider.GetService(generated.Type("IOther"));
+        var asImplementation = provider.GetService(generated.Type("Thing"));
+
+        Assert.NotNull(asThing);
+        Assert.Same(asThing, asOther);
+        Assert.Same(asThing, asImplementation);
+    }
+
+    [Fact]
+    public void TryRegistration_DoesNotReplaceAnExistingRegistration() {
+        var generated = GeneratedAssembly.Create(Module(
+            "[SingletonService(Using = RegistrationType.Try)] public class Thing : IThing;"));
+
+        Assert.Equal(ServiceLifetime.Singleton, generated.Descriptor("IThing").Lifetime);
+        Assert.Equal(generated.Type("Thing"), generated.ResolveRequired("IThing").GetType());
+    }
+
+    [Fact]
+    public void ReplaceRegistration_LeavesASingleRegistration() {
+        var generated = GeneratedAssembly.Create(Module(
+            "[SingletonService(Using = RegistrationType.Replace)] public class Thing : IThing;"));
+
+        Assert.Single(generated.Descriptors("IThing"));
+    }
+
+    [Fact]
+    public void ConstructorDependencies_AreInjectedFromTheContainer() {
+        var generated = GeneratedAssembly.Create(Module(
+            """
+            public interface IDependency;
+
+            [SingletonService] public class Dependency : IDependency;
+
+            [SingletonService]
+            public class Thing : IThing {
+                public IDependency Injected { get; }
+                public Thing(IDependency dependency) => Injected = dependency;
+            }
+            """));
+
+        var provider = generated.BuildProvider();
+        var thing = provider.GetService(generated.Type("IThing"))!;
+
+        var injected = thing.GetType().GetProperty("Injected")!.GetValue(thing);
+
+        Assert.NotNull(injected);
+        Assert.Same(provider.GetService(generated.Type("IDependency")), injected);
+    }
+
+    [Fact]
+    public void StaticFactory_IsInvokedToCreateTheService() {
+        var generated = GeneratedAssembly.Create(Module(
+            """
+            public class Thing : IThing {
+                public string Origin { get; private set; } = "constructor";
+
+                [SingletonService]
+                public static IThing Create() => new Thing { Origin = "factory" };
+            }
+            """));
+
+        var thing = generated.ResolveRequired("IThing");
+
+        Assert.Equal("factory", thing.GetType().GetProperty("Origin")!.GetValue(thing));
+    }
+
+    [Fact]
+    public void StaticFactory_ReceivesItsDependenciesFromTheContainer() {
+        var generated = GeneratedAssembly.Create(Module(
+            """
+            public interface IDependency;
+
+            [SingletonService] public class Dependency : IDependency;
+
+            public class Thing : IThing {
+                public IDependency? Injected { get; private set; }
+
+                [SingletonService]
+                public static IThing Create(IDependency dependency) => new Thing { Injected = dependency };
+            }
+            """));
+
+        var provider = generated.BuildProvider();
+        var thing = provider.GetService(generated.Type("IThing"))!;
+
+        Assert.Same(
+            provider.GetService(generated.Type("IDependency")),
+            thing.GetType().GetProperty("Injected")!.GetValue(thing));
+    }
+
+    [Fact]
+    public void OpenGenericService_ResolvesForAnyTypeArgument() {
+        var generated = GeneratedAssembly.Create(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            public interface IGeneric<T>;
+
+            [SingletonService]
+            public class GenericThing<T> : IGeneric<T>;
+
+            [DependencyModule]
+            public partial class TestModule;
+            """);
+
+        var provider = generated.BuildProvider();
+        var closed = generated.Type("IGeneric`1").MakeGenericType(typeof(string));
+
+        Assert.NotNull(provider.GetService(closed));
+    }
+
+    [Fact]
+    public void ClosedGenericService_ResolvesForItsOwnArgumentOnly() {
+        var generated = GeneratedAssembly.Create(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            public interface IGeneric<T>;
+
+            [SingletonService]
+            public class StringGeneric : IGeneric<string>;
+
+            [DependencyModule]
+            public partial class TestModule;
+            """);
+
+        var provider = generated.BuildProvider();
+        var generic = generated.Type("IGeneric`1");
+
+        Assert.NotNull(provider.GetService(generic.MakeGenericType(typeof(string))));
+        Assert.Null(provider.GetService(generic.MakeGenericType(typeof(int))));
+    }
+
+    [Fact]
+    public void NestedService_ResolvesThroughItsContainingType() {
+        var generated = GeneratedAssembly.Create(Module(
+            """
+            public static class Outer {
+                [SingletonService]
+                public class Inner : IThing;
+            }
+            """));
+
+        Assert.Equal("Inner", generated.ResolveRequired("IThing").GetType().Name);
+    }
+
+    [Fact]
+    public void RecordService_Resolves() {
+        var generated = GeneratedAssembly.Create(Module("[SingletonService] public record ThingRecord : IThing;"));
+
+        Assert.Equal(generated.Type("ThingRecord"), generated.ResolveRequired("IThing").GetType());
+    }
+
+    [Fact]
+    public void ModuleConfiguration_RunsAlongsideGeneratedRegistrations() {
+        var generated = GeneratedAssembly.Create(
+            """
+            using DependencyModules.Runtime.Attributes;
+            using DependencyModules.Runtime.Interfaces;
+            using Microsoft.Extensions.DependencyInjection;
+
+            namespace TestNamespace;
+
+            public interface IThing;
+            public interface IManual;
+
+            [SingletonService] public class Thing : IThing;
+
+            public class Manual : IManual;
+
+            [DependencyModule]
+            public partial class TestModule : IServiceCollectionConfiguration {
+                public void ConfigureServices(IServiceCollection services) {
+                    services.AddSingleton<IManual, Manual>();
+                }
+            }
+            """);
+
+        var provider = generated.BuildProvider();
+
+        Assert.NotNull(provider.GetService(generated.Type("IThing")));
+        Assert.NotNull(provider.GetService(generated.Type("IManual")));
+    }
+
+    [Fact]
+    public void OnlyRealm_RegistersOnlyServicesInThatRealm() {
+        var generated = GeneratedAssembly.Create(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            public interface IInRealm;
+            public interface IOutsideRealm;
+
+            [DependencyModule(OnlyRealm = true)]
+            public partial class RealmModule;
+
+            [SingletonService(Realm = typeof(RealmModule))]
+            public class InRealm : IInRealm;
+
+            [SingletonService]
+            public class OutsideRealm : IOutsideRealm;
+            """,
+            "RealmModule");
+
+        var provider = generated.BuildProvider();
+
+        Assert.NotNull(provider.GetService(generated.Type("IInRealm")));
+        Assert.Null(provider.GetService(generated.Type("IOutsideRealm")));
+    }
+
+    [Fact]
+    public void ComposedModule_AppliesTheModulesItReferences() {
+        var generated = GeneratedAssembly.Create(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            public interface IFromBase;
+
+            [DependencyModule(OnlyRealm = true)]
+            public partial class BaseModule;
+
+            [SingletonService(Realm = typeof(BaseModule))]
+            public class FromBase : IFromBase;
+
+            [DependencyModule(OnlyRealm = true)]
+            [BaseModule]
+            public partial class ComposedModule;
+            """,
+            "ComposedModule");
+
+        Assert.NotNull(generated.BuildProvider().GetService(generated.Type("IFromBase")));
+    }
+
+    [Fact]
+    public void ServiceWithNoInterface_ResolvesAsItself() {
+        var generated = GeneratedAssembly.Create(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            [SingletonService]
+            public class Standalone;
+
+            [DependencyModule]
+            public partial class TestModule;
+            """);
+
+        Assert.NotNull(generated.BuildProvider().GetService(generated.Type("Standalone")));
+    }
+
+    private static string Module(string body, string extraUsings = "") =>
+        $$"""
+          using DependencyModules.Runtime.Attributes;
+          {{extraUsings}}
+
+          namespace TestNamespace;
+
+          public interface IThing;
+
+          {{body}}
+
+          [DependencyModule]
+          public partial class TestModule;
+          """;
+}

--- a/tests/DependencyModules.Tests/Infrastructure/GeneratedAssembly.cs
+++ b/tests/DependencyModules.Tests/Infrastructure/GeneratedAssembly.cs
@@ -1,0 +1,139 @@
+using System.Reflection;
+using DependencyModules.Runtime;
+using DependencyModules.Runtime.Interfaces;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DependencyModules.Tests.Infrastructure;
+
+/// <summary>
+/// Compiles source with the generator, emits a real assembly, loads it, and builds a service
+/// provider from the generated module.
+///
+/// This is the counterpart to asserting on generated text. The generator's contract is not that its
+/// output contains particular strings, it is that the code the compiler produces registers the right
+/// services with the right lifetimes and that they resolve. Tests built on this class exercise the
+/// registrations the same way an application would, so a change that still emits plausible-looking
+/// code but breaks behaviour fails here.
+/// </summary>
+public class GeneratedAssembly {
+    private static int _assemblyCounter;
+
+    private readonly Assembly _assembly;
+
+    private GeneratedAssembly(Assembly assembly, IServiceCollection services) {
+        _assembly = assembly;
+        Services = services;
+    }
+
+    /// <summary>
+    /// The populated collection, for asserting on registrations that cannot be observed by
+    /// resolving, such as lifetime or registration method.
+    /// </summary>
+    public IServiceCollection Services { get; }
+
+    /// <summary>
+    /// Compiles <paramref name="source"/>, loads the result, and applies the named module.
+    /// </summary>
+    /// <param name="source">Source to compile. Types are expected in the TestNamespace namespace.</param>
+    /// <param name="moduleName">Name of the module type to apply, without its namespace.</param>
+    /// <param name="buildProperties">MSBuild properties visible to the generator.</param>
+    public static GeneratedAssembly Create(
+        string source,
+        string moduleName = "TestModule",
+        IReadOnlyDictionary<string, string>? buildProperties = null) {
+
+        var assemblyName = "GeneratedAssemblyTest" + Interlocked.Increment(ref _assemblyCounter);
+
+        var result = GeneratorTestHarness.Run(
+            new Dictionary<string, string> { ["Test.cs"] = source },
+            buildProperties,
+            assemblyName: assemblyName);
+
+        result.AssertNoErrors();
+
+        var assembly = Emit(result, assemblyName);
+
+        var moduleType = assembly.GetType($"TestNamespace.{moduleName}")
+                         ?? throw new InvalidOperationException(
+                             $"The compiled assembly has no type 'TestNamespace.{moduleName}'. " +
+                             $"Types present: {string.Join(", ", assembly.GetTypes().Select(t => t.FullName))}");
+
+        if (Activator.CreateInstance(moduleType) is not IDependencyModule module) {
+            throw new InvalidOperationException(
+                $"'{moduleType.FullName}' did not implement IDependencyModule. The generator should " +
+                "have added that to the partial declaration.");
+        }
+
+        var services = new ServiceCollection();
+        services.AddModule(module);
+
+        return new GeneratedAssembly(assembly, services);
+    }
+
+    private static Assembly Emit(GeneratorResult result, string assemblyName) {
+        using var stream = new MemoryStream();
+
+        EmitResult emitResult = result.Compilation.Emit(stream);
+
+        Assert.True(emitResult.Success,
+            $"The generated code did not emit. Errors:{Environment.NewLine}" +
+            string.Join(Environment.NewLine,
+                emitResult.Diagnostics
+                    .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                    .Select(diagnostic => $"  {diagnostic.Id} {diagnostic.GetMessage()}")));
+
+        // Loaded into the default context so it binds against the DependencyModules.Runtime already
+        // loaded by this test assembly. That is what lets tests cast to IDependencyModule and
+        // resolve through the real extension methods rather than through reflection.
+        return Assembly.Load(stream.ToArray());
+    }
+
+    /// <summary>
+    /// A type from the compiled assembly, by name within TestNamespace.
+    /// </summary>
+    public Type Type(string name) =>
+        _assembly.GetType($"TestNamespace.{name}")
+        ?? throw new InvalidOperationException(
+            $"No type 'TestNamespace.{name}'. Present: {string.Join(", ", _assembly.GetTypes().Select(t => t.Name))}");
+
+    /// <summary>
+    /// Builds a provider from the applied registrations.
+    /// </summary>
+    public ServiceProvider BuildProvider() => Services.BuildServiceProvider();
+
+    /// <summary>
+    /// Resolves a service by type name, failing the test if it was never registered.
+    /// </summary>
+    public object ResolveRequired(string typeName) {
+        var provider = BuildProvider();
+        var service = provider.GetService(Type(typeName));
+
+        Assert.True(service != null,
+            $"'{typeName}' did not resolve. Registered service types: " +
+            string.Join(", ", Services.Select(descriptor => descriptor.ServiceType.Name)));
+
+        return service!;
+    }
+
+    /// <summary>
+    /// The descriptor registered for a service type, failing the test if there is not exactly one.
+    /// </summary>
+    public ServiceDescriptor Descriptor(string serviceTypeName) {
+        var serviceType = Type(serviceTypeName);
+        var matches = Services.Where(descriptor => descriptor.ServiceType == serviceType).ToArray();
+
+        Assert.True(matches.Length == 1,
+            $"Expected exactly one registration for '{serviceTypeName}', found {matches.Length}.");
+
+        return matches[0];
+    }
+
+    public IReadOnlyList<ServiceDescriptor> Descriptors(string serviceTypeName) {
+        var serviceType = Type(serviceTypeName);
+
+        return Services.Where(descriptor => descriptor.ServiceType == serviceType).ToArray();
+    }
+}

--- a/tests/DependencyModules.Tests/Infrastructure/GeneratorTestHarness.cs
+++ b/tests/DependencyModules.Tests/Infrastructure/GeneratorTestHarness.cs
@@ -26,7 +26,8 @@ public static class GeneratorTestHarness {
     public static GeneratorResult Run(
         IReadOnlyDictionary<string, string> sources,
         IReadOnlyDictionary<string, string>? buildProperties = null,
-        OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary) {
+        OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary,
+        string assemblyName = "GeneratorTestAssembly") {
 
         // MSBuild hands the compiler absolute paths, and the generator compares a file's location
         // against ProjectDir to decide whether it owns the auto-generated ApplicationModule.
@@ -41,7 +42,7 @@ public static class GeneratorTestHarness {
             .ToArray();
 
         var compilation = CSharpCompilation.Create(
-            "GeneratorTestAssembly",
+            assemblyName,
             syntaxTrees,
             References.Value,
             new CSharpCompilationOptions(outputKind, nullableContextOptions: NullableContextOptions.Enable));

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
@@ -1,0 +1,150 @@
+namespace DependencyModules.Runtime.Attributes
+{
+    public abstract class BaseServiceAttribute : System.Attribute, DependencyModules.Runtime.Attributes.IServiceRegistrationAttribute
+    {
+        protected BaseServiceAttribute() { }
+        public System.Type? As { get; set; }
+        public object? Key { get; set; }
+        protected abstract Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime { get; }
+        public System.Type? Realm { get; set; }
+        public DependencyModules.Runtime.Attributes.RegistrationType Using { get; set; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true, Inherited=false)]
+    public class CrossWireServiceAttribute : System.Attribute, DependencyModules.Runtime.Attributes.IServiceRegistrationAttribute
+    {
+        public CrossWireServiceAttribute() { }
+        public object? Key { get; set; }
+        public Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime { get; set; }
+        public System.Type? Realm { get; set; }
+        public DependencyModules.Runtime.Attributes.RegistrationType Using { get; set; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class, Inherited=false)]
+    public class DependencyModuleAttribute : System.Attribute
+    {
+        public DependencyModuleAttribute() { }
+        public bool GenerateAttribute { get; set; }
+        public bool GenerateFactories { get; set; }
+        public string? GenerateUseMethod { get; set; }
+        public bool OnlyRealm { get; set; }
+        public bool RegisterJsonSerializers { get; set; }
+        public DependencyModules.Runtime.Attributes.RegistrationType Using { get; set; }
+    }
+    public interface IServiceRegistrationAttribute
+    {
+        System.Type? As { get; set; }
+        object? Key { get; set; }
+        Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime { get; set; }
+        DependencyModules.Runtime.Attributes.RegistrationType Using { get; set; }
+    }
+    public enum RegistrationType
+    {
+        Add = 0,
+        Try = 1,
+        TryEnumerable = 2,
+        Replace = 3,
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true, Inherited=false)]
+    public class ScopedServiceAttribute : DependencyModules.Runtime.Attributes.BaseServiceAttribute
+    {
+        public ScopedServiceAttribute() { }
+        protected override Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime { get; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true, Inherited=false)]
+    public class SingletonServiceAttribute : DependencyModules.Runtime.Attributes.BaseServiceAttribute
+    {
+        public SingletonServiceAttribute() { }
+        protected override Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime { get; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true, Inherited=false)]
+    public class TransientServiceAttribute : DependencyModules.Runtime.Attributes.BaseServiceAttribute
+    {
+        public TransientServiceAttribute() { }
+        protected override Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime { get; }
+    }
+}
+namespace DependencyModules.Runtime.Features
+{
+    public class FeatureApplicator<TFeature> : DependencyModules.Runtime.Features.IFeatureApplicator
+    {
+        public FeatureApplicator(DependencyModules.Runtime.Features.IDependencyModuleFeature<TFeature> handler) { }
+        public int Order { get; }
+        public void Apply(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection, System.Collections.Generic.IReadOnlyList<DependencyModules.Runtime.Interfaces.IDependencyModule> modules) { }
+    }
+    public interface IDependencyModuleApplicatorProvider
+    {
+        System.Collections.Generic.IEnumerable<DependencyModules.Runtime.Features.IFeatureApplicator> FeatureApplicators();
+    }
+    public interface IDependencyModuleFeature<in TFeature>
+    {
+        int Order { get; }
+        void HandleFeature(Microsoft.Extensions.DependencyInjection.IServiceCollection collection, System.Collections.Generic.IEnumerable<TFeature> feature);
+    }
+    public interface IFeatureApplicator
+    {
+        int Order { get; }
+        void Apply(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection, System.Collections.Generic.IReadOnlyList<DependencyModules.Runtime.Interfaces.IDependencyModule> modules);
+    }
+}
+namespace DependencyModules.Runtime.Helpers
+{
+    public class DependencyRegistry<T>
+    {
+        public DependencyRegistry() { }
+        public static int Add(DependencyModules.Runtime.Helpers.RegistryFunc registryFunc) { }
+        public static int Add<TInstance>(System.Func<System.IServiceProvider, TInstance> provider, Microsoft.Extensions.DependencyInjection.ServiceLifetime lifetime = 2)
+            where TInstance :  class { }
+        public static int Add<TInstance>(System.Type implementationType, Microsoft.Extensions.DependencyInjection.ServiceLifetime lifetime = 2, object? serviceKey = null)
+            where TInstance :  class { }
+        public static int AddDecorator(DependencyModules.Runtime.Helpers.RegistryFunc registryFunc) { }
+        public static int AddModule(params DependencyModules.Runtime.Interfaces.IDependencyModule[] modules) { }
+        public static void ApplyDecorators(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
+        public static void ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
+        public static System.Collections.Generic.IEnumerable<object> GetModules(params object[] modules) { }
+        public static void LoadModules(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection, params DependencyModules.Runtime.Interfaces.IDependencyModule[] dependencyModules) { }
+    }
+    public delegate void RegistryFunc(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection);
+}
+namespace DependencyModules.Runtime.Interfaces
+{
+    public interface IDependencyModule
+    {
+        bool LoadModule { get; }
+        System.Collections.Generic.IEnumerable<DependencyModules.Runtime.Interfaces.IDependencyModule> GetModules();
+        [System.ComponentModel.Browsable(false)]
+        void InternalApplyDecorators(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection);
+        [System.ComponentModel.Browsable(false)]
+        void InternalApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection);
+        [System.ComponentModel.Browsable(false)]
+        System.Collections.Generic.IEnumerable<object> InternalGetModules();
+        void PopulateServiceCollection(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection);
+    }
+    public interface IDependencyModuleProvider
+    {
+        DependencyModules.Runtime.Interfaces.IDependencyModule GetModule();
+    }
+    public interface IEnvironmentServiceCollectionConfiguration
+    {
+        void ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services, DependencyModules.Runtime.Interfaces.IModuleEnvironment? environment);
+    }
+    public interface IModuleEnvironment
+    {
+        string EnvironmentName { get; }
+        string? Value(string name);
+    }
+    public interface IServiceCollectionConfiguration
+    {
+        void ConfigureDecorators(Microsoft.Extensions.DependencyInjection.IServiceCollection services);
+        void ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services);
+    }
+}
+namespace DependencyModules.Runtime
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddModule(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, DependencyModules.Runtime.Interfaces.IDependencyModule module) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddModule<T>(this Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+            where T : DependencyModules.Runtime.Interfaces.IDependencyModule, new () { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddModules(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, params DependencyModules.Runtime.Interfaces.IDependencyModule[] modules) { }
+        public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddModules(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, DependencyModules.Runtime.Interfaces.IModuleEnvironment? environment, params DependencyModules.Runtime.Interfaces.IDependencyModule[] modules) { }
+    }
+}

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -765,6 +765,12 @@ namespace DependencyModules.SourceGenerator.Impl
         public DependencyFileWriter(DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
         public string Write(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel, System.Collections.Generic.IEnumerable<DependencyModules.SourceGenerator.Impl.Models.ServiceModel> serviceModels, string uniqueId) { }
     }
+    public static class DependencyModuleDiagnostics
+    {
+        public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor GeneratorFailure;
+        public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ModuleMustBePartial;
+        public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ServiceCannotBeConstructed;
+    }
     public class DependencyModuleWriter
     {
         public DependencyModuleWriter(bool generateAttribute) { }
@@ -927,6 +933,7 @@ namespace DependencyModules.SourceGenerator.Impl.Models
         OnlyRealm = 2,
         ShouldImplementEquals = 4,
         IsRecord = 8,
+        NotPartial = 16,
     }
     public class ModuleEntryPointModel : DependencyModules.SourceGenerator.Impl.Models.IClassModel, System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel>
     {
@@ -979,6 +986,8 @@ namespace DependencyModules.SourceGenerator.Impl.Models
     {
         None = 0,
         AutoRegisterSourceGenerator = 1,
+        AbstractImplementation = 2,
+        StaticImplementation = 4,
     }
     public enum RegistrationType
     {
@@ -1082,7 +1091,7 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities
         public void Error(string message, object data) { }
         public void Info(string message) { }
         public void Info(string message, object data) { }
-        public static void Wrap(string loggerName, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel, System.Action<DependencyModules.SourceGenerator.Impl.Utilities.FileLogger> logger) { }
+        public static void Wrap(string loggerName, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel, System.Action<DependencyModules.SourceGenerator.Impl.Utilities.FileLogger> logger, System.Action<System.Exception>? reportFailure = null) { }
     }
     public static class ITypeDefinitionExtensions
     {

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -1,0 +1,1181 @@
+namespace CSharpAuthor
+{
+    public class AppendStatement : CSharpAuthor.BaseOutputComponent
+    {
+        public AppendStatement(string appendString, CSharpAuthor.IOutputComponent outputComponent) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class AssignmentStatement : CSharpAuthor.BaseOutputComponent
+    {
+        public AssignmentStatement(CSharpAuthor.IOutputComponent valueComponent, CSharpAuthor.IOutputComponent destinationComponent) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class AttributeDefinition : CSharpAuthor.BaseOutputComponent
+    {
+        public AttributeDefinition(CSharpAuthor.ITypeDefinition attributeType) { }
+        public System.Collections.Generic.IList<CSharpAuthor.IOutputComponent>? Arguments { get; set; }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public abstract class BaseBlockDefinition : CSharpAuthor.BaseOutputComponent
+    {
+        protected readonly System.Collections.Generic.List<CSharpAuthor.IOutputComponent> StatementList;
+        protected BaseBlockDefinition() { }
+        public int StatementCount { get; }
+        public T Add<T>(T component)
+            where T : CSharpAuthor.IOutputComponent { }
+        public virtual CSharpAuthor.CodeOutputComponent AddCode(string statement, params object[] types) { }
+        public virtual object AddIndentedStatement(object component) { }
+        public CSharpAuthor.BaseBlockDefinition.ToClass Assign(CSharpAuthor.IOutputComponent value) { }
+        public CSharpAuthor.BaseBlockDefinition.ToClass Assign(string value) { }
+        public void Break() { }
+        public CSharpAuthor.ForEachDefinition ForEach(string variable, CSharpAuthor.IOutputComponent enumerableComponent) { }
+        public CSharpAuthor.IfElseLogicBlockDefinition If(CSharpAuthor.IOutputComponent outputComponent) { }
+        public CSharpAuthor.IfElseLogicBlockDefinition If(string ifStatement) { }
+        public virtual void NewLine() { }
+        public void Return(object? returnValue = null) { }
+        public CSharpAuthor.SwitchBlockDefinition Switch(object switchValue) { }
+        public void Throw(CSharpAuthor.ITypeDefinition exceptionType, params object[] parameters) { }
+        public void Throw(System.Type type, params object[] parameters) { }
+        public CSharpAuthor.TryCatchBlock Try() { }
+        public CSharpAuthor.WhileDefinition While(object testStatement) { }
+        protected void WriteBlock(CSharpAuthor.IOutputContext context) { }
+        public class ToClass
+        {
+            public ToClass(System.Action<CSharpAuthor.IOutputComponent> addStatement, CSharpAuthor.IOutputComponent valueComponent) { }
+            public void To(CSharpAuthor.IOutputComponent outputComponent) { }
+            public void To(string destination) { }
+            public CSharpAuthor.InstanceDefinition ToLocal(CSharpAuthor.ITypeDefinition typeDefinition, string name) { }
+            public CSharpAuthor.InstanceDefinition ToVar(string name) { }
+        }
+    }
+    public abstract class BaseOutputComponent : CSharpAuthor.IOutputComponent
+    {
+        protected System.Collections.Generic.List<CSharpAuthor.AttributeDefinition>? AttributeDefinitions;
+        protected System.Collections.Generic.List<CSharpAuthor.IOutputComponent>? LeadingTraits;
+        protected System.Collections.Generic.List<CSharpAuthor.IOutputComponent>? TrailingTraits;
+        protected System.Collections.Generic.List<string>? UsingNamespaces;
+        protected BaseOutputComponent() { }
+        public string? Comment { get; set; }
+        public bool Indented { get; set; }
+        public CSharpAuthor.ComponentModifier Modifiers { get; set; }
+        public CSharpAuthor.AttributeDefinition AddAttribute(CSharpAuthor.ITypeDefinition typeDefinition, params object[] args) { }
+        public CSharpAuthor.AttributeDefinition AddAttribute(System.Type type, params object[] args) { }
+        public void AddLeadingTrait(CSharpAuthor.IOutputComponent outputComponent) { }
+        public void AddTrailingTrait(CSharpAuthor.IOutputComponent component) { }
+        public void AddUsingNamespace(string ns) { }
+        protected string GetAccessModifier(string defaultString) { }
+        protected string GetVirtualModifier() { }
+        protected virtual void ProcessAttributes(CSharpAuthor.IOutputContext outputContext) { }
+        protected virtual void ProcessLeadingTraits(CSharpAuthor.IOutputContext outputContext) { }
+        protected virtual void ProcessTrailingTraits(CSharpAuthor.IOutputContext outputContext) { }
+        protected virtual void WriteComment(CSharpAuthor.IOutputContext outputContext) { }
+        protected abstract void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext);
+        public void WriteOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class BaseStatement : CSharpAuthor.BaseOutputComponent
+    {
+        public BaseStatement(System.Collections.Generic.IReadOnlyList<CSharpAuthor.IOutputComponent> components) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public abstract class BaseTypeDefinition : CSharpAuthor.ITypeDefinition, System.IComparable<CSharpAuthor.ITypeDefinition>
+    {
+        protected BaseTypeDefinition(CSharpAuthor.TypeDefinitionEnum typeDefinitionEnum, string ns, string name, bool isArray, bool isNullable) { }
+        public bool IsArray { get; }
+        public bool IsNullable { get; }
+        public abstract System.Collections.Generic.IEnumerable<string> KnownNamespaces { get; }
+        public string Name { get; }
+        public string Namespace { get; }
+        public abstract System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> TypeArguments { get; }
+        public CSharpAuthor.TypeDefinitionEnum TypeDefinitionEnum { get; }
+        protected int BaseCompareTo(CSharpAuthor.ITypeDefinition other) { }
+        public abstract int CompareTo(CSharpAuthor.ITypeDefinition other);
+        public abstract CSharpAuthor.ITypeDefinition MakeArray();
+        public abstract CSharpAuthor.ITypeDefinition MakeNullable(bool nullable = true);
+        public abstract void WriteTypeName(System.Text.StringBuilder builder, CSharpAuthor.TypeOutputMode typeOutputMode = 2);
+    }
+    public class CSharpFileDefinition : CSharpAuthor.BaseOutputComponent, CSharpAuthor.IConstructContainer
+    {
+        public CSharpFileDefinition(string ns = "") { }
+        public CSharpAuthor.ClassDefinition AddClass(string name) { }
+        public void AddComponent(CSharpAuthor.IOutputComponent component) { }
+        public CSharpAuthor.EnumDefinition AddEnum(string name) { }
+        public CSharpAuthor.InterfaceDefinition AddInterface(string interfaceName) { }
+        public System.Collections.Generic.IEnumerable<CSharpAuthor.IOutputComponent> GetAllNamedComponents() { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class CaseBlockDefinition : CSharpAuthor.BaseBlockDefinition
+    {
+        public CaseBlockDefinition(CSharpAuthor.IOutputComponent caseStatement) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class ClassDefinition : CSharpAuthor.BaseOutputComponent, CSharpAuthor.IConstructContainer, CSharpAuthor.INamedComponent
+    {
+        public ClassDefinition(string name) { }
+        public System.Collections.Generic.IReadOnlyList<CSharpAuthor.ConstructorDefinition> Constructors { get; }
+        public int FieldCount { get; }
+        public System.Collections.Generic.IReadOnlyList<CSharpAuthor.FieldDefinition> Fields { get; }
+        public System.Collections.Generic.IReadOnlyList<CSharpAuthor.MethodDefinition> Methods { get; }
+        public string Name { get; }
+        public System.Collections.Generic.IReadOnlyList<CSharpAuthor.PropertyDefinition> Properties { get; }
+        public CSharpAuthor.ClassDefinition AddBaseType(CSharpAuthor.ITypeDefinition typeDefinition) { }
+        public CSharpAuthor.ClassDefinition AddClass(string name) { }
+        public void AddComponent(CSharpAuthor.IOutputComponent outputComponent) { }
+        public CSharpAuthor.ConstructorDefinition AddConstructor(CSharpAuthor.IOutputComponent? baseComponent = null) { }
+        public CSharpAuthor.EnumDefinition AddEnum(string name) { }
+        public CSharpAuthor.FieldDefinition AddField(CSharpAuthor.ITypeDefinition typeDefinition, string fieldName) { }
+        public CSharpAuthor.FieldDefinition AddField(System.Type type, string fieldName) { }
+        public CSharpAuthor.InterfaceDefinition AddInterface(string name) { }
+        public CSharpAuthor.MethodDefinition AddMethod(string method) { }
+        public CSharpAuthor.PropertyDefinition AddProperty(CSharpAuthor.ITypeDefinition type, string fieldName) { }
+        public CSharpAuthor.PropertyDefinition AddProperty(System.Type type, string fieldName) { }
+        public System.Collections.Generic.IEnumerable<CSharpAuthor.IOutputComponent> GetAllNamedComponents() { }
+        protected override void WriteComment(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class CloseScopeComponent : CSharpAuthor.BaseOutputComponent
+    {
+        public CloseScopeComponent() { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class CodeOutputComponent : CSharpAuthor.BaseOutputComponent
+    {
+        public CodeOutputComponent(string statement) { }
+        public void AddType(CSharpAuthor.ITypeDefinition typeDefinition) { }
+        public void AddTypes(System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> typeDefinitions) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+        public static CSharpAuthor.IOutputComponent Get(object? value, bool indented = false) { }
+        public static System.Collections.Generic.IEnumerable<CSharpAuthor.IOutputComponent> GetAll(System.Collections.Generic.IEnumerable<object> values, bool indented = false) { }
+        public static CSharpAuthor.CodeOutputComponent op_Implicit(string statement) { }
+    }
+    public class CombineOutputComponent : CSharpAuthor.BaseOutputComponent
+    {
+        public CombineOutputComponent(params object[] components) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    [System.Flags]
+    public enum ComponentModifier
+    {
+        None = 0,
+        Public = 1,
+        Protected = 2,
+        Private = 4,
+        Readonly = 8,
+        Static = 16,
+        Virtual = 32,
+        Override = 64,
+        Abstract = 128,
+        Async = 256,
+        Partial = 512,
+        Internal = 1024,
+        NoAccessibility = 2048,
+    }
+    public class ConstructorDefinition : CSharpAuthor.MethodDefinition
+    {
+        public ConstructorDefinition(string name, CSharpAuthor.IOutputComponent? base = null) { }
+        public CSharpAuthor.IOutputComponent? Base { get; }
+        protected override void WriteAccessModifier(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteEndOfMethodSignature(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteReturnType(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class DeclarationStatement : CSharpAuthor.BaseOutputComponent
+    {
+        public DeclarationStatement(CSharpAuthor.ITypeDefinition typeDefinition, CSharpAuthor.IOutputComponent outputComponent) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class DelegateDefinition : CSharpAuthor.MethodDefinition
+    {
+        public DelegateDefinition(string name) { }
+        protected override void WriteAccessModifier(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteEndOfMethodSignature(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteMethodBody(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class EnumDefinition : CSharpAuthor.BaseOutputComponent, CSharpAuthor.INamedComponent
+    {
+        public EnumDefinition(string enumName) { }
+        public CSharpAuthor.ITypeDefinition? BaseType { get; set; }
+        public string Name { get; }
+        public CSharpAuthor.EnumDefinition AddFlags() { }
+        public CSharpAuthor.EnumValueDefinition AddValue(string enumValueName) { }
+        public CSharpAuthor.EnumValueDefinition AddValue(string enumValueName, object value) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class EnumValueDefinition : CSharpAuthor.BaseOutputComponent
+    {
+        public EnumValueDefinition(string enumValueName) { }
+        public object? Value { get; set; }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class FieldDefinition : CSharpAuthor.BaseOutputComponent, CSharpAuthor.INamedComponent
+    {
+        public FieldDefinition(CSharpAuthor.ITypeDefinition typeDefinition, string name) { }
+        public CSharpAuthor.IOutputComponent? InitializeValue { get; set; }
+        public CSharpAuthor.InstanceDefinition Instance { get; }
+        public string Name { get; }
+        public CSharpAuthor.ITypeDefinition TypeDefinition { get; }
+        protected override void WriteComment(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class ForDefinition : CSharpAuthor.BaseBlockDefinition
+    {
+        public ForDefinition() { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class ForEachDefinition : CSharpAuthor.BaseBlockDefinition
+    {
+        public ForEachDefinition(string instanceName, CSharpAuthor.IOutputComponent enumerableStatement) { }
+        public CSharpAuthor.InstanceDefinition Instance { get; }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class GenericTypeDefinition : CSharpAuthor.BaseTypeDefinition
+    {
+        public GenericTypeDefinition(System.Type type, System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> closeTypes, bool isArray = false, bool isNullable = false) { }
+        public GenericTypeDefinition(CSharpAuthor.TypeDefinitionEnum classType, string ns, string name, System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> closingTypes, bool isArray = false, bool isNullable = false) { }
+        public override System.Collections.Generic.IEnumerable<string> KnownNamespaces { get; }
+        public override System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> TypeArguments { get; }
+        public override int CompareTo(CSharpAuthor.ITypeDefinition other) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+        public override CSharpAuthor.ITypeDefinition MakeArray() { }
+        public override CSharpAuthor.ITypeDefinition MakeNullable(bool nullable = true) { }
+        public CSharpAuthor.ITypeDefinition MakeOpenType() { }
+        public override string ToString() { }
+        public override void WriteTypeName(System.Text.StringBuilder builder, CSharpAuthor.TypeOutputMode typeOutputMode = 2) { }
+    }
+    public interface IAttributeAware
+    {
+        CSharpAuthor.AttributeDefinition AddAttribute(CSharpAuthor.ITypeDefinition typeDefinition, string argumentStatement = "");
+        CSharpAuthor.AttributeDefinition AddAttribute(System.Type type, string argumentStatement = "");
+    }
+    public interface IConstructContainer
+    {
+        CSharpAuthor.ClassDefinition AddClass(string name);
+        CSharpAuthor.EnumDefinition AddEnum(string name);
+        CSharpAuthor.InterfaceDefinition AddInterface(string name);
+        System.Collections.Generic.IEnumerable<CSharpAuthor.IOutputComponent> GetAllNamedComponents();
+    }
+    public static class IEnumerableExtensions
+    {
+        public static void OutputCommaSeparatedList(this System.Collections.Generic.IEnumerable<CSharpAuthor.IOutputComponent> components, CSharpAuthor.IOutputContext context, bool newLineBeforeItems = false) { }
+        public static void OutputCommaSeparatedList(this System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> components, CSharpAuthor.IOutputContext context, bool newLineBeforeItems = false) { }
+        public static void OutputCommaSeparatedList<T>(this System.Collections.Generic.IEnumerable<T> components, CSharpAuthor.IOutputContext context, System.Action<CSharpAuthor.IOutputContext, T> writeAction, bool newLineBeforeItems = false) { }
+        public static void OutputSeparatedList<T>(this System.Collections.Generic.IEnumerable<T> components, CSharpAuthor.IOutputContext context, System.Action<CSharpAuthor.IOutputContext, T> writeAction, string separator, bool newLineBeforeItems = false) { }
+    }
+    public interface INamedComponent
+    {
+        string Name { get; }
+    }
+    public interface IOutputComponent
+    {
+        void AddUsingNamespace(string ns);
+        void WriteOutput(CSharpAuthor.IOutputContext outputContext);
+    }
+    public interface IOutputContext
+    {
+        string IndentString { get; }
+        char? LastCharacter { get; }
+        CSharpAuthor.OutputContextOptions Options { get; }
+        string SingleIndent { get; }
+        void AddImportNamespace(CSharpAuthor.ITypeDefinition typeDefinition);
+        void AddImportNamespace(string ns);
+        void AddImportNamespaces(System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> typeDefinition);
+        void AddImportNamespaces(System.Collections.Generic.IEnumerable<string> namespaces);
+        void CloseScope();
+        void DecrementIndent();
+        void GenerateUsingStatements();
+        void IncrementIndent();
+        void OpenScope();
+        string Output();
+        void Write(CSharpAuthor.ITypeDefinition typeDefinition);
+        void Write(string text);
+        void WriteIndent(string text = "");
+        void WriteIndentedLine(string text);
+        void WriteLine();
+        void WriteLine(string text);
+        void WriteSpace();
+    }
+    public interface ITypeDefinition : System.IComparable<CSharpAuthor.ITypeDefinition>
+    {
+        bool IsArray { get; }
+        bool IsNullable { get; }
+        System.Collections.Generic.IEnumerable<string> KnownNamespaces { get; }
+        string Name { get; }
+        string Namespace { get; }
+        System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> TypeArguments { get; }
+        CSharpAuthor.TypeDefinitionEnum TypeDefinitionEnum { get; }
+        CSharpAuthor.ITypeDefinition MakeArray();
+        CSharpAuthor.ITypeDefinition MakeNullable(bool nullable = true);
+        void WriteTypeName(System.Text.StringBuilder builder, CSharpAuthor.TypeOutputMode typeOutputMode = 2);
+    }
+    public static class ITypeDefinitionExtensions
+    {
+        public static string GetShortName(this CSharpAuthor.ITypeDefinition typeDefinition) { }
+    }
+    public class IfElseLogicBlockDefinition : CSharpAuthor.BaseBlockDefinition
+    {
+        public IfElseLogicBlockDefinition(CSharpAuthor.IOutputComponent ifStatement) { }
+        public CSharpAuthor.BaseBlockDefinition Else() { }
+        public CSharpAuthor.BaseBlockDefinition ElseIf(CSharpAuthor.IOutputComponent ifStatement) { }
+        public CSharpAuthor.BaseBlockDefinition ElseIf(string ifStatement) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class IndentedStatementComponent : CSharpAuthor.BaseOutputComponent
+    {
+        public IndentedStatementComponent(CSharpAuthor.IOutputComponent component) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class IndexStatement : CSharpAuthor.WrapStatement
+    {
+        public IndexStatement(CSharpAuthor.IOutputComponent instance, CSharpAuthor.IOutputComponent index) { }
+    }
+    public class InstanceDefinition : CSharpAuthor.BaseOutputComponent
+    {
+        public InstanceDefinition(string name) { }
+        public string Name { get; }
+        public CSharpAuthor.InvokeDefinition Invoke(string methodName, params object[] parameters) { }
+        public CSharpAuthor.InvokeGenericDefinition InvokeGeneric(string methodName, System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> genericArgs, params object[] parameters) { }
+        public CSharpAuthor.InstanceDefinition Property(string propertyName) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class InterfaceDefinition : CSharpAuthor.BaseOutputComponent, CSharpAuthor.INamedComponent
+    {
+        protected readonly System.Collections.Generic.List<CSharpAuthor.ITypeDefinition> BaseTypes;
+        protected readonly System.Collections.Generic.List<CSharpAuthor.InterfaceMethodDefinition> Methods;
+        protected readonly System.Collections.Generic.List<CSharpAuthor.InterfacePropertyDefinition> Properties;
+        public InterfaceDefinition(string name) { }
+        public string Name { get; }
+        public CSharpAuthor.InterfaceDefinition AddBaseType(CSharpAuthor.ITypeDefinition typeDefinition) { }
+        public CSharpAuthor.InterfaceDefinition AddBaseType(System.Type type) { }
+        public CSharpAuthor.InterfaceMethodDefinition AddMethod(string name) { }
+        public CSharpAuthor.InterfacePropertyDefinition AddProperty(CSharpAuthor.ITypeDefinition typeDefinition, string name) { }
+        public CSharpAuthor.InterfacePropertyDefinition AddProperty(System.Type type, string name) { }
+        protected override void WriteComment(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class InterfaceMethodDefinition : CSharpAuthor.MethodDefinition
+    {
+        public InterfaceMethodDefinition(string name) { }
+        protected override void WriteAccessModifier(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteEndOfMethodSignature(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteMethodBody(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class InterfacePropertyDefinition : CSharpAuthor.PropertyDefinition
+    {
+        public InterfacePropertyDefinition(CSharpAuthor.ITypeDefinition typeDefinition, string name) { }
+        protected override void WriteAccessModifiers(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class InvokeDefinition : CSharpAuthor.BaseOutputComponent
+    {
+        public InvokeDefinition(string instance, string methodName, params object[] arguments) { }
+        public void AddArgument(CSharpAuthor.IOutputComponent argument) { }
+        public void AddArgument(object argument) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class InvokeGenericDefinition : CSharpAuthor.BaseOutputComponent
+    {
+        public InvokeGenericDefinition(string instance, string methodName, System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> genericArguments, params object[] arguments) { }
+        public void AddArgument(CSharpAuthor.IOutputComponent argument) { }
+        public void AddArgument(object argument) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public static class KeyWords
+    {
+        public static string Abstract { get; }
+        public static string Async { get; }
+        public static string Await { get; }
+        public static string Class { get; }
+        public static string Interface { get; }
+        public static string Internal { get; }
+        public static string Override { get; }
+        public static string Partial { get; }
+        public static string Private { get; }
+        public static string Protected { get; }
+        public static string Public { get; }
+        public static string ReadOnly { get; }
+        public static string Static { get; }
+        public static string Virtual { get; }
+    }
+    public class ListOutputComponent : CSharpAuthor.BaseOutputComponent
+    {
+        public ListOutputComponent(System.Collections.Generic.IReadOnlyList<CSharpAuthor.IOutputComponent> components) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class LogicStatement : CSharpAuthor.BaseOutputComponent
+    {
+        public LogicStatement(string logicStatement, System.Collections.Generic.IReadOnlyList<CSharpAuthor.IOutputComponent> outputComponents) { }
+        public LogicStatement(string logicStatement, params object[] outputComponents) { }
+        public bool PrintParentheses { get; set; }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class MethodDefinition : CSharpAuthor.BaseBlockDefinition, CSharpAuthor.INamedComponent
+    {
+        protected readonly System.Collections.Generic.List<CSharpAuthor.ParameterDefinition> ParameterList;
+        protected int VariableCount;
+        public MethodDefinition(string name) { }
+        public System.Collections.Generic.List<CSharpAuthor.ITypeDefinition> GenericParameters { get; }
+        public CSharpAuthor.ITypeDefinition? InterfaceImplementation { get; set; }
+        public string Name { get; }
+        public System.Collections.Generic.IReadOnlyList<CSharpAuthor.ParameterDefinition> Parameters { get; }
+        public string? ReturnComment { get; set; }
+        public CSharpAuthor.ITypeDefinition? ReturnType { get; }
+        public CSharpAuthor.IOutputComponent? WhereStatement { get; set; }
+        public void AddGenericParameter(CSharpAuthor.ITypeDefinition typeDefinition) { }
+        public CSharpAuthor.MethodDefinition AddParameter(CSharpAuthor.ParameterDefinition parameterDefinition) { }
+        public CSharpAuthor.ParameterDefinition AddParameter(CSharpAuthor.ITypeDefinition typeDefinition, string name) { }
+        public CSharpAuthor.ParameterDefinition AddParameter(System.Type type, string name) { }
+        public string GetUniqueVariable(string prefix) { }
+        public CSharpAuthor.MethodDefinition SetReturnType(CSharpAuthor.ITypeDefinition type) { }
+        public CSharpAuthor.MethodDefinition SetReturnType(System.Type type) { }
+        protected virtual void WriteAccessModifier(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteComment(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+        protected virtual void WriteEndOfMethodSignature(CSharpAuthor.IOutputContext outputContext) { }
+        protected virtual void WriteMethodBody(CSharpAuthor.IOutputContext outputContext) { }
+        protected virtual void WriteMethodSignature(CSharpAuthor.IOutputContext outputContext) { }
+        protected virtual void WriteReturnType(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class NamespaceDefinition : CSharpAuthor.BaseOutputComponent, CSharpAuthor.IConstructContainer
+    {
+        public NamespaceDefinition(string ns = "") { }
+        public CSharpAuthor.ClassDefinition AddClass(string name) { }
+        public void AddComponent(CSharpAuthor.IOutputComponent component) { }
+        public CSharpAuthor.EnumDefinition AddEnum(string name) { }
+        public CSharpAuthor.InterfaceDefinition AddInterface(string interfaceName) { }
+        public CSharpAuthor.NamespaceDefinition AddNamespace(string @namespace) { }
+        public System.Collections.Generic.IEnumerable<CSharpAuthor.IOutputComponent> GetAllNamedComponents() { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class NewArrayStatement : CSharpAuthor.BaseOutputComponent
+    {
+        public NewArrayStatement(CSharpAuthor.ITypeDefinition typeDefinition, params CSharpAuthor.IOutputComponent[] components) { }
+        public NewArrayStatement(CSharpAuthor.ITypeDefinition typeDefinition, int length) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class NewStatement : CSharpAuthor.InstanceDefinition
+    {
+        public NewStatement(CSharpAuthor.ITypeDefinition typeDefinition, params object[] arguments) { }
+        public void AddArgument(CSharpAuthor.IOutputComponent argument) { }
+        public void AddArgument(object argument) { }
+        public void AddInitValue(object initValue) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class NullableEnableComponent : CSharpAuthor.BaseOutputComponent
+    {
+        public NullableEnableComponent(bool enable) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class OpenScopeComponent : CSharpAuthor.BaseOutputComponent
+    {
+        public OpenScopeComponent() { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class OutputContext : CSharpAuthor.IOutputContext
+    {
+        public OutputContext(CSharpAuthor.OutputContextOptions? options = null) { }
+        public string IndentString { get; }
+        public char? LastCharacter { get; }
+        public CSharpAuthor.OutputContextOptions Options { get; }
+        public string SingleIndent { get; }
+        public void AddImportNamespace(CSharpAuthor.ITypeDefinition typeDefinition) { }
+        public void AddImportNamespace(string ns) { }
+        public void AddImportNamespaces(System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> typeDefinitions) { }
+        public void AddImportNamespaces(System.Collections.Generic.IEnumerable<string> namespaces) { }
+        public void CloseScope() { }
+        public void DecrementIndent() { }
+        public void GenerateUsingStatements() { }
+        public void IncrementIndent() { }
+        public void OpenScope() { }
+        public string Output() { }
+        public void Write(CSharpAuthor.ITypeDefinition typeDefinition) { }
+        public void Write(string text) { }
+        public void WriteIndent(string text = "") { }
+        public void WriteIndentedLine(string text) { }
+        public void WriteLine() { }
+        public void WriteLine(string text) { }
+        public void WriteSpace() { }
+    }
+    public class OutputContextOptions
+    {
+        public OutputContextOptions() { }
+        public bool BreakInvokeLines { get; set; }
+        public bool GenerateDocumentation { get; set; }
+        public char IndentChar { get; set; }
+        public int IndentCharCount { get; set; }
+        public string NewLine { get; set; }
+        public CSharpAuthor.TypeOutputMode TypeOutputMode { get; set; }
+    }
+    public class ParameterDefinition : CSharpAuthor.InstanceDefinition
+    {
+        public ParameterDefinition(CSharpAuthor.ITypeDefinition typeDefinition, string name) { }
+        public CSharpAuthor.IOutputComponent? DefaultValue { get; set; }
+        public bool IsOut { get; set; }
+        public bool This { get; set; }
+        public CSharpAuthor.ITypeDefinition TypeDefinition { get; }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+        public void WriteWithSignature(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class PostfixOutputComponent : CSharpAuthor.BaseOutputComponent
+    {
+        public PostfixOutputComponent(string postfix, CSharpAuthor.IOutputComponent outputComponent) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class PragmaOutputComponent : CSharpAuthor.BaseOutputComponent
+    {
+        public PragmaOutputComponent(bool enable, params string[] pragma) { }
+        protected override void ProcessLeadingTraits(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void ProcessTrailingTraits(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class PrefixOutputComponent : CSharpAuthor.BaseOutputComponent
+    {
+        public PrefixOutputComponent(string prefix, CSharpAuthor.IOutputComponent awaitableOutputComponent) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class PropertyDefinition : CSharpAuthor.BaseOutputComponent, CSharpAuthor.INamedComponent
+    {
+        public PropertyDefinition(CSharpAuthor.ITypeDefinition type, string name) { }
+        public CSharpAuthor.IOutputComponent? DefaultValue { get; set; }
+        public CSharpAuthor.PropertyMethodDefinition Get { get; }
+        public string IndexName { get; set; }
+        public CSharpAuthor.ITypeDefinition? IndexType { get; set; }
+        public CSharpAuthor.InstanceDefinition Instance { get; }
+        public string Name { get; }
+        public CSharpAuthor.PropertyMethodDefinition? Set { get; set; }
+        public CSharpAuthor.ITypeDefinition Type { get; }
+        protected virtual void WriteAccessModifiers(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteComment(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class PropertyMethodDefinition : CSharpAuthor.MethodDefinition
+    {
+        public PropertyMethodDefinition() { }
+        public bool LambdaSyntax { get; set; }
+        protected override void WriteMethodBody(CSharpAuthor.IOutputContext outputContext) { }
+        protected override void WriteMethodSignature(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class StaticCastComponent : CSharpAuthor.BaseOutputComponent
+    {
+        public StaticCastComponent(CSharpAuthor.ITypeDefinition typeDefinition, object value) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class StaticInvokeGenericStatement : CSharpAuthor.BaseOutputComponent
+    {
+        public StaticInvokeGenericStatement(CSharpAuthor.ITypeDefinition typeDefinition, string methodName, System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> genericArguments, System.Collections.Generic.IReadOnlyList<CSharpAuthor.IOutputComponent> parameters) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class StaticInvokeStatement : CSharpAuthor.BaseOutputComponent
+    {
+        public StaticInvokeStatement(CSharpAuthor.ITypeDefinition typeDefinition, string methodName, System.Collections.Generic.IReadOnlyList<CSharpAuthor.IOutputComponent> parameters) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class StaticPropertyStatement : CSharpAuthor.BaseOutputComponent
+    {
+        public StaticPropertyStatement(CSharpAuthor.ITypeDefinition typeDefinition, string propertyName) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class SwitchBlockDefinition : CSharpAuthor.BaseOutputComponent
+    {
+        public SwitchBlockDefinition(CSharpAuthor.IOutputComponent switchValue) { }
+        public CSharpAuthor.CaseBlockDefinition AddCase(object value) { }
+        public CSharpAuthor.CaseBlockDefinition AddDefault() { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public static class SyntaxHelpers
+    {
+        public static CSharpAuthor.LogicStatement Add(params object[] andStatements) { }
+        public static CSharpAuthor.LogicStatement And(System.Collections.Generic.IReadOnlyList<CSharpAuthor.IOutputComponent> andStatements) { }
+        public static CSharpAuthor.LogicStatement And(params object[] andStatements) { }
+        public static CSharpAuthor.IOutputComponent Await(object outputComponent) { }
+        public static CSharpAuthor.IOutputComponent Bang(object outputComponent) { }
+        public static CSharpAuthor.BaseStatement Base(params object[] parameters) { }
+        public static CSharpAuthor.LogicStatement ConcatSymbol(string symbol, params object[] andStatements) { }
+        public static CSharpAuthor.IOutputComponent Decrement(object outputComponent) { }
+        public static CSharpAuthor.LogicStatement Divide(params object[] andStatements) { }
+        public static void EnableNullable(this CSharpAuthor.BaseOutputComponent baseOutputComponent) { }
+        public static CSharpAuthor.LogicStatement EqualsStatement(object leftHandSide, object rightHandSide) { }
+        public static CSharpAuthor.LogicStatement GreaterThan(object leftHandSide, object rightHandSide) { }
+        public static CSharpAuthor.LogicStatement GreaterThanOrEquals(object leftHandSide, object rightHandSide) { }
+        public static CSharpAuthor.IOutputComponent Increment(object outputComponent) { }
+        public static CSharpAuthor.IndexStatement Index(this CSharpAuthor.IOutputComponent component, object index) { }
+        public static CSharpAuthor.InvokeDefinition Invoke(string methodName, params object[] parameters) { }
+        public static CSharpAuthor.IOutputComponent Invoke(this CSharpAuthor.IOutputComponent outputComponent, string methodName, params object[] parameters) { }
+        public static CSharpAuthor.StaticInvokeStatement Invoke(CSharpAuthor.ITypeDefinition typeDefinition, string methodName, params object[] parameters) { }
+        public static CSharpAuthor.StaticInvokeStatement Invoke(System.Type type, string methodName, params object[] parameters) { }
+        public static CSharpAuthor.InvokeGenericDefinition InvokeGeneric(string methodName, System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> genericArgs, params object[] parameters) { }
+        public static CSharpAuthor.IOutputComponent InvokeGeneric(this CSharpAuthor.IOutputComponent outputComponent, string methodName, System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> genericArgs, params object[] parameters) { }
+        public static CSharpAuthor.StaticInvokeGenericStatement InvokeGeneric(CSharpAuthor.ITypeDefinition typeDefinition, string methodName, System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> genericArgs, params object[] parameters) { }
+        public static CSharpAuthor.StaticInvokeGenericStatement InvokeGeneric(System.Type type, string methodName, System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> genericArgs, params object[] parameters) { }
+        public static CSharpAuthor.IOutputComponent Is(CSharpAuthor.IOutputComponent testComponent, CSharpAuthor.ITypeDefinition typeDefinition) { }
+        public static CSharpAuthor.LogicStatement LessThan(object leftHandSide, object rightHandSide) { }
+        public static CSharpAuthor.LogicStatement LessThanOrEquals(object leftHandSide, object rightHandSide) { }
+        public static CSharpAuthor.LogicStatement Multiply(params object[] andStatements) { }
+        public static CSharpAuthor.NewStatement New(CSharpAuthor.ITypeDefinition typeDefinition, params object[] parameters) { }
+        public static CSharpAuthor.NewStatement New(System.Type type, params object[] parameters) { }
+        public static CSharpAuthor.NewArrayStatement NewArray(CSharpAuthor.ITypeDefinition type, params object[] parameters) { }
+        public static CSharpAuthor.NewArrayStatement NewArray(CSharpAuthor.ITypeDefinition typeDefinition, int length) { }
+        public static CSharpAuthor.NewArrayStatement NewArray(System.Type type, int length) { }
+        public static CSharpAuthor.NewArrayStatement NewArray(System.Type type, params object[] parameters) { }
+        public static CSharpAuthor.LogicStatement NotEquals(object leftHandSide, object rightHandSide) { }
+        public static CSharpAuthor.IOutputComponent Null() { }
+        public static CSharpAuthor.LogicStatement NullCoalesce(object leftHandSide, object rightHandSide) { }
+        public static CSharpAuthor.LogicStatement NullCoalesceEqual(object leftHandSide, object rightHandSide) { }
+        public static CSharpAuthor.LogicStatement Or(System.Collections.Generic.IReadOnlyList<CSharpAuthor.IOutputComponent> orStatements) { }
+        public static CSharpAuthor.LogicStatement Or(params object[] orStatements) { }
+        public static CSharpAuthor.IOutputComponent Parenthesis(object value) { }
+        public static CSharpAuthor.IOutputComponent Property(CSharpAuthor.IOutputComponent outputComponent, string propertyName) { }
+        public static CSharpAuthor.StaticPropertyStatement Property(CSharpAuthor.ITypeDefinition typeDefinition, string propertyName) { }
+        public static CSharpAuthor.IOutputComponent Question(object outputComponent) { }
+        public static string QuoteString(string stringValue) { }
+        public static CSharpAuthor.IOutputComponent StaticCast(CSharpAuthor.ITypeDefinition typeDefinition, object value) { }
+        public static CSharpAuthor.IOutputComponent StaticCast(System.Type type, object value) { }
+        public static CSharpAuthor.LogicStatement Subtract(params object[] andStatements) { }
+        public static CSharpAuthor.IOutputComponent This(params object[] parameters) { }
+        public static CSharpAuthor.IOutputComponent ThisInstance() { }
+        public static CSharpAuthor.IOutputComponent TypeOf(CSharpAuthor.ITypeDefinition typeDefinition) { }
+        public static void WrapInPragma(this CSharpAuthor.BaseOutputComponent baseOutputComponent, params string[] pragma) { }
+        public static CSharpAuthor.WrapStatement YieldReturn(object value) { }
+    }
+    public class TryCatchBlock : CSharpAuthor.BaseBlockDefinition
+    {
+        public TryCatchBlock() { }
+        public CSharpAuthor.BaseBlockDefinition Catch(CSharpAuthor.ITypeDefinition exceptionType, string name = "", CSharpAuthor.IOutputComponent? when = null) { }
+        public CSharpAuthor.BaseBlockDefinition Catch(System.Type exceptionType, string name = "", CSharpAuthor.IOutputComponent? when = null) { }
+        public CSharpAuthor.BaseBlockDefinition Finally() { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class TypeDefinition : CSharpAuthor.BaseTypeDefinition
+    {
+        public TypeDefinition(CSharpAuthor.TypeDefinitionEnum typeDefinitionEnum, string ns, string name, bool isArray, bool isNullable = false) { }
+        public override System.Collections.Generic.IEnumerable<string> KnownNamespaces { get; }
+        public override System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> TypeArguments { get; }
+        public override int CompareTo(CSharpAuthor.ITypeDefinition other) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+        public override CSharpAuthor.ITypeDefinition MakeArray() { }
+        public override CSharpAuthor.ITypeDefinition MakeNullable(bool nullable = true) { }
+        public override string ToString() { }
+        public override void WriteTypeName(System.Text.StringBuilder builder, CSharpAuthor.TypeOutputMode typeOutputMode = 2) { }
+        public static CSharpAuthor.ITypeDefinition Action(params object[] typeArguments) { }
+        public static CSharpAuthor.ITypeDefinition Func(params object[] typeArguments) { }
+        public static CSharpAuthor.ITypeDefinition Get(System.Type type) { }
+        public static CSharpAuthor.TypeDefinition Get(string ns, string name, bool isArray = false, bool isNullable = false) { }
+        public static CSharpAuthor.TypeDefinition Get(CSharpAuthor.TypeDefinitionEnum definitionEnum, string ns, string name, bool isArray = false, bool isNullable = false) { }
+        public static CSharpAuthor.ITypeDefinition IEnumerable(object typeObject) { }
+        public static CSharpAuthor.ITypeDefinition IOptions(object typeObject) { }
+        public static CSharpAuthor.ITypeDefinition List(object typeObject) { }
+        public static CSharpAuthor.ITypeDefinition Task(object typeObject) { }
+    }
+    public enum TypeDefinitionEnum
+    {
+        ClassDefinition = 0,
+        EnumDefinition = 1,
+        InterfaceDefinition = 2,
+    }
+    public static class TypeExtensions
+    {
+        public static string GetGenericName(this System.Type type) { }
+    }
+    public enum TypeOutputMode
+    {
+        Global = 0,
+        FullName = 1,
+        ShortName = 2,
+    }
+    public class TypeStatement : CSharpAuthor.BaseOutputComponent
+    {
+        public TypeStatement(CSharpAuthor.ITypeDefinition typeDefinition) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class VarStatement : CSharpAuthor.BaseOutputComponent
+    {
+        public VarStatement(CSharpAuthor.IOutputComponent variable) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class WhileDefinition : CSharpAuthor.BaseBlockDefinition
+    {
+        public WhileDefinition(object testStatement) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class WrapStatement : CSharpAuthor.BaseOutputComponent
+    {
+        public WrapStatement(CSharpAuthor.IOutputComponent outputComponent, string prefixString, string postfixString) { }
+        public WrapStatement(CSharpAuthor.IOutputComponent? outputComponent, CSharpAuthor.IOutputComponent? prefixString, CSharpAuthor.IOutputComponent? postfixString) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+}
+namespace DependencyModules.SourceGenerator.Impl
+{
+    public abstract class BaseAttributeSourceGenerator<T> : DependencyModules.SourceGenerator.Impl.IDependencyModuleSourceGenerator
+    {
+        protected BaseAttributeSourceGenerator() { }
+        protected virtual string LoggerName { get; }
+        protected abstract System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> AttributeTypes();
+        protected abstract T GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext arg1, System.Threading.CancellationToken arg2);
+        protected abstract void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext arg1, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right",
+                "Left",
+                "Right"})] System.ValueTuple<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>, System.Collections.Immutable.ImmutableArray<T>> valueTuple, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger);
+        protected abstract System.Collections.Generic.IEqualityComparer<T> GetComparer();
+        public void SetupGenerator(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right"})] Microsoft.CodeAnalysis.IncrementalValuesProvider<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>> incrementalValueProvider) { }
+    }
+    public abstract class BaseAttributeWithConfigSourceGenerator<TModel, TConfig> : DependencyModules.SourceGenerator.Impl.IDependencyModuleSourceGenerator
+    {
+        protected BaseAttributeWithConfigSourceGenerator() { }
+        protected abstract System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> AttributeTypes();
+        protected abstract TModel GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext arg1, System.Threading.CancellationToken arg2);
+        protected abstract TConfig GenerateConfigAttributeModel(Microsoft.CodeAnalysis.Diagnostics.AnalyzerConfigOptionsProvider arg1, System.Threading.CancellationToken arg2);
+        protected abstract void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext arg1, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right",
+                "Left",
+                "Right",
+                "Left",
+                "Right"})] System.ValueTuple<System.ValueTuple<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>, TConfig>, System.Collections.Immutable.ImmutableArray<TModel>> arg2);
+        protected abstract System.Collections.Generic.IEqualityComparer<TModel> GetComparer();
+        protected abstract System.Collections.Generic.IEqualityComparer<TConfig> GetConfigComparer();
+        public void SetupGenerator(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right"})] Microsoft.CodeAnalysis.IncrementalValuesProvider<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>> incrementalValueProvider) { }
+    }
+    public abstract class BaseSourceGenerator : Microsoft.CodeAnalysis.IIncrementalGenerator
+    {
+        protected BaseSourceGenerator() { }
+        protected virtual bool ShouldAutoApproveCompilationUnit { get; }
+        protected abstract System.Collections.Generic.IEnumerable<DependencyModules.SourceGenerator.Impl.IDependencyModuleSourceGenerator> AttributeSourceGenerators();
+        protected virtual DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel GenerateEntryPointModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellation) { }
+        public void Initialize(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context) { }
+        protected virtual CSharpAuthor.ITypeDefinition[] ModuleAttributeTypes() { }
+        protected virtual void SetupRootGenerator(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right"})] Microsoft.CodeAnalysis.IncrementalValueProvider<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>> valuesProvider) { }
+        public static DependencyModules.SourceGenerator.Impl.Models.RegistrationType GetRegistrationType(string toString) { }
+    }
+    public class CollectionSyntaxDeclaration : CSharpAuthor.BaseOutputComponent
+    {
+        public CollectionSyntaxDeclaration() { }
+        public void Add(object item) { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+    public class DependencyFileWriter
+    {
+        public DependencyFileWriter(DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
+        public string Write(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel, System.Collections.Generic.IEnumerable<DependencyModules.SourceGenerator.Impl.Models.ServiceModel> serviceModels, string uniqueId) { }
+    }
+    public class DependencyModuleWriter
+    {
+        public DependencyModuleWriter(bool generateAttribute) { }
+        public void GenerateSource(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right"})] System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>> allEntryPoints) { }
+    }
+    public interface IDependencyModuleSourceGenerator
+    {
+        void SetupGenerator(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right"})] Microsoft.CodeAnalysis.IncrementalValuesProvider<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>> incrementalValueProvider);
+    }
+    public static class KnownTypes
+    {
+        public static class DependencyModules
+        {
+            public static class Attributes
+            {
+                public const string Namespace = "DependencyModules.Runtime.Attributes";
+                public static readonly CSharpAuthor.ITypeDefinition CrossWireServiceAttribute;
+                public static readonly CSharpAuthor.ITypeDefinition DependencyModuleAttribute;
+                public static readonly CSharpAuthor.ITypeDefinition ScopedServiceAttribute;
+                public static readonly CSharpAuthor.ITypeDefinition SingletonServiceAttribute;
+                public static readonly CSharpAuthor.ITypeDefinition TransientServiceAttribute;
+            }
+            public static class Features
+            {
+                public const string Namespace = "DependencyModules.Runtime.Features";
+                public static readonly CSharpAuthor.ITypeDefinition FeatureApplicator;
+                public static readonly CSharpAuthor.ITypeDefinition IDependencyModuleApplicatorProvider;
+                public static readonly CSharpAuthor.ITypeDefinition IFeatureApplicator;
+            }
+            public static class Helpers
+            {
+                public const string Namespace = "DependencyModules.Runtime.Helpers";
+            }
+            public static class Interfaces
+            {
+                public const string Namespace = "DependencyModules.Runtime.Interfaces";
+                public static readonly CSharpAuthor.ITypeDefinition IDependencyModule;
+                public static readonly CSharpAuthor.ITypeDefinition IDependencyModuleProvider;
+            }
+        }
+        public static class Microsoft
+        {
+            public static class DependencyInjection
+            {
+                public const string Namespace = "Microsoft.Extensions.DependencyInjection";
+                public static readonly CSharpAuthor.ITypeDefinition FromKeyedServicesAttribute;
+                public static readonly CSharpAuthor.ITypeDefinition IServiceCollection;
+                public static readonly CSharpAuthor.ITypeDefinition IServiceProvider;
+                public static readonly CSharpAuthor.ITypeDefinition ServiceDescriptor;
+            }
+            public static class TextJson
+            {
+                public const string Namespace = "System.Text.Json.Serialization";
+                public static readonly CSharpAuthor.ITypeDefinition IJsonTypeInfoResolver;
+                public static readonly CSharpAuthor.ITypeDefinition JsonSourceGenerationOptionsAttribute;
+            }
+        }
+    }
+    public class ModuleAttributeWriter : DependencyModules.SourceGenerator.Impl.Utilities.BaseAttributeWriter<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel>
+    {
+        public ModuleAttributeWriter() { }
+        protected override void CustomImplementation(CSharpAuthor.IConstructContainer container, CSharpAuthor.ClassDefinition attributeClass, DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel model) { }
+    }
+}
+namespace DependencyModules.SourceGenerator.Impl.Models
+{
+    public enum AccessModifier
+    {
+        PublicModifier = 0,
+        PrivateModifier = 1,
+        ProtectedModifier = 2,
+        InternalModifier = 3,
+    }
+    public class AttributeArgumentValue : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.AttributeArgumentValue>
+    {
+        public AttributeArgumentValue(string Name, object? Value) { }
+        public string Name { get; init; }
+        public object? Value { get; init; }
+        public virtual bool Equals(DependencyModules.SourceGenerator.Impl.Models.AttributeArgumentValue? other) { }
+        public override int GetHashCode() { }
+    }
+    public class AttributeClassInfo : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.AttributeClassInfo>
+    {
+        public AttributeClassInfo(DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel ConstructorInfo, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.PropertyInfoModel> Properties) { }
+        public DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel ConstructorInfo { get; init; }
+        public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.PropertyInfoModel> Properties { get; init; }
+    }
+    public class AttributeModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.AttributeModel>
+    {
+        public AttributeModel(CSharpAuthor.ITypeDefinition TypeDefinition, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.AttributeArgumentValue> Arguments, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.AttributeArgumentValue> Properties, System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> ImplementedInterfaces) { }
+        public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.AttributeArgumentValue> Arguments { get; init; }
+        public System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> ImplementedInterfaces { get; init; }
+        public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.AttributeArgumentValue> Properties { get; init; }
+        public CSharpAuthor.ITypeDefinition TypeDefinition { get; init; }
+        public virtual bool Equals(DependencyModules.SourceGenerator.Impl.Models.AttributeModel? other) { }
+        public System.Collections.Generic.IList<CSharpAuthor.IOutputComponent> GetArguments() { }
+        public override int GetHashCode() { }
+        public System.Collections.Generic.IList<CSharpAuthor.IOutputComponent> PropertyValues() { }
+    }
+    public class ConstructorInfoModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel>
+    {
+        public ConstructorInfoModel(System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> Parameters) { }
+        public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> Parameters { get; init; }
+        public virtual bool Equals(DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? other) { }
+        public override int GetHashCode() { }
+    }
+    public class DependencyModuleConfigurationModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>
+    {
+        public DependencyModuleConfigurationModel(DependencyModules.SourceGenerator.Impl.Models.RegistrationType RegistrationType, bool RegisterSourceGenerator, string RootNamespace, string ProjectDir, bool AutoGenerateEntry, string LogOutputFolder, DependencyModules.SourceGenerator.Impl.Models.LogOutputLevel LogOutputLevel, bool GenerateFactories, bool ExcludeGeneratedCodeFromCoverage = true) { }
+        public bool AutoGenerateEntry { get; init; }
+        public bool ExcludeGeneratedCodeFromCoverage { get; init; }
+        public bool GenerateFactories { get; init; }
+        public string LogOutputFolder { get; init; }
+        public DependencyModules.SourceGenerator.Impl.Models.LogOutputLevel LogOutputLevel { get; init; }
+        public string ProjectDir { get; init; }
+        public bool RegisterSourceGenerator { get; init; }
+        public DependencyModules.SourceGenerator.Impl.Models.RegistrationType RegistrationType { get; init; }
+        public string RootNamespace { get; init; }
+    }
+    public class DependencyModuleConfigurationModelComparer : System.Collections.Generic.IEqualityComparer<DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>
+    {
+        public DependencyModuleConfigurationModelComparer() { }
+        public bool Equals(DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel? x, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel? y) { }
+        public int GetHashCode(DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel obj) { }
+    }
+    public delegate CSharpAuthor.IOutputComponent? FactoryOutputDelegate(DependencyModules.SourceGenerator.Impl.Models.ServiceModel serviceModel, DependencyModules.SourceGenerator.Impl.Models.ServiceRegistrationModel registrationModel);
+    public interface IClassModel
+    {
+        System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.AttributeModel> AttributeModels { get; }
+        CSharpAuthor.ITypeDefinition ClassType { get; }
+        System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> Parameters { get; }
+        System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.PropertyInfoModel> PropertyInfoModels { get; }
+    }
+    public enum LogOutputLevel
+    {
+        Debug = 1,
+        Info = 2,
+        Warning = 3,
+        Error = 4,
+        Fatal = 5,
+    }
+    public class MethodInfoModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.MethodInfoModel>
+    {
+        public MethodInfoModel(DependencyModules.SourceGenerator.Impl.Models.AccessModifier AccessModifier, string MethodName, CSharpAuthor.ITypeDefinition ReturnType, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> Parameters, System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> GenericArguments) { }
+        public DependencyModules.SourceGenerator.Impl.Models.AccessModifier AccessModifier { get; init; }
+        public System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> GenericArguments { get; init; }
+        public string MethodName { get; init; }
+        public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> Parameters { get; init; }
+        public CSharpAuthor.ITypeDefinition ReturnType { get; init; }
+    }
+    [System.Flags]
+    public enum ModuleEntryPointFeatures
+    {
+        None = 0,
+        AutoGenerateModule = 1,
+        OnlyRealm = 2,
+        ShouldImplementEquals = 4,
+        IsRecord = 8,
+    }
+    public class ModuleEntryPointModel : DependencyModules.SourceGenerator.Impl.Models.IClassModel, System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel>
+    {
+        public ModuleEntryPointModel(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointFeatures ModuleFeatures, string FileLocation, CSharpAuthor.ITypeDefinition EntryPointType, DependencyModules.SourceGenerator.Impl.Models.RegistrationType? RegistrationType, bool? GenerateAttribute, bool? RegisterJsonSerializers, string? UseMethod, bool? GenerateFactories, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> Parameters, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.PropertyInfoModel> PropertyInfoModels, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.AttributeModel> AttributeModels, System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> AdditionalModules, System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> Features) { }
+        public System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> AdditionalModules { get; init; }
+        public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.AttributeModel> AttributeModels { get; init; }
+        public CSharpAuthor.ITypeDefinition ClassType { get; }
+        public CSharpAuthor.ITypeDefinition EntryPointType { get; init; }
+        public System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> Features { get; init; }
+        public string FileLocation { get; init; }
+        public bool? GenerateAttribute { get; init; }
+        public bool? GenerateFactories { get; init; }
+        public DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointFeatures ModuleFeatures { get; init; }
+        public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> Parameters { get; init; }
+        public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.PropertyInfoModel> PropertyInfoModels { get; init; }
+        public bool? RegisterJsonSerializers { get; init; }
+        public DependencyModules.SourceGenerator.Impl.Models.RegistrationType? RegistrationType { get; init; }
+        public string? UseMethod { get; init; }
+    }
+    public class ModuleEntryPointModelComparer : System.Collections.Generic.IEqualityComparer<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel>
+    {
+        public ModuleEntryPointModelComparer() { }
+        public bool Equals(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel? x, DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel? y) { }
+        public int GetHashCode(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel obj) { }
+    }
+    public static class ModuleEntryPointModelExtensions
+    {
+        public static string UniqueId(this DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel model) { }
+    }
+    public class ParameterInfoModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel>
+    {
+        public ParameterInfoModel(string ParameterName, CSharpAuthor.ITypeDefinition ParameterType, object? DefaultValue, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.AttributeModel> Attributes) { }
+        public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.AttributeModel> Attributes { get; init; }
+        public object? DefaultValue { get; init; }
+        public string ParameterName { get; init; }
+        public CSharpAuthor.ITypeDefinition ParameterType { get; init; }
+        public virtual bool Equals(DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel? other) { }
+        public override int GetHashCode() { }
+    }
+    public class PropertyInfoModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.PropertyInfoModel>
+    {
+        public PropertyInfoModel(CSharpAuthor.ITypeDefinition PropertyType, string PropertyName, bool IsReadOnly, bool IsStatic) { }
+        public bool IsReadOnly { get; init; }
+        public bool IsStatic { get; init; }
+        public string PropertyName { get; init; }
+        public CSharpAuthor.ITypeDefinition PropertyType { get; init; }
+    }
+    [System.Flags]
+    public enum RegistrationFeature
+    {
+        None = 0,
+        AutoRegisterSourceGenerator = 1,
+    }
+    public enum RegistrationType
+    {
+        Add = 0,
+        Try = 1,
+        TryEnumerable = 2,
+        Replace = 3,
+    }
+    public class ServiceFactoryModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.ServiceFactoryModel>
+    {
+        public ServiceFactoryModel(CSharpAuthor.ITypeDefinition TypeDefinition, string MethodName, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> Parameters) { }
+        public string MethodName { get; init; }
+        public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> Parameters { get; init; }
+        public CSharpAuthor.ITypeDefinition TypeDefinition { get; init; }
+        public virtual bool Equals(DependencyModules.SourceGenerator.Impl.Models.ServiceFactoryModel? other) { }
+        public override int GetHashCode() { }
+    }
+    public enum ServiceLifestyle
+    {
+        Transient = 0,
+        Scoped = 1,
+        Singleton = 2,
+    }
+    public class ServiceModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>
+    {
+        public static DependencyModules.SourceGenerator.Impl.Models.ServiceModel Ignore;
+        public ServiceModel(CSharpAuthor.ITypeDefinition ImplementationType, DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? Constructor, DependencyModules.SourceGenerator.Impl.Models.ServiceFactoryModel? Factory, DependencyModules.SourceGenerator.Impl.Models.FactoryOutputDelegate? FactoryOutput, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ServiceRegistrationModel> Registrations, DependencyModules.SourceGenerator.Impl.Models.RegistrationFeature Features) { }
+        public DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? Constructor { get; init; }
+        public DependencyModules.SourceGenerator.Impl.Models.ServiceFactoryModel? Factory { get; init; }
+        public DependencyModules.SourceGenerator.Impl.Models.FactoryOutputDelegate? FactoryOutput { get; init; }
+        public DependencyModules.SourceGenerator.Impl.Models.RegistrationFeature Features { get; init; }
+        public CSharpAuthor.ITypeDefinition ImplementationType { get; init; }
+        public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ServiceRegistrationModel> Registrations { get; init; }
+    }
+    public class ServiceModelComparer : System.Collections.Generic.IEqualityComparer<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>
+    {
+        public ServiceModelComparer() { }
+        public bool Equals(DependencyModules.SourceGenerator.Impl.Models.ServiceModel? x, DependencyModules.SourceGenerator.Impl.Models.ServiceModel? y) { }
+        public int GetHashCode(DependencyModules.SourceGenerator.Impl.Models.ServiceModel obj) { }
+    }
+    public class ServiceRegistrationModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.ServiceRegistrationModel>
+    {
+        public ServiceRegistrationModel(CSharpAuthor.ITypeDefinition ServiceType, DependencyModules.SourceGenerator.Impl.Models.ServiceLifestyle Lifestyle, DependencyModules.SourceGenerator.Impl.Models.RegistrationType? RegistrationType = default, CSharpAuthor.ITypeDefinition? Realm = null, object? Key = null, bool? CrossWire = false, System.Collections.Generic.IReadOnlyList<string>? Namespaces = null) { }
+        public bool? CrossWire { get; init; }
+        public object? Key { get; init; }
+        public DependencyModules.SourceGenerator.Impl.Models.ServiceLifestyle Lifestyle { get; init; }
+        public System.Collections.Generic.IReadOnlyList<string>? Namespaces { get; init; }
+        public CSharpAuthor.ITypeDefinition? Realm { get; init; }
+        public DependencyModules.SourceGenerator.Impl.Models.RegistrationType? RegistrationType { get; init; }
+        public CSharpAuthor.ITypeDefinition ServiceType { get; init; }
+    }
+}
+namespace DependencyModules.SourceGenerator.Impl.Utilities
+{
+    public static class AttributeModelHelper
+    {
+        public static DependencyModules.SourceGenerator.Impl.Models.AttributeModel? GetAttribute(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax attribute) { }
+        public static DependencyModules.SourceGenerator.Impl.Models.AttributeClassInfo GetAttributeClassInfo(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.AttributeModel> GetAttributeModels(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken, System.Func<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax, bool>? filter = null) { }
+        public static System.Collections.Generic.IEnumerable<DependencyModules.SourceGenerator.Impl.Models.AttributeModel> GetAttributes(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax> attributeListSyntax, System.Threading.CancellationToken cancellationToken, System.Func<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax, bool>? filter = null) { }
+    }
+    public abstract class BaseAttributeWriter<T>
+        where T : DependencyModules.SourceGenerator.Impl.Models.IClassModel
+    {
+        protected BaseAttributeWriter() { }
+        public void CreateAttributeClass(CSharpAuthor.IConstructContainer container, T model) { }
+        protected virtual void CreateConstructor(CSharpAuthor.IConstructContainer container, CSharpAuthor.ClassDefinition attributeClass, T model) { }
+        protected virtual void CreateProperties(CSharpAuthor.IConstructContainer container, CSharpAuthor.ClassDefinition attributeClass, T model) { }
+        protected virtual void CustomImplementation(CSharpAuthor.IConstructContainer container, CSharpAuthor.ClassDefinition attributeClass, T model) { }
+    }
+    public static class BaseMethodHelper
+    {
+        public static System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> GetMethodParameters(this Microsoft.CodeAnalysis.CSharp.Syntax.BaseMethodDeclarationSyntax methodDeclarationSyntax, Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> GetParameters(this Microsoft.CodeAnalysis.CSharp.Syntax.ParameterListSyntax? parameterList, Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+    }
+    public abstract class BaseSyntaxSelector
+    {
+        protected BaseSyntaxSelector(params CSharpAuthor.ITypeDefinition[] attributes) { }
+        public string ApproveFilter { get; set; }
+        public bool AutoApproveCompilationUnit { get; set; }
+        protected abstract bool TestForTypes(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken token);
+        public bool Where(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken token) { }
+    }
+    public class EntryModelUtil
+    {
+        public EntryModelUtil() { }
+        [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "uniqueEntryPoints",
+                "configurationModel"})]
+        public static System.ValueTuple<System.Collections.Generic.IList<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel>, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel> ConsolidateEntryPointModels([System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right"})] System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>> entryPointList) { }
+        public static DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel EnsureNamespace(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel) { }
+        public static string GenerateFileName(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, string uniquePortion) { }
+    }
+    public class FileLogger : System.IDisposable
+    {
+        public FileLogger(DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel, string loggerName) { }
+        public void Dispose() { }
+        public void Error(string message) { }
+        public void Error(string message, object data) { }
+        public void Info(string message) { }
+        public void Info(string message, object data) { }
+        public static void Wrap(string loggerName, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel, System.Action<DependencyModules.SourceGenerator.Impl.Utilities.FileLogger> logger) { }
+    }
+    public static class ITypeDefinitionExtensions
+    {
+        public static string GetFileNameHint(this CSharpAuthor.ITypeDefinition typeDefinition, string rootNamespace, string uniquePart) { }
+    }
+    public class ServiceModelUtility
+    {
+        public ServiceModelUtility() { }
+        public static DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? GetConstructorInfo(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) { }
+        public static DependencyModules.SourceGenerator.Impl.Models.ServiceModel? GetServiceModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+    }
+    public static class SyntaxNodeExtensions
+    {
+        public static Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax? GetAttribute(this Microsoft.CodeAnalysis.SyntaxNode node, string attributeName, string ns = "") { }
+        public static System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax> GetAttributes(this Microsoft.CodeAnalysis.SyntaxNode node, string attributeName, string ns = "") { }
+        public static string GetNamespace(this Microsoft.CodeAnalysis.CSharp.Syntax.BaseTypeDeclarationSyntax syntax) { }
+        public static CSharpAuthor.ITypeDefinition GetTypeDefinition(this Microsoft.CodeAnalysis.CSharp.Syntax.TypeDeclarationSyntax typeDeclarationSyntax) { }
+        public static bool IsAttributed(this Microsoft.CodeAnalysis.SyntaxNode node, CSharpAuthor.ITypeDefinition typeDefinition) { }
+        public static bool IsAttributed(this Microsoft.CodeAnalysis.SyntaxNode node, string attributeName, string ns = "") { }
+    }
+    public class SyntaxSelector<T> : DependencyModules.SourceGenerator.Impl.Utilities.BaseSyntaxSelector
+        where T : Microsoft.CodeAnalysis.SyntaxNode
+    {
+        public SyntaxSelector(params CSharpAuthor.ITypeDefinition[] attributes) { }
+        protected override bool TestForTypes(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken token) { }
+    }
+    public class SyntaxSelector<T1, T2> : DependencyModules.SourceGenerator.Impl.Utilities.BaseSyntaxSelector
+        where T1 : Microsoft.CodeAnalysis.SyntaxNode
+        where T2 : Microsoft.CodeAnalysis.SyntaxNode
+    {
+        public SyntaxSelector(params CSharpAuthor.ITypeDefinition[] attributes) { }
+        protected override bool TestForTypes(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken token) { }
+    }
+    public class SyntaxSelector<T1, T2, T3> : DependencyModules.SourceGenerator.Impl.Utilities.BaseSyntaxSelector
+        where T1 : Microsoft.CodeAnalysis.SyntaxNode
+        where T2 : Microsoft.CodeAnalysis.SyntaxNode
+        where T3 : Microsoft.CodeAnalysis.SyntaxNode
+    {
+        public SyntaxSelector(params CSharpAuthor.ITypeDefinition[] attributes) { }
+        protected override bool TestForTypes(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken token) { }
+    }
+    public class TypeParameterDefinition : CSharpAuthor.ITypeDefinition, System.IComparable<CSharpAuthor.ITypeDefinition>
+    {
+        public TypeParameterDefinition(CSharpAuthor.TypeDefinitionEnum typeDefinitionEnum, bool isNullable, bool isArray, string name) { }
+        public bool IsArray { get; }
+        public bool IsNullable { get; }
+        public System.Collections.Generic.IEnumerable<string> KnownNamespaces { get; }
+        public string Name { get; }
+        public string Namespace { get; }
+        public System.Collections.Generic.IReadOnlyList<CSharpAuthor.ITypeDefinition> TypeArguments { get; }
+        public CSharpAuthor.TypeDefinitionEnum TypeDefinitionEnum { get; }
+        public int CompareTo(CSharpAuthor.ITypeDefinition other) { }
+        public CSharpAuthor.ITypeDefinition MakeArray() { }
+        public CSharpAuthor.ITypeDefinition MakeNullable(bool nullable = true) { }
+        public void WriteTypeName(System.Text.StringBuilder builder, CSharpAuthor.TypeOutputMode typeOutputMode = 2) { }
+    }
+    public static class TypeSyntaxExtensions
+    {
+        public static string GetFullName(this Microsoft.CodeAnalysis.INamespaceSymbol? namespaceSymbol) { }
+        public static CSharpAuthor.ITypeDefinition GetTypeDefinition(this Microsoft.CodeAnalysis.ITypeSymbol typeSymbol) { }
+        public static CSharpAuthor.ITypeDefinition? GetTypeDefinition(this Microsoft.CodeAnalysis.CSharp.Syntax.MemberAccessExpressionSyntax syntax, Microsoft.CodeAnalysis.GeneratorSyntaxContext generatorSyntaxContext) { }
+        public static CSharpAuthor.ITypeDefinition? GetTypeDefinition(this Microsoft.CodeAnalysis.SyntaxNode typeSyntax, Microsoft.CodeAnalysis.GeneratorSyntaxContext generatorSyntaxContext) { }
+        public static CSharpAuthor.ITypeDefinition? GetTypeDefinitionFromNamedSymbol(this Microsoft.CodeAnalysis.INamedTypeSymbol? namedTypeSymbol) { }
+        public static CSharpAuthor.ITypeDefinition? GetTypeDefinitionFromSymbolInfo(Microsoft.CodeAnalysis.SymbolInfo symbolInfo) { }
+    }
+    public class UsageAttributeComponent : CSharpAuthor.BaseOutputComponent
+    {
+        public UsageAttributeComponent(string usage) { }
+        protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
+    }
+}
+namespace DependencyModules.SourceGenerator
+{
+    public class ServiceSourceGenerator : DependencyModules.SourceGenerator.Impl.BaseAttributeSourceGenerator<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>
+    {
+        public ServiceSourceGenerator() { }
+        protected override System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> AttributeTypes() { }
+        protected override DependencyModules.SourceGenerator.Impl.Models.ServiceModel GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        protected override void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right",
+                "Left",
+                "Right"})] System.ValueTuple<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>, System.Collections.Immutable.ImmutableArray<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>> inputData, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
+        protected void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext context, DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel, System.Collections.Immutable.ImmutableArray<DependencyModules.SourceGenerator.Impl.Models.ServiceModel> serviceModels, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
+        protected override System.Collections.Generic.IEqualityComparer<DependencyModules.SourceGenerator.Impl.Models.ServiceModel> GetComparer() { }
+    }
+    [Microsoft.CodeAnalysis.Generator]
+    public class SourceGenerator : DependencyModules.SourceGenerator.Impl.BaseSourceGenerator
+    {
+        public SourceGenerator() { }
+        protected override System.Collections.Generic.IEnumerable<DependencyModules.SourceGenerator.Impl.IDependencyModuleSourceGenerator> AttributeSourceGenerators() { }
+        protected override void SetupRootGenerator(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right"})] Microsoft.CodeAnalysis.IncrementalValueProvider<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>> valuesProvider) { }
+    }
+}

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.XUnitApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.XUnitApi.verified.txt
@@ -1,0 +1,108 @@
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.AppVeyorReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.DefaultRunnerReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.JsonReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.QuietReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.SilentReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.TeamCityReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.VerboseReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.VstsReporter))]
+namespace DependencyModules.xUnit.Attributes
+{
+    public class InjectValuesAttribute : System.Attribute, DependencyModules.xUnit.Attributes.Interfaces.IInjectValueAttribute
+    {
+        public InjectValuesAttribute(params object[] value) { }
+        public object[] ProvideValue(System.IServiceProvider serviceProvider, System.Reflection.ParameterInfo parameter) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Parameter, AllowMultiple=true)]
+    public class MockAttribute : System.Attribute, DependencyModules.xUnit.Attributes.Interfaces.ITestParameterValueProvider
+    {
+        public MockAttribute() { }
+        public System.Threading.Tasks.Task<object?> GetParameterValueAsync(Xunit.v3.IXunitTestMethod context, System.IServiceProvider serviceProvider, System.Reflection.ParameterInfo parameter) { }
+        public void SetupServiceCollection(Xunit.v3.IXunitTestMethod testCaseContext, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection, System.Reflection.ParameterInfo parameter) { }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Method)]
+    [Xunit.v3.XunitTestCaseDiscoverer(typeof(DependencyModules.xUnit.Impl.ModuleTestDiscoverer))]
+    public class ModuleTestAttribute : Xunit.FactAttribute
+    {
+        public ModuleTestAttribute(params System.Type[] modules) { }
+        public System.Type[] ModuleTypes { get; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true)]
+    public class TestExportAttribute : System.Attribute, DependencyModules.xUnit.Attributes.Interfaces.ITestStartupAttribute
+    {
+        public TestExportAttribute(System.Type service) { }
+        public System.Type? Implementation { get; set; }
+        public Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime { get; set; }
+        public System.Type Service { get; }
+        public void SetupServiceCollection(Xunit.v3.IXunitTestMethod testMethod, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
+        public System.Threading.Tasks.Task StartupAsync(Xunit.v3.IXunitTestMethod testMethod, System.IServiceProvider serviceProvider) { }
+    }
+}
+namespace DependencyModules.xUnit.Attributes.Interfaces
+{
+    public interface IInjectValueAttribute
+    {
+        object[] ProvideValue(System.IServiceProvider serviceProvider, System.Reflection.ParameterInfo parameter);
+    }
+    public interface IMockSupportAttribute
+    {
+        object ProvideMock(System.Type type);
+    }
+    public interface IOrderedAttribute
+    {
+        int Order { get; }
+    }
+    public interface IServiceProviderBuilderAttribute
+    {
+        System.IServiceProvider BuildServiceProvider(Xunit.v3.IXunitTestMethod testCaseContext, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection);
+    }
+    public interface ITestParameterValueProvider
+    {
+        System.Threading.Tasks.Task<object?> GetParameterValueAsync(Xunit.v3.IXunitTestMethod context, System.IServiceProvider serviceProvider, System.Reflection.ParameterInfo parameter);
+        void SetupServiceCollection(Xunit.v3.IXunitTestMethod testCaseContext, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection, System.Reflection.ParameterInfo parameter);
+    }
+    public interface ITestStartupAttribute
+    {
+        void SetupServiceCollection(Xunit.v3.IXunitTestMethod testMethod, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection);
+        System.Threading.Tasks.Task StartupAsync(Xunit.v3.IXunitTestMethod testMethod, System.IServiceProvider serviceProvider);
+    }
+}
+namespace DependencyModules.xUnit.Impl
+{
+    public static class AttributeUtility
+    {
+        public static T? GetTestAttribute<T>(this System.Reflection.MethodInfo methodInfo)
+            where T :  class { }
+        public static T? GetTestAttribute<T>(this System.Reflection.ParameterInfo parameterInfo)
+            where T :  class { }
+        public static System.Collections.Generic.IEnumerable<T> GetTestAttributes<T>(this System.Reflection.MethodInfo methodInfo)
+            where T :  class { }
+        public static System.Collections.Generic.IEnumerable<T> GetTestAttributes<T>(this System.Reflection.ParameterInfo parameterInfo)
+            where T :  class { }
+    }
+    public interface ITestCaseInfo
+    {
+        Xunit.v3.IXunitTestMethod TestMethod { get; }
+        System.Collections.Generic.IReadOnlyList<object?> TestMethodArguments { get; set; }
+        System.Collections.Generic.IReadOnlyList<System.Attribute> TestMethodAttributes { get; }
+    }
+    public class ModuleTestCase : Xunit.v3.XunitTestCase
+    {
+        public ModuleTestCase() { }
+        public ModuleTestCase(Xunit.v3.IXunitTestMethod testMethod, string testCaseDisplayName, string uniqueID, bool @explicit, string? skipReason = null, System.Type? skipType = null, string? skipUnless = null, string? skipWhen = null, System.Collections.Generic.Dictionary<string, System.Collections.Generic.HashSet<string>>? traits = null, object?[]? testMethodArguments = null, string? sourceFilePath = null, int? sourceLineNumber = default, int? timeout = default) { }
+        public override System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyCollection<Xunit.v3.IXunitTest>> CreateTests() { }
+        public override void PreInvoke() { }
+    }
+    public class ModuleTestDiscoverer : Xunit.v3.IXunitTestCaseDiscoverer
+    {
+        public ModuleTestDiscoverer() { }
+        public System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyCollection<Xunit.v3.IXunitTestCase>> Discover(Xunit.Sdk.ITestFrameworkDiscoveryOptions discoveryOptions, Xunit.v3.IXunitTestMethod testMethod, Xunit.v3.IFactAttribute factAttribute) { }
+    }
+    public class TestCaseInfo : DependencyModules.xUnit.Impl.ITestCaseInfo
+    {
+        public TestCaseInfo(Xunit.v3.IXunitTestMethod testMethod, System.Collections.Generic.IReadOnlyList<object> testMethodArguments, System.Collections.Generic.IReadOnlyList<System.Attribute> testMethodAttributes) { }
+        public Xunit.v3.IXunitTestMethod TestMethod { get; }
+        public System.Collections.Generic.IReadOnlyList<object?> TestMethodArguments { get; set; }
+        public System.Collections.Generic.IReadOnlyList<System.Attribute> TestMethodAttributes { get; }
+    }
+}

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.XUnitNSubstituteApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.XUnitNSubstituteApi.verified.txt
@@ -1,0 +1,17 @@
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.AppVeyorReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.DefaultRunnerReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.JsonReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.QuietReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.SilentReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.TeamCityReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.VerboseReporter))]
+[assembly: Xunit.Runner.Common.RegisterRunnerReporter(typeof(Xunit.Runner.Common.VstsReporter))]
+namespace DependencyModules.xUnit.NSubstitute
+{
+    [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method)]
+    public class NSubstituteSupportAttribute : System.Attribute, DependencyModules.xUnit.Attributes.Interfaces.IMockSupportAttribute
+    {
+        public NSubstituteSupportAttribute() { }
+        public object ProvideMock(System.Type type) { }
+    }
+}

--- a/tests/DependencyModules.Tests/xUnitTests/ModuleTestDiscovererTests.cs
+++ b/tests/DependencyModules.Tests/xUnitTests/ModuleTestDiscovererTests.cs
@@ -1,0 +1,151 @@
+using System.Reflection;
+using DependencyModules.xUnit.Attributes;
+using DependencyModules.xUnit.Impl;
+using Xunit;
+using Xunit.Sdk;
+using Xunit.v3;
+
+namespace DependencyModules.Tests.xUnitTests;
+
+/// <summary>
+/// Drives ModuleTestDiscoverer directly, from plain [Fact] tests.
+///
+/// This matters more than it looks. Every integration test runs *through* [ModuleTest], so a
+/// discoverer that drops test cases makes that suite quietly smaller rather than red — which is
+/// exactly how a unique ID collision shipped undetected. Testing the discoverer from outside the
+/// framework it provides is the only way those failures become visible.
+/// </summary>
+public class ModuleTestDiscovererTests {
+
+    /// <summary>
+    /// Regression test. Unique IDs used to be the bare method name, so two test classes each
+    /// declaring a same-named test produced colliding IDs and xUnit silently discarded one.
+    /// </summary>
+    [Fact]
+    public async Task SameMethodNameInDifferentClasses_ProducesDifferentUniqueIDs() {
+        var first = await DiscoverSingle(typeof(FirstSample), nameof(FirstSample.SharedName));
+        var second = await DiscoverSingle(typeof(SecondSample), nameof(SecondSample.SharedName));
+
+        Assert.NotEqual(first.UniqueID, second.UniqueID);
+    }
+
+    [Fact]
+    public async Task SameMethodNameInDifferentClasses_ProducesDifferentDisplayNames() {
+        var first = await DiscoverSingle(typeof(FirstSample), nameof(FirstSample.SharedName));
+        var second = await DiscoverSingle(typeof(SecondSample), nameof(SecondSample.SharedName));
+
+        Assert.NotEqual(first.TestCaseDisplayName, second.TestCaseDisplayName);
+    }
+
+    [Fact]
+    public async Task UniqueID_IsNotJustTheMethodName() {
+        var testCase = await DiscoverSingle(typeof(FirstSample), nameof(FirstSample.SharedName));
+
+        Assert.NotEqual(nameof(FirstSample.SharedName), testCase.UniqueID);
+    }
+
+    [Fact]
+    public async Task UniqueID_IsStableAcrossRepeatedDiscovery() {
+        var first = await DiscoverSingle(typeof(FirstSample), nameof(FirstSample.SharedName));
+        var second = await DiscoverSingle(typeof(FirstSample), nameof(FirstSample.SharedName));
+
+        Assert.Equal(first.UniqueID, second.UniqueID);
+    }
+
+    [Fact]
+    public async Task DifferentMethodsInOneClass_ProduceDifferentUniqueIDs() {
+        var first = await DiscoverSingle(typeof(FirstSample), nameof(FirstSample.SharedName));
+        var second = await DiscoverSingle(typeof(FirstSample), nameof(FirstSample.AnotherName));
+
+        Assert.NotEqual(first.UniqueID, second.UniqueID);
+    }
+
+    [Fact]
+    public async Task DisplayName_IsQualifiedByItsDeclaringClass() {
+        var testCase = await DiscoverSingle(typeof(FirstSample), nameof(FirstSample.SharedName));
+
+        Assert.Contains(nameof(FirstSample), testCase.TestCaseDisplayName);
+    }
+
+    [Fact]
+    public async Task Discovery_ProducesExactlyOneTestCasePerMethod() {
+        var cases = await Discover(typeof(FirstSample), nameof(FirstSample.SharedName));
+
+        Assert.Single(cases);
+    }
+
+    [Fact]
+    public async Task Discovery_ProducesAModuleTestCase() {
+        var testCase = await DiscoverSingle(typeof(FirstSample), nameof(FirstSample.SharedName));
+
+        Assert.IsType<ModuleTestCase>(testCase);
+    }
+
+    /// <summary>
+    /// The whole point of the unique ID is that xUnit uses it to deduplicate. Collecting IDs for
+    /// every sample method asserts the set is distinct, which is the property that was violated.
+    /// </summary>
+    [Fact]
+    public async Task EveryDiscoveredTestCase_HasADistinctUniqueID() {
+        var ids = new List<string>();
+
+        foreach (var (type, method) in new[] {
+                     (typeof(FirstSample), nameof(FirstSample.SharedName)),
+                     (typeof(FirstSample), nameof(FirstSample.AnotherName)),
+                     (typeof(SecondSample), nameof(SecondSample.SharedName)),
+                     (typeof(SecondSample), nameof(SecondSample.AnotherName))
+                 }) {
+            ids.Add((await DiscoverSingle(type, method)).UniqueID);
+        }
+
+        Assert.Equal(ids.Count, ids.Distinct().Count());
+    }
+
+    private static async Task<IXunitTestCase> DiscoverSingle(Type testClass, string methodName) =>
+        Assert.Single(await Discover(testClass, methodName));
+
+    private static async Task<IReadOnlyCollection<IXunitTestCase>> Discover(Type testClass, string methodName) {
+        var testMethod = BuildTestMethod(testClass, methodName);
+
+        // Supplied directly rather than read off the sample methods: annotating private nested
+        // classes with [ModuleTest] makes the xUnit analyzer treat them as test classes.
+        return await new ModuleTestDiscoverer().Discover(
+            new DiscoveryOptions(), testMethod, new ModuleTestAttribute());
+    }
+
+    /// <summary>
+    /// The discoverer only reads method display settings, and xUnit falls back to its defaults for
+    /// anything unset, so an empty option bag is enough to exercise it.
+    /// </summary>
+    private class DiscoveryOptions : ITestFrameworkDiscoveryOptions {
+        private readonly Dictionary<string, object?> _values = new(StringComparer.OrdinalIgnoreCase);
+
+        public TValue? GetValue<TValue>(string name) =>
+            _values.TryGetValue(name, out var value) && value is TValue typed ? typed : default;
+
+        public void SetValue<TValue>(string name, TValue value) => _values[name] = value;
+
+        public string ToJson() => "{}";
+    }
+
+    private static IXunitTestMethod BuildTestMethod(Type testClass, string methodName) {
+        var assembly = new XunitTestAssembly(testClass.Assembly);
+        var collection = new XunitTestCollection(assembly, null, false, "Test collection");
+        var xunitClass = new XunitTestClass(testClass, collection);
+        var method = testClass.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+
+        return new XunitTestMethod(xunitClass, method, []);
+    }
+
+    private class FirstSample {
+        public void SharedName() { }
+
+        public void AnotherName() { }
+    }
+
+    private class SecondSample {
+        public void SharedName() { }
+
+        public void AnotherName() { }
+    }
+}


### PR DESCRIPTION
Two commits, both prompted by asking what the test suite and the support experience actually guarantee. Each turned up real bugs.

## Bugs fixed

**`[CrossWireService(Lifetime = ...)]` registered everything as a singleton.** The lifetime arrives as the source text `"ServiceLifetime.Scoped"`; `Enum.TryParse` fails on the qualified name and the silent fallback returned `Singleton`. Independently hit by a downstream consumer. Verified across all three spellings (`ServiceLifetime.Scoped`, fully qualified, and the unset default).

**The generator's configuration was unreachable from a package.** The packaged `build/*.targets` declared 2 of the 8 properties the generator reads. `DependencyModules_LogOutputDirectory`, `_RegisterGenerator`, `_AutoGenerateModule`, and `_GenerateFactories` silently took their defaults for every package consumer — the diagnostic log could not be switched on at all. Unnoticed because the integration tests reference the generator as a *project*, which bypasses `build/*.targets`.

**Declaring those properties then exposed a second bug.** MSBuild delivers a visible property as an empty string when unset, and the code treated that as a value, flipping every boolean default to `false`. `AutoGenerateModule` turned off and the generated `ApplicationModule` disappeared. Blank is now treated as unspecified.

**A failing generator was completely invisible.** `FileLogger.Wrap` caught the exception and, with no log directory, discarded it — which also suppressed Roslyn's own CS8785. Verified by making the generator throw: the app **built and ran with an empty container, no error, no warning**. `Wrap` now rethrows unless given a reporter, and the generator reports DM0001.

## New diagnostics

| ID | Severity | Previously |
|---|---|---|
| DM0001 | Error | Generator crash was silent |
| DM0002 | Warning | Abstract/static service produced a registration that threw at `BuildServiceProvider` |
| DM0003 | Error | Non-partial module surfaced as CS0260 against the developer's own declaration |

## Tests: 334 → 391

**Public API approval tests** pin the surface of every shipping assembly. After 1.0.0 that is a compatibility promise, and nothing else would notice a removed member since the library and its tests compile together. It has already earned its place — it flagged this PR's own API additions for review.

**Behavioural verification** compiles with the real compiler, loads the emitted assembly, and asserts on resolved instances and lifetimes. Validated by mutation: making `Singleton` emit `AddScoped` fails these tests, while **all 62 integration tests passed unchanged** — resolving twice from one provider cannot distinguish a singleton from a scoped service. Hence new scope-crossing lifetime tests.

**`ModuleTestDiscoverer` tested directly** as plain `[Fact]` tests. Every integration test runs *through* `[ModuleTest]`, so a discoverer fault makes that suite quietly smaller rather than red. Validated by mutation: reverting the discoverer fails 5 of the 9.

**Fixed two tests that could never fail.** `CrossWireTests` asserted `Assert.Same(interface1, interface1)` — a value against itself — in two byte-identical methods. That is why the cross-wire bug survived.

## Also

- The generator log now records the effective configuration, every module and service discovered with lifetime/key/realm, and anything skipped with the reason. It previously contained one line.
- README gains a "Reporting a problem" section.
- Analyzer release tracking (`AnalyzerReleases.*.md`) for the new rules.

Clean build, 0 warnings. Coverage 87.5%, gated at 85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPG3s4DPZZ6E4qJ6q8kSs