### PR TITLE
Mark prerelease versions as prereleases on GitHub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,7 +104,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # A version carrying a prerelease label must not appear as a stable release.
+          case "${{ steps.version.outputs.version }}" in
+            *-*) prerelease="--prerelease" ;;
+            *)   prerelease="" ;;
+          esac
+
           gh release create "${GITHUB_REF_NAME}" \
             --title "${GITHUB_REF_NAME}" \
             --generate-notes \
+            ${prerelease} \
             ./artifacts/*.nupkg


### PR DESCRIPTION
`gh release create` does not infer prerelease status from the version, so tagging `v1.0.0-rc9200` published a GitHub release marked **stable**. A release candidate appearing as "Latest" is misleading to anyone browsing the releases page.

The release step now derives the flag from the resolved version:

```bash
case "${{ steps.version.outputs.version }}" in
  *-*) prerelease="--prerelease" ;;
  *)   prerelease="" ;;
esac
```

| Version | Result |
|---|---|
| `1.0.0-rc9200` | `--prerelease` |
| `2.1.0-beta.1` | `--prerelease` |
| `1.0.0` | stable |

The existing `v1.0.0-rc9200` release has already been corrected in place, so this only affects future tags.

Found by checking the published release rather than assuming the workflow was right — the first real run of a pipeline that had never published anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPG3s4DPZZ6E4qJ6q8kSs