### PR TITLE
Only allow a release to be dispatched from main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,14 @@ jobs:
       - name: Resolve version
         id: version
         run: |
+          # A manual dispatch runs against whatever ref was selected, and that selector remembers
+          # the last branch used. Without this, an unreviewed branch could be published to
+          # nuget.org, where a version can be unlisted but never removed.
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error::Releases may only be dispatched from main. This run is on '${GITHUB_REF_NAME}'."
+            exit 1
+          fi
+
           if [ -n "${{ github.event.inputs.version }}" ]; then
             VERSION="${{ github.event.inputs.version }}"
           else


### PR DESCRIPTION
`release.yaml` publishes to nuget.org and can be triggered two ways:

- a `v*` tag — inherently reviewed, since tags are cut from merged code
- `workflow_dispatch` — **runs against whatever ref is selected in the UI**, with no ref check

The dispatch path meant an unreviewed branch could be published to nuget.org, where a version can be unlisted but **never removed**. The branch selector on a manual dispatch also remembers the last branch used, so this is an easy misfire rather than a theoretical one.

The check sits inside the existing version-resolution step, so a blocked dispatch fails with an explanation rather than skipping silently:

```bash
if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${GITHUB_REF}" != "refs/heads/main" ]; then
  echo "::error::Releases may only be dispatched from main. This run is on '${GITHUB_REF_NAME}'."
  exit 1
fi
```

| Trigger | Ref | Result |
|---|---|---|
| `push` | `refs/tags/v1.0.0` | allowed |
| `push` | `refs/tags/v1.0.0-rc9201` | allowed |
| `workflow_dispatch` | `main` | allowed |
| `workflow_dispatch` | any other branch | **blocked** |

An explicit ref comparison is used rather than `github.ref_protected`, so the guard does not quietly weaken if branch protection is ever reconfigured.

Follow-up to the publish-path audit: the GitHub Packages job in `build-package.yaml` was already correctly guarded by `github.ref == 'refs/heads/main' && github.event_name == 'push'`, confirmed against every recent run. This was the one remaining unguarded path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPG3s4DPZZ6E4qJ6q8kSs