### PR TITLE
Decorators: [Decorator], [Decorate], open generics, and global ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ fixes packaging and generated-code defects and commits to the API surface going 
 - **A failing generator no longer fails silently.** Exceptions were caught and, with no log
   directory configured, discarded — which also stopped Roslyn reporting its own CS8785. The build
   succeeded, no registrations were produced, and nothing said so. The generator now reports DM0001.
+- **`IServiceCollectionConfiguration.ConfigureDecorators` is invoked.** It was declared on the public
+  interface and never called by anything, so a module that implemented it silently did nothing.
+  It now runs after every module has registered its services, which is what decoration requires.
 - **`[CrossWireService(Lifetime = ...)]` is honoured.** The lifetime arrived as the source text
   `"ServiceLifetime.Scoped"`, `Enum.TryParse` failed on the qualified name, and the silent fallback
   registered every cross-wired service as a singleton no matter what was asked for. The existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ fixes packaging and generated-code defects and commits to the API surface going 
 
 ### Added
 
+- **Decorators.** `[Decorator]` on a class wraps the registered implementation of the service it
+  implements and takes as a constructor parameter; `[Decorate(service, decorator)]` on a module does
+  the same for types declared elsewhere. `Order` controls nesting, with lower values sitting closer
+  to the implementation, and is compared across every module in an `AddModule(s)` call rather than
+  only within the declaring one. Open generic decorators are supported, so one decorator can wrap
+  every closed registration of a generic service. Two decorators of one service sharing an order is
+  reported as DM0007 rather than nesting arbitrarily.
+
 - `tests/DependencyModules.Tests`: unit tests for `DependencyRegistry<T>` (including its
   thread-safety guarantees), module graph loading, generator configuration, and snapshot tests
   over the generator's full output.

--- a/docs/design/convention-registration-and-decorators.md
+++ b/docs/design/convention-registration-and-decorators.md
@@ -540,6 +540,10 @@ Each step is independently shippable and makes the next cheaper.
 | Step | Effort | Notes |
 |---|---|---|
 | `AddDecorator` order parameter | done | Implemented; source-compatible |
+| Global decorator ordering | done | `InternalGetDecorators` collects across modules; sorted together |
+| `DecoratorHelper` descriptor rewrite | done | All three descriptor shapes, open generics, keyed, lifetime preserved |
+| `[Decorator]` / `[Decorate]` attributes | done | Runtime surface only; the generator does not read them yet |
+| Generator emission for decorators | **remaining** | Model, provider, `ModuleDecorators` emission, DM0007-DM0010 |
 | Wire `ConfigureDecorators` | done | Was a public no-op; now invoked after all services are registered |
 | Convention registration | days | Independent of decorators; can proceed in parallel |
 | Phase A, typed decorators | ~1 day | Closes the Scrutor gap. Emit the body through a template |

--- a/docs/design/convention-registration-and-decorators.md
+++ b/docs/design/convention-registration-and-decorators.md
@@ -37,9 +37,9 @@ ApplyServices(serviceCollection, modules);      // every module's registrations
 ApplyDecorators(serviceCollection, modules);    // then every module's decorators
 ```
 
-`IDependencyModule.InternalApplyDecorators` exists as a default no-op. What is missing is the
-generator half — nothing emits an override — and `IServiceCollectionConfiguration.ConfigureDecorators`
-is declared but never invoked by anything.
+`IDependencyModule.InternalApplyDecorators` exists as a default no-op. `ConfigureDecorators` is now
+invoked; what remains missing is the generator half, since nothing emits an `InternalApplyDecorators`
+override.
 
 **This ordering is the feature, not an accident.** Decorators observe everything registered by every
 module in the `AddModule(s)` call, so cross-module decoration works without the developer sequencing
@@ -540,7 +540,7 @@ Each step is independently shippable and makes the next cheaper.
 | Step | Effort | Notes |
 |---|---|---|
 | `AddDecorator` order parameter | done | Implemented; source-compatible |
-| Wire or remove `ConfigureDecorators` | ~2 lines | **Before 1.0.** It is a public no-op today, and this is the last chance to remove it without a breaking change |
+| Wire `ConfigureDecorators` | done | Was a public no-op; now invoked after all services are registered |
 | Convention registration | days | Independent of decorators; can proceed in parallel |
 | Phase A, typed decorators | ~1 day | Closes the Scrutor gap. Emit the body through a template |
 | Phase B, generated forwarding | 4–6× A | Only worth it if C is plausible; keep signature and body separate |

--- a/docs/design/convention-registration-and-decorators.md
+++ b/docs/design/convention-registration-and-decorators.md
@@ -1,0 +1,551 @@
+# Design: convention registration and decorators
+
+Status: proposal. One piece is implemented — `AddDecorator`'s `order` parameter, noted below —
+because it changes public API and was cheaper to settle before 1.0 than after. Everything else is
+design only.
+
+Two features that would close the functional gap with [Scrutor](https://github.com/khellang/Scrutor)
+without giving up what makes this library different: everything resolved at compile time, no
+reflection, no assembly scanning at run time, trimming and Native AOT safe.
+
+They are described together because they share machinery and because the ordering model has to be
+agreed once for both.
+
+- [Part 1: convention registration](#part-1-convention-registration)
+- [Part 2: decorators](#part-2-decorators)
+- [Part 3: interceptors](#part-3-interceptors)
+- [Sequencing](#sequencing)
+
+---
+
+## Background: what already exists
+
+Worth knowing before reading either part, because both build on it.
+
+**The registration pipeline.** `BaseSourceGenerator` builds a `ModuleEntryPointModel` per module and
+a `ServiceModel` per service. `ServiceSourceGenerator` combines them and hands them to
+`DependencyFileWriter`, which emits `ModuleDependencies(IServiceCollection)`. The runtime applies
+those through `DependencyRegistry<T>`.
+
+**The decorator plumbing is already half-built and unused.** `DependencyRegistry` has a public
+`AddDecorator(RegistryFunc)`, an `ApplyDecorators(IServiceCollection)`, and `LoadModules` already
+runs decorators as a distinct phase after all services are registered:
+
+```csharp
+ApplyFeatures(serviceCollection, modules);
+ApplyServices(serviceCollection, modules);      // every module's registrations
+ApplyDecorators(serviceCollection, modules);    // then every module's decorators
+```
+
+`IDependencyModule.InternalApplyDecorators` exists as a default no-op. What is missing is the
+generator half — nothing emits an override — and `IServiceCollectionConfiguration.ConfigureDecorators`
+is declared but never invoked by anything.
+
+**This ordering is the feature, not an accident.** Decorators observe everything registered by every
+module in the `AddModule(s)` call, so cross-module decoration works without the developer sequencing
+anything. Scrutor requires `Decorate` to be called after the relevant `Add`, by hand.
+
+**The contract to document:** a decorator sees the services registered by the modules in its
+`AddModule(s)` call. Anything the application registers afterwards is outside that scope. This is
+inherent to `IServiceCollection` — decoration rewrites descriptors, so it can only see descriptors
+that exist. Scrutor has the same constraint.
+
+---
+
+## Part 1: convention registration
+
+### Motivation
+
+Scrutor's headline feature is assembly scanning:
+
+```csharp
+services.Scan(scan => scan
+    .FromAssemblyOf<IRepository>()
+    .AddClasses(c => c.AssignableTo<IRepository>())
+    .AsImplementedInterfaces()
+    .WithScopedLifetime());
+```
+
+The attributes in this library already solve the same problem at compile time. The gap is narrower
+than it looks: developers who do not want to annotate every class individually.
+
+**Do not port Scrutor's API.** A fluent scanning DSL means runtime reflection over assemblies, which
+is exactly what this library exists to remove, and would give the package two registration
+mechanisms with different trimming characteristics. The compile-time equivalent is a pattern
+evaluated by the generator.
+
+Note also that `IServiceCollectionConfiguration.ConfigureServices` already provides unrestricted
+fluent access to `IServiceCollection` for anything a convention cannot express.
+
+### Proposed API
+
+```csharp
+[DependencyModule]
+[RegisterByConvention("*Repository", Lifetime = ServiceLifetime.Scoped)]
+[RegisterByConvention("*Service", Lifetime = ServiceLifetime.Singleton, As = RegisterAs.ImplementedInterfaces)]
+public partial class DataModule;
+```
+
+| Property | Meaning | Default |
+|---|---|---|
+| pattern (ctor arg) | glob over the type's **name**, or its fully qualified name when the pattern contains `.` | required |
+| `Lifetime` | lifetime for matches | `Transient` |
+| `As` | `ImplementedInterfaces`, `Self`, or `SelfAndInterfaces` | `ImplementedInterfaces` |
+| `Using` | `RegistrationType` (`Add`, `Try`, `TryEnumerable`, `Replace`) | `Add` |
+| `Realm` | scope the convention to a realm | none |
+
+### Selector priority
+
+Name globbing is the weakest of the available selectors and is listed last deliberately. The one
+that carries most real usage is assignability:
+
+```csharp
+[RegisterByConvention(AssignableTo = typeof(IRequestHandler<,>), Lifetime = ServiceLifetime.Scoped)]
+```
+
+Ordered by value:
+
+1. **`AssignableTo`**, including open generic interfaces. Handlers, validators, policies, strategies.
+   Cheaper here than in Scrutor, because assignability is a symbol question at compile time rather
+   than a reflection question at run time.
+2. **`WithAttribute`** for marker attributes.
+3. **Namespace**.
+4. **Name glob**, last. It is the selector most likely to match something unintended when a class is
+   added years later.
+
+**Open generic closing is the make-or-break behaviour.** `CreateOrderHandler : IRequestHandler<CreateOrder, OrderId>`
+must register the *closed* interface against the implementation. Emission for this is already proven:
+a class closing an open generic registers and resolves correctly today, and only for its own type
+argument. What is new is the selector, not the code generation.
+
+### Explicitly out of scope: scanning referenced assemblies
+
+Scrutor's `FromApplicationDependencies()` registers types from packages you do not own. That is
+**not** planned, for two reasons:
+
+- It contradicts the compile-time goal. It is the one Scrutor capability that has no honest
+  compile-time equivalent.
+- The module system already covers the case that actually matters. Cross-assembly scanning is largely
+  a workaround for having no way to compose registrations across projects; here each project declares
+  its own module and composes through module attributes.
+
+If demand appears, a separate runtime-scanning package could provide it without compromising the
+core. It should not live in this library.
+
+### Glob semantics
+
+Deliberately small. Two wildcards, no regex:
+
+| Token | Matches |
+|---|---|
+| `*` | zero or more characters |
+| `?` | exactly one character |
+
+A pattern containing `.` matches against `Namespace.TypeName`; otherwise against the bare type name.
+Matching is ordinal and case-sensitive, consistent with C# identifiers.
+
+Implement by translating the glob to a `Regex` **once per pattern** at model construction, not per
+candidate class. Anchor both ends.
+
+### Where it goes in the pipeline
+
+The convention lives on the module, but the classes it matches are separate syntax nodes, and an
+incremental generator's predicate cannot see other providers. So candidate classes must flow through
+their own provider and be filtered after the combine.
+
+1. **New provider** for candidate types: predicate accepts any `ClassDeclarationSyntax` /
+   `RecordDeclarationSyntax` that is `public` or `internal`, not `static`, not `abstract`, and
+   carries **no** existing service attribute (an explicit attribute always wins).
+2. **Transform** extracts a *syntax-only* `ConventionCandidateModel`: type name, namespace,
+   base-list entries as written, modifiers, file path. It must not touch the semantic model.
+3. **Combine** candidates with the module's conventions, then filter by glob.
+4. **Resolve semantically only for survivors**, producing the same `ServiceModel` /
+   `ServiceRegistrationModel` the attribute path produces.
+
+From step 4 onward this is the existing pipeline. Convention registration should produce models
+indistinguishable from attribute registration, so `DependencyFileWriter` needs no changes.
+
+### Performance
+
+Measured on this generator, in-process, excluding MSBuild overhead:
+
+| Classes | Matching | Generator time |
+|---|---|---|
+| 500 | 0 | 53 ms |
+| 500 | 500 | 167 ms |
+| 2000 | 0 | 182 ms |
+| 2000 | 2000 | 605 ms |
+
+Consistently **~0.2 ms per class that reaches the transform**.
+
+Three conclusions:
+
+- **"Listening to all classes" is already what happens.** `CreateSyntaxProvider`'s predicate runs on
+  every syntax node today. Conventions do not add a new category of work; they move classes from
+  "rejected by the predicate" (near free) into "runs the transform" (~0.2 ms).
+- **A convention matching everything in a 2000-class project costs roughly 0.4 s on a cold build.**
+  Acceptable for a build. Not acceptable per keystroke, which is what incremental caching exists to
+  prevent: after the first run only the edited node re-runs. This is why the model comparers matter
+  and must stay correct.
+- **Keep step 2 syntax-only.** Non-matching classes must never reach the semantic model. Return the
+  existing `ServiceModel.Ignore` sentinel for non-matches, as the attribute path already does.
+
+**Unrelated optimisation available.** Every provider here uses `CreateSyntaxProvider`. Roslyn 4.3+
+offers `ForAttributeWithMetadataName`, which pre-indexes attribute usage and is substantially faster
+for attribute-driven providers. Switching the existing attribute paths would reduce that 0.2 ms and
+cleanly separate the two cost profiles: attributes become an indexed lookup, conventions remain a
+full visit. Worth doing independently of this proposal.
+
+### Conflicts and precedence
+
+1. An explicit service attribute always wins; a class carrying one is never a convention candidate.
+2. If several conventions in one module match a class, it is an error (DM0004) rather than a silent
+   pick. Ambiguity here produces registrations nobody can predict from reading the source.
+3. Conventions in *different* modules may both match; each module registers into its own realm, which
+   is existing behaviour.
+4. A convention matching zero types is a warning (DM0005). A typo in a pattern otherwise fails
+   silently, which is the failure mode this codebase has repeatedly had to hunt down.
+
+### Diagnostics
+
+| ID | Severity | Condition |
+|---|---|---|
+| DM0004 | Error | Two conventions in one module match the same type |
+| DM0005 | Warning | A convention matched no types |
+| DM0006 | Warning | A convention matched a type that cannot be constructed, e.g. no accessible constructor |
+
+Add to `DependencyModuleDiagnostics`, and record them in `AnalyzerReleases.Unshipped.md` or the
+build fails RS2008.
+
+### Test plan
+
+Behavioural, using `GeneratedAssembly` — compile, load, resolve. Do not assert on generated text.
+
+- each glob token, including no-wildcard exact match
+- name-only versus fully-qualified patterns
+- `As` options: interfaces, self, both
+- lifetime and `Using` propagation
+- explicit attribute beats convention
+- abstract, static, and non-public types excluded
+- DM0004/DM0005/DM0006 fire; a valid convention reports nothing
+- incremental: editing an unrelated method body reuses cached output
+  (`GeneratorTestHarness.RunIncremental`)
+
+---
+
+## Part 2: decorators
+
+### Phase A: typed decorators
+
+The smallest thing that closes the Scrutor gap. Estimated one day.
+
+```csharp
+public interface IRepository { Item Get(int id); }
+
+[SingletonService]
+public class Repository : IRepository { ... }
+
+[Decorator(Order = 1)]
+public class CachingRepository(IRepository inner, IMemoryCache cache) : IRepository {
+    public Item Get(int id) => cache.GetOrCreate(id, _ => inner.Get(id))!;
+}
+```
+
+Plus a module-level form for services you do not own:
+
+```csharp
+[DependencyModule]
+[Decorate(typeof(IRepository), typeof(CachingRepository), Order = 1)]
+public partial class DataModule;
+```
+
+**Not** an attribute on the interface. That inverts the dependency — the abstraction would name a
+concrete implementation detail and could no longer be declared without referencing its decorators —
+and it does not work for interfaces you do not own.
+
+#### Implementation
+
+1. New `DecoratorModel` (service type, decorator type, order, realm), produced by a provider keyed on
+   `[Decorator]` and by reading `[Decorate]` from the module.
+2. `DependencyFileWriter` gains a second emitted method, `ModuleDecorators(IServiceCollection)`,
+   registered through the **existing** `DependencyRegistry<T>.AddDecorator`.
+3. `DependencyModuleWriter` emits the `InternalApplyDecorators` override that nothing currently
+   generates, calling `DependencyRegistry<T>.ApplyDecorators(services)`.
+4. `DependencyRegistry.ApplyDecorators(collection, modules)` additionally invokes
+   `IServiceCollectionConfiguration.ConfigureDecorators`, mirroring how `ApplyServices` invokes
+   `ConfigureServices`.
+
+Step 4 is two lines and fixes a public API that is currently a no-op, independently of the rest.
+
+#### Emitted shape
+
+Descriptor rewrite, the same approach Scrutor takes:
+
+```csharp
+private static void ModuleDecorators(IServiceCollection services) {
+    for (var i = services.Count - 1; i >= 0; i--) {
+        var descriptor = services[i];
+        if (descriptor.ServiceType != typeof(global::App.IRepository)) continue;
+
+        var inner = descriptor;   // capture before replacing
+        services[i] = new ServiceDescriptor(
+            typeof(global::App.IRepository),
+            provider => new global::App.CachingRepository(
+                (global::App.IRepository)Instantiate(provider, inner),
+                provider.GetRequiredService<global::Microsoft.Extensions.Caching.Memory.IMemoryCache>()),
+            descriptor.Lifetime);
+    }
+}
+```
+
+Points that matter:
+
+- **Every** matching descriptor is decorated, not just the first, so multiple implementations behind
+  one interface all get wrapped.
+- The decorated descriptor keeps the **original lifetime**. A decorator must not silently change it.
+- Iterate backwards; the list is mutated in place.
+- Capture the original descriptor before replacing it, or the factory closes over its own replacement
+  and recurses infinitely at resolve time. This is the single most likely bug in the whole feature
+  and deserves a dedicated test.
+- `Instantiate` handles the three descriptor shapes: implementation type, factory, and instance.
+
+#### Ordering
+
+**Implemented.** `DependencyRegistry.AddDecorator` takes an optional trailing `order`:
+
+```csharp
+public static int AddDecorator(RegistryFunc registryFunc, int order = 0)
+```
+
+Lower values are applied first and sit closer to the implementation; higher values wrap them.
+`ApplyDecorators` sorts with a stable sort, so decorators sharing an order keep registration order
+rather than nesting arbitrarily.
+
+Design notes:
+
+- **Optional and trailing, not required and leading.** `AddDecorator` is called by generated code, not
+  by developers, so a required parameter would improve no one's ergonomics. It also keeps the change
+  source-compatible, and matches `IDependencyModuleFeature<T>.Order`, which already defaults to 0 and
+  is already sorted by `ApplyFeatures`.
+- **Convention for composition across packages:** framework packages use `0-999`, application code
+  uses `1000` and above, so an application's decorators wrap those contributed by its libraries.
+- **Rejected: carrying the service type on `AddDecorator`.** It would allow runtime detection of
+  colliding orders across packages, which cannot be caught at compile time because a package's
+  decorators are already compiled when the application builds. Judged not worth the API complexity;
+  the documented range convention solves the practical problem. Recorded here because adding it later
+  is a breaking change.
+
+With attributes there is **no natural order**. Source order is not meaningful, and partial classes
+across files make it worse. `Logging(Caching(Repo))` and `Caching(Logging(Repo))` behave differently
+on a cache hit, so this cannot be left implicit.
+
+- `Order` is applied ascending; lower wraps closer to the implementation.
+- Forcing an explicit order is **not** wanted. Scrutor, MediatR pipeline behaviours and ASP.NET
+  middleware all use declaration order; attributes cannot, since order across files is not
+  guaranteed. So the rule is: default to 0, and report **DM0007** when two decorators target the same
+  service with *equal* order, which is precisely when the result would be unpredictable.
+- `Order = 1` and `Order = 2` therefore need no ceremony, and a single decorator needs no `Order`.
+
+#### Keyed services and generics
+
+- Decorating `IRepository` does **not** decorate `[SingletonService(Key = "x")] IRepository` by
+  default. Add `Key` to the attribute to target one, `Key = "*"` for all.
+- Open generic decorators (`CachingRepository<T> : IRepository<T>`) are legal C# and should be
+  supported; match the open generic descriptor by `ServiceType.GetGenericTypeDefinition()`.
+
+#### Diagnostics
+
+| ID | Severity | Condition |
+|---|---|---|
+| DM0007 | Error | Multiple decorators target one service and `Order` is ambiguous |
+| DM0008 | Error | Decorator does not implement the service type it decorates |
+| DM0009 | Warning | Decorator targets a service no module registers |
+| DM0010 | Error | Decorator has no constructor parameter of the decorated type |
+
+### Phase B: generated forwarding
+
+Removes the boilerplate of writing a decorator that overrides one member and forwards the rest.
+
+```csharp
+[Decorator]
+public partial class CachingRepository(IRepository inner, IMemoryCache cache) : IRepository {
+    public Item Get(int id) => cache.GetOrCreate(id, _ => inner.Get(id))!;
+    // every other IRepository member is generated, forwarding to inner
+}
+```
+
+Estimated four to six times phase A. The algorithm is roughly 150 lines; the work is the member
+matrix.
+
+#### The two APIs that make it tractable
+
+**`ITypeSymbol.FindImplementationForInterfaceMember`** answers "did the developer write this?" At
+generation time the partial is incomplete, so it returns null exactly for the members that need
+forwarding. No name matching, no heuristics.
+
+**`SymbolDisplayFormat` renders the signature.** Never hand-roll this. Configure one format with
+`IncludeParameters | IncludeRef | IncludeDefaultValue | IncludeTypeConstraints |
+IncludeNullableReferenceTypeModifier` and Roslyn renders generics, constraints, `ref`/`out`/`in`,
+default values, `params`, tuple element names and nullability — it is the authority on its own
+syntax. The body is then mechanical.
+
+#### Caching constraint
+
+Symbols are not equatable and must never be stored in a model. **Render signatures to strings during
+the syntax transform** and store those. This satisfies fidelity and incremental caching in one move.
+
+#### Architectural requirement
+
+**Separate signature rendering from body emission.** Phase C reuses the signature half with a
+different body. If phase B hardcodes `=> inner.Foo(...)` throughout, phase C is a rewrite rather than
+an addition. This costs nothing to honour now and is the main reason to read parts 2 and 3 together.
+
+#### Member matrix
+
+| Shape | Handling |
+|---|---|
+| Methods, properties, generics, constraints | `SymbolDisplayFormat` |
+| `ref` / `out` / `in`, `params`, default values | same format; repeat the ref kind at the call site |
+| Nullable annotations | format flag |
+| Events, indexers | separate emission shapes |
+| Members inherited from base interfaces | walk `AllInterfaces`, not just `GetMembers()` |
+| Two interfaces with colliding members | emit explicit implementations |
+| `static abstract` members | **refuse, DM0011** |
+| `ref` returns | **refuse, DM0011** |
+
+The last two rows are the safety valve. For any shape not supported, emit a clear diagnostic and
+generate nothing. The failure mode must be "DependencyModules does not support X" and never a `CS`
+error inside generated code.
+
+#### Test plan
+
+`GeneratedAssembly` is the right tool: declare an interface with an awkward shape, implement one
+member, assert the others actually reach `inner`. Each case executes rather than matching text. Cover
+every row above, and confirm DM0011 fires for the refused shapes.
+
+---
+
+## Part 3: interceptors
+
+### The constraint that forces the design
+
+This is illegal C#:
+
+```csharp
+public class LoggingDecorator<T> : T   // a type parameter cannot be a base type
+```
+
+A hand-written decorator can therefore only target a specific interface, or a generic one. One class
+can never wrap `IFoo`, `IBar` and `IBaz`. **A generic interceptor must be generated per service** —
+there is no other route.
+
+Which is why this belongs with phase B: it is the same forwarding machinery with a different body
+template.
+
+| Feature | Generated body |
+|---|---|
+| Phase B decorator | `=> inner.Foo(a, b);` |
+| Interceptor | `=> pipeline.Run(() => inner.Foo(a, b));` |
+
+Castle DynamicProxy emits IL at run time and does not work under Native AOT. A compile-time
+interceptor does. That is a stronger differentiator than Scrutor parity.
+
+### Two tiers
+
+**Tier 1, lifecycle hooks.** No boxing, no argument array.
+
+```csharp
+public interface IInterceptor<TService> {
+    void OnEnter(string member);
+    void OnExit(string member);
+    void OnError(string member, Exception exception);
+}
+```
+
+The wrapper calls `OnEnter`, invokes `inner.Foo(a, b)` directly, then `OnExit`. Covers logging,
+metrics, tracing and timing — realistically most interceptor use. It is cheap *because* it is
+compile-time; a runtime proxy cannot do this without reifying the call, because it does not know the
+signature.
+
+**Tier 2, full invocation.** Opt-in, for caching, retry and authorisation.
+
+```csharp
+public interface IInvocationInterceptor {
+    ValueTask<object?> InterceptAsync(IInvocation invocation);   // arguments, ProceedAsync, short-circuit
+}
+```
+
+Costs boxing of value-type arguments and returns, plus an array per call. Making it explicitly
+opt-in keeps the fast path fast and keeps faith with the library's performance claims.
+
+### Async
+
+The hardest part, and where a generator has a structural advantage. `Task`, `Task<T>`, `ValueTask`,
+`ValueTask<T>`, `IAsyncEnumerable<T>` and synchronous methods each need a different wrapper shape.
+Castle handles this so poorly that `AsyncInterceptorBase` exists as a community workaround. A
+generator knows the return type at compile time and emits the correct shape per method with no
+runtime type inspection.
+
+### Restrictions
+
+- **Interfaces only.** Class interception needs virtual members and inheritance; silently doing
+  nothing on a non-virtual method is a classic AOP trap. Diagnose instead.
+- **`ref` / `out` parameters** cannot round-trip through `object[]`; refuse in tier 2. Tier 1 handles
+  them, since it does not reify.
+- Decorators and interceptors both produce wrappers around the same service and therefore **share one
+  ordering model**.
+
+---
+
+## Designed for a future mediator package
+
+The decorator work is the foundation for a possible `DependencyModules.Mediator`, which raises its
+priority: a pipeline behaviour *is* a decorator, so building the mediator first would mean
+implementing the pipeline mechanism twice.
+
+**The cross-package guarantee already holds**, and is intentional rather than incidental:
+
+```
+ApplyServices(all modules)     // the application registers its handlers
+ApplyDecorators(all modules)   // then every module's decorators run
+```
+
+Because decorators run in a separate phase *after* all services, a decorator declared in a referenced
+package wraps handlers registered by the consuming application, regardless of module order.
+Registrations cross assembly boundaries at run time through `DependencyRegistry<TModule>`, so a
+package genuinely can contribute decorations to an application's services. This is exactly the
+semantics `IPipelineBehavior` needs.
+
+What a mediator would require from this design, all of which it now has:
+
+| Requirement | Status |
+|---|---|
+| Open generic decoration of `IRequestHandler<,>` | Phase A, primary scenario |
+| A package decorating the consuming application's services | Already works, verified |
+| Ordering that composes across packages | `order` parameter plus the range convention |
+| Short-circuiting, for validation failures | Falls out: do not call `inner` |
+| Decorator receiving its own dependencies | Falls out: normal constructor injection |
+
+The differentiator for such a package would not be feature parity with MediatR, which went commercial
+in July 2025. It would be **compile-time verification** — a missing handler reported as a build error
+rather than a production exception — and direct dispatch with no reflection. That is the same shape
+as the community's move from AutoMapper to source-generator alternatives.
+
+It should ship as a **separate package** depending on the core, never fused into it.
+
+## Sequencing
+
+Each step is independently shippable and makes the next cheaper.
+
+| Step | Effort | Notes |
+|---|---|---|
+| `AddDecorator` order parameter | done | Implemented; source-compatible |
+| Wire or remove `ConfigureDecorators` | ~2 lines | **Before 1.0.** It is a public no-op today, and this is the last chance to remove it without a breaking change |
+| Convention registration | days | Independent of decorators; can proceed in parallel |
+| Phase A, typed decorators | ~1 day | Closes the Scrutor gap. Emit the body through a template |
+| Phase B, generated forwarding | 4–6× A | Only worth it if C is plausible; keep signature and body separate |
+| Tier 1 interceptors | moderate | Reuses B's signature rendering |
+| Tier 2 interceptors | moderate | Only if demand appears |
+
+Nothing beyond the first row is 1.0 work. The one decision that is live now is the architectural
+constraint in phase B: keep signature rendering separate from body emission.

--- a/docs/design/convention-registration-and-decorators.md
+++ b/docs/design/convention-registration-and-decorators.md
@@ -1,8 +1,8 @@
 # Design: convention registration and decorators
 
-Status: proposal. One piece is implemented — `AddDecorator`'s `order` parameter, noted below —
-because it changes public API and was cheaper to settle before 1.0 than after. Everything else is
-design only.
+Status: part 2 phase A is implemented — typed decorators, module-level `[Decorate]`, open generic
+decorators, and global ordering. Convention registration (part 1), generated forwarding (phase B),
+and interceptors (part 3) remain design only.
 
 Two features that would close the functional gap with [Scrutor](https://github.com/khellang/Scrutor)
 without giving up what makes this library different: everything resolved at compile time, no
@@ -543,7 +543,9 @@ Each step is independently shippable and makes the next cheaper.
 | Global decorator ordering | done | `InternalGetDecorators` collects across modules; sorted together |
 | `DecoratorHelper` descriptor rewrite | done | All three descriptor shapes, open generics, keyed, lifetime preserved |
 | `[Decorator]` / `[Decorate]` attributes | done | Runtime surface only; the generator does not read them yet |
-| Generator emission for decorators | **remaining** | Model, provider, `ModuleDecorators` emission, DM0007-DM0010 |
+| Generator emission for decorators | done | `[Decorator]` and `[Decorate]` are read and emitted; DM0007 for ambiguous order |
+| Phase B: generated forwarding | remaining | Opt-in via `partial`; additive |
+| Interceptors | remaining | Reuses the same descriptor rewrite |
 | Wire `ConfigureDecorators` | done | Was a public no-op; now invoked after all services are registered |
 | Convention registration | days | Independent of decorators; can proceed in parallel |
 | Phase A, typed decorators | ~1 day | Closes the Scrutor gap. Emit the body through a template |

--- a/src/DependencyModules.Runtime/Attributes/DecorateAttribute.cs
+++ b/src/DependencyModules.Runtime/Attributes/DecorateAttribute.cs
@@ -1,0 +1,34 @@
+namespace DependencyModules.Runtime.Attributes;
+
+/// <summary>
+/// Declares a decorator on a module rather than on the decorator class itself.
+/// </summary>
+/// <remarks>
+/// Use this when the decorated service, the decorator, or both come from an assembly you do not
+/// control, so there is nowhere to put a <see cref="DecoratorAttribute"/>.
+///
+/// <code>
+/// [DependencyModule]
+/// [Decorate(typeof(IRepository), typeof(CachingRepository), Order = 100)]
+/// public partial class DataModule;
+/// </code>
+/// </remarks>
+/// <param name="service">The service being decorated. May be an open generic.</param>
+/// <param name="decorator">The decorator, which must implement <paramref name="service"/>.</param>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public class DecorateAttribute(Type service, Type decorator) : Attribute {
+    /// <summary>
+    /// The service being decorated.
+    /// </summary>
+    public Type Service { get; } = service;
+
+    /// <summary>
+    /// The decorator wrapping it.
+    /// </summary>
+    public Type Decorator { get; } = decorator;
+
+    /// <summary>
+    /// Controls how decorators nest. See <see cref="DecoratorAttribute.Order"/>.
+    /// </summary>
+    public int Order { get; set; }
+}

--- a/src/DependencyModules.Runtime/Attributes/DecoratorAttribute.cs
+++ b/src/DependencyModules.Runtime/Attributes/DecoratorAttribute.cs
@@ -1,0 +1,43 @@
+namespace DependencyModules.Runtime.Attributes;
+
+/// <summary>
+/// Marks a class as a decorator. The generator rewrites the registrations of the decorated service
+/// so that resolving it returns this class wrapping the original implementation.
+/// </summary>
+/// <remarks>
+/// The decorated service is inferred from the constructor: the parameter whose type the decorator
+/// also implements is the one being wrapped. Set <see cref="Service"/> when a decorator implements
+/// more than one candidate interface.
+///
+/// <code>
+/// [Decorator(Order = 100)]
+/// public class CachingRepository(IRepository inner, IMemoryCache cache) : IRepository {
+///     public Item Get(int id) => cache.GetOrCreate(id, _ => inner.Get(id))!;
+/// }
+/// </code>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public class DecoratorAttribute : Attribute {
+    /// <summary>
+    /// Controls how decorators nest. Lower values are applied first and therefore sit closer to the
+    /// implementation; higher values wrap them.
+    /// </summary>
+    /// <remarks>
+    /// Compared across every module in an <c>AddModule(s)</c> call, not only within the declaring
+    /// module. By convention framework packages use 0-999 and application code uses 1000 and above,
+    /// so an application's decorators wrap those contributed by the libraries it consumes.
+    /// </remarks>
+    public int Order { get; set; }
+
+    /// <summary>
+    /// The service being decorated. Only needed when it cannot be inferred, which happens when the
+    /// decorator implements more than one interface it also accepts as a constructor parameter.
+    /// </summary>
+    public Type? Service { get; set; }
+
+    /// <summary>
+    /// Restricts the decorator to a single module, matching the Realm property on the service
+    /// registration attributes.
+    /// </summary>
+    public Type? Realm { get; set; }
+}

--- a/src/DependencyModules.Runtime/Helpers/DecoratorHelper.cs
+++ b/src/DependencyModules.Runtime/Helpers/DecoratorHelper.cs
@@ -1,0 +1,110 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DependencyModules.Runtime.Helpers;
+
+/// <summary>
+/// Rewrites registrations so that a decorator wraps the implementation already registered for a
+/// service type.
+/// </summary>
+/// <remarks>
+/// Generated code calls into this rather than emitting the rewrite inline, because the same three
+/// mistakes are easy to make each time it is written out: capturing the descriptor after replacing
+/// it, decorating only the first match, and losing the original lifetime.
+/// </remarks>
+public static class DecoratorHelper {
+
+    /// <summary>
+    /// Wraps every registration of <paramref name="serviceType"/> using <paramref name="decoratorFactory"/>.
+    /// </summary>
+    /// <param name="services">The collection to rewrite.</param>
+    /// <param name="serviceType">
+    /// The service being decorated. For an open generic such as <c>IRepository&lt;&gt;</c>, every
+    /// closed registration of it is wrapped.
+    /// </param>
+    /// <param name="decoratorFactory">
+    /// Builds the decorator given the provider and the instance being wrapped.
+    /// </param>
+    public static void Decorate(
+        IServiceCollection services,
+        Type serviceType,
+        Func<IServiceProvider, object, object> decoratorFactory) {
+
+        for (var i = services.Count - 1; i >= 0; i--) {
+            var descriptor = services[i];
+
+            if (!Matches(descriptor.ServiceType, serviceType)) {
+                continue;
+            }
+
+            // Captured before the slot is overwritten. Reading services[i] inside the factory would
+            // close over the replacement and recurse until the stack runs out, at a point far from
+            // the registration that caused it.
+            var inner = descriptor;
+
+            services[i] = descriptor.IsKeyedService
+                ? new ServiceDescriptor(
+                    descriptor.ServiceType,
+                    descriptor.ServiceKey,
+                    (provider, key) => decoratorFactory(provider, CreateKeyedInner(provider, key, inner)),
+                    descriptor.Lifetime)
+                : new ServiceDescriptor(
+                    descriptor.ServiceType,
+                    provider => decoratorFactory(provider, CreateInner(provider, inner)),
+                    // The decorator must not change how long the service lives.
+                    descriptor.Lifetime);
+        }
+    }
+
+    /// <summary>
+    /// True when a registered service type is the one being decorated, including a closed
+    /// construction of a decorated open generic.
+    /// </summary>
+    private static bool Matches(Type registeredServiceType, Type decoratedServiceType) {
+        if (registeredServiceType == decoratedServiceType) {
+            return true;
+        }
+
+        return decoratedServiceType.IsGenericTypeDefinition &&
+               registeredServiceType.IsGenericType &&
+               registeredServiceType.GetGenericTypeDefinition() == decoratedServiceType;
+    }
+
+    /// <summary>
+    /// Produces the instance being decorated, covering all three shapes a descriptor can take.
+    /// </summary>
+    private static object CreateInner(IServiceProvider provider, ServiceDescriptor descriptor) {
+        if (descriptor.ImplementationInstance != null) {
+            return descriptor.ImplementationInstance;
+        }
+
+        if (descriptor.ImplementationFactory != null) {
+            return descriptor.ImplementationFactory(provider);
+        }
+
+        if (descriptor.ImplementationType != null) {
+            return ActivatorUtilities.CreateInstance(provider, descriptor.ImplementationType);
+        }
+
+        throw new InvalidOperationException(
+            $"The registration for '{descriptor.ServiceType}' has no implementation type, factory, or " +
+            "instance, so there is nothing to decorate.");
+    }
+
+    private static object CreateKeyedInner(IServiceProvider provider, object? key, ServiceDescriptor descriptor) {
+        if (descriptor.KeyedImplementationInstance != null) {
+            return descriptor.KeyedImplementationInstance;
+        }
+
+        if (descriptor.KeyedImplementationFactory != null) {
+            return descriptor.KeyedImplementationFactory(provider, key);
+        }
+
+        if (descriptor.KeyedImplementationType != null) {
+            return ActivatorUtilities.CreateInstance(provider, descriptor.KeyedImplementationType);
+        }
+
+        throw new InvalidOperationException(
+            $"The keyed registration for '{descriptor.ServiceType}' has no implementation type, factory, " +
+            "or instance, so there is nothing to decorate.");
+    }
+}

--- a/src/DependencyModules.Runtime/Helpers/DecoratorHelper.cs
+++ b/src/DependencyModules.Runtime/Helpers/DecoratorHelper.cs
@@ -56,6 +56,55 @@ public static class DecoratorHelper {
     }
 
     /// <summary>
+    /// Wraps every registration of <paramref name="serviceType"/> in <paramref name="decoratorType"/>,
+    /// resolving the decorator's remaining constructor parameters from the container.
+    /// </summary>
+    /// <remarks>
+    /// This is the overload generated code calls. Keeping the construction here rather than emitting
+    /// it means the awkward parts — closing an open generic decorator against whichever type
+    /// arguments the registration used, and passing the wrapped instance positionally — are written
+    /// and tested once.
+    /// </remarks>
+    /// <param name="services">The collection to rewrite.</param>
+    /// <param name="serviceType">The service being decorated. May be an open generic.</param>
+    /// <param name="decoratorType">
+    /// The decorator. Must be an open generic when <paramref name="serviceType"/> is, and is closed
+    /// with the type arguments of each matched registration.
+    /// </param>
+    public static void Decorate(IServiceCollection services, Type serviceType, Type decoratorType) {
+        Decorate(services, serviceType, (provider, inner) => {
+            var closedDecorator = decoratorType.IsGenericTypeDefinition
+                ? decoratorType.MakeGenericType(ResolveTypeArguments(inner, serviceType))
+                : decoratorType;
+
+            return ActivatorUtilities.CreateInstance(provider, closedDecorator, inner);
+        });
+    }
+
+    /// <summary>
+    /// The type arguments the wrapped instance closed the decorated open generic with, so the
+    /// decorator can be closed the same way.
+    /// </summary>
+    private static Type[] ResolveTypeArguments(object inner, Type openServiceType) {
+        var innerType = inner.GetType();
+
+        foreach (var candidate in innerType.GetInterfaces()) {
+            if (candidate.IsGenericType && candidate.GetGenericTypeDefinition() == openServiceType) {
+                return candidate.GetGenericArguments();
+            }
+        }
+
+        // The wrapped instance may itself be a closed construction of the decorated type rather than
+        // an implementation of it, which happens when decorators are stacked.
+        if (innerType.IsGenericType && innerType.GetGenericTypeDefinition() == openServiceType) {
+            return innerType.GetGenericArguments();
+        }
+
+        throw new InvalidOperationException(
+            $"'{innerType}' does not implement '{openServiceType}', so the decorator cannot be closed.");
+    }
+
+    /// <summary>
     /// True when a registered service type is the one being decorated, including a closed
     /// construction of a decorated open generic.
     /// </summary>

--- a/src/DependencyModules.Runtime/Helpers/DecoratorRegistration.cs
+++ b/src/DependencyModules.Runtime/Helpers/DecoratorRegistration.cs
@@ -1,0 +1,27 @@
+namespace DependencyModules.Runtime.Helpers;
+
+/// <summary>
+/// A decorator registration together with the order in which it should be applied.
+/// </summary>
+/// <remarks>
+/// Order is compared across every module in an <c>AddModule(s)</c> call, not just within the module
+/// that declared it. A pipeline assembled from several packages would otherwise nest by module
+/// discovery order rather than by intent.
+/// </remarks>
+/// <param name="order">
+/// Lower values are applied first and therefore sit closer to the implementation; higher values wrap
+/// them. By convention framework packages use 0-999 and application code uses 1000 and above, so an
+/// application's decorators wrap those contributed by the libraries it consumes.
+/// </param>
+/// <param name="registryFunc">The function that rewrites registrations in the collection.</param>
+public readonly struct DecoratorRegistration(int order, RegistryFunc registryFunc) {
+    /// <summary>
+    /// Order in which this decorator is applied relative to all others.
+    /// </summary>
+    public int Order { get; } = order;
+
+    /// <summary>
+    /// The function that performs the decoration.
+    /// </summary>
+    public RegistryFunc RegistryFunc { get; } = registryFunc;
+}

--- a/src/DependencyModules.Runtime/Helpers/DependencyRegistry.cs
+++ b/src/DependencyModules.Runtime/Helpers/DependencyRegistry.cs
@@ -150,22 +150,25 @@ public class DependencyRegistry<T> {
     /// </summary>
     /// <param name="serviceCollection"></param>
     public static void ApplyDecorators(IServiceCollection serviceCollection) {
-        DecoratorRegistration[] snapshot;
-        lock (SyncLock) {
-            snapshot = Decorators.ToArray();
-        }
-
         // OrderBy is a stable sort, so decorators sharing an order keep their registration order
         // rather than nesting arbitrarily.
-        foreach (var decorator in snapshot.OrderBy(decorator => decorator.Order)) {
+        foreach (var decorator in GetDecorators().OrderBy(decorator => decorator.Order)) {
             decorator.RegistryFunc(serviceCollection);
         }
     }
 
-    private readonly struct DecoratorRegistration(int order, RegistryFunc registryFunc) {
-        public int Order { get; } = order;
-
-        public RegistryFunc RegistryFunc { get; } = registryFunc;
+    /// <summary>
+    /// The decorators registered for this type, unsorted.
+    /// </summary>
+    /// <remarks>
+    /// Generated modules return these from <see cref="IDependencyModule.InternalGetDecorators"/> so
+    /// that decorators from every module can be sorted together. Applying each module's decorators
+    /// separately would make module discovery order outrank the declared order.
+    /// </remarks>
+    public static IReadOnlyList<DecoratorRegistration> GetDecorators() {
+        lock (SyncLock) {
+            return Decorators.ToArray();
+        }
     }
 
     /// <summary>
@@ -191,13 +194,31 @@ public class DependencyRegistry<T> {
     }
 
     private static void ApplyDecorators(IServiceCollection serviceCollection, IReadOnlyList<IDependencyModule> modules) {
+        // Gathered from every module and sorted together, the same way ApplyFeatures collects and
+        // sorts feature applicators. Applying each module's decorators in turn would let module
+        // discovery order outrank the declared order, which breaks a pipeline assembled from more
+        // than one package.
+        var decorators = new List<DecoratorRegistration>();
+
+        for (var i = 0; i < modules.Count; i++) {
+            decorators.AddRange(modules[i].InternalGetDecorators());
+        }
+
+        if (decorators.Count > 0) {
+            foreach (var decorator in decorators.OrderBy(decorator => decorator.Order)) {
+                decorator.RegistryFunc(serviceCollection);
+            }
+        }
+
         for (var i = 0; i < modules.Count; i++) {
             var module = modules[i];
+
+            // Retained for hand-written modules that decorate directly. Generated modules use
+            // InternalGetDecorators so their decorators take part in the global ordering.
             module.InternalApplyDecorators(serviceCollection);
 
-            // Mirrors how ApplyServices invokes ConfigureServices. Without this,
-            // IServiceCollectionConfiguration.ConfigureDecorators was declared but never called by
-            // anything, so a module that implemented it silently did nothing.
+            // Mirrors how ApplyServices invokes ConfigureServices. Runs last, so the manual escape
+            // hatch sees every declared decorator already in place.
             if (module is IServiceCollectionConfiguration serviceCollectionConfigure) {
                 serviceCollectionConfigure.ConfigureDecorators(serviceCollection);
             }

--- a/src/DependencyModules.Runtime/Helpers/DependencyRegistry.cs
+++ b/src/DependencyModules.Runtime/Helpers/DependencyRegistry.cs
@@ -194,6 +194,13 @@ public class DependencyRegistry<T> {
         for (var i = 0; i < modules.Count; i++) {
             var module = modules[i];
             module.InternalApplyDecorators(serviceCollection);
+
+            // Mirrors how ApplyServices invokes ConfigureServices. Without this,
+            // IServiceCollectionConfiguration.ConfigureDecorators was declared but never called by
+            // anything, so a module that implemented it silently did nothing.
+            if (module is IServiceCollectionConfiguration serviceCollectionConfigure) {
+                serviceCollectionConfigure.ConfigureDecorators(serviceCollection);
+            }
         }
     }
 

--- a/src/DependencyModules.Runtime/Helpers/DependencyRegistry.cs
+++ b/src/DependencyModules.Runtime/Helpers/DependencyRegistry.cs
@@ -21,7 +21,7 @@ public class DependencyRegistry<T> {
     // ReSharper disable StaticMemberInGenericType
     private static readonly object SyncLock = new();
     private static readonly List<RegistryFunc> RegistryFuncs = [];
-    private static readonly List<RegistryFunc> Decorators = [];
+    private static readonly List<DecoratorRegistration> Decorators = [];
     private static readonly List<IDependencyModule> Modules = [];
 
     /// <summary>
@@ -84,11 +84,19 @@ public class DependencyRegistry<T> {
     /// <summary>
     ///      Add decorator func
     /// </summary>
-    /// <param name="registryFunc"></param>
+    /// <param name="registryFunc">Function that decorates registrations already in the collection.</param>
+    /// <param name="order">
+    ///     Controls how decorators nest. Lower values are applied first and therefore sit closer to
+    ///     the implementation; higher values wrap them. Decorators sharing an order are applied in
+    ///     registration order.
+    ///
+    ///     By convention, framework packages use 0-999 and application code uses 1000 and above, so
+    ///     that an application's decorators wrap those contributed by the libraries it consumes.
+    /// </param>
     /// <returns></returns>
-    public static int AddDecorator(RegistryFunc registryFunc) {
+    public static int AddDecorator(RegistryFunc registryFunc, int order = 0) {
         lock (SyncLock) {
-            Decorators.Add(registryFunc);
+            Decorators.Add(new DecoratorRegistration(order, registryFunc));
         }
 
         return 1;
@@ -142,14 +150,22 @@ public class DependencyRegistry<T> {
     /// </summary>
     /// <param name="serviceCollection"></param>
     public static void ApplyDecorators(IServiceCollection serviceCollection) {
-        RegistryFunc[] snapshot;
+        DecoratorRegistration[] snapshot;
         lock (SyncLock) {
             snapshot = Decorators.ToArray();
         }
 
-        foreach (var registryFunc in snapshot) {
-            registryFunc(serviceCollection);
+        // OrderBy is a stable sort, so decorators sharing an order keep their registration order
+        // rather than nesting arbitrarily.
+        foreach (var decorator in snapshot.OrderBy(decorator => decorator.Order)) {
+            decorator.RegistryFunc(serviceCollection);
         }
+    }
+
+    private readonly struct DecoratorRegistration(int order, RegistryFunc registryFunc) {
+        public int Order { get; } = order;
+
+        public RegistryFunc RegistryFunc { get; } = registryFunc;
     }
 
     /// <summary>

--- a/src/DependencyModules.Runtime/Interfaces/IDependencyModule.cs
+++ b/src/DependencyModules.Runtime/Interfaces/IDependencyModule.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using DependencyModules.Runtime.Features;
+using DependencyModules.Runtime.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DependencyModules.Runtime.Interfaces;
@@ -50,4 +51,17 @@ public interface IDependencyModule {
     /// <param name="serviceCollection"></param>
     [Browsable(false)]
     void InternalApplyDecorators(IServiceCollection serviceCollection) { }
+
+    /// <summary>
+    /// Internal method not intended to be called by general developers.
+    /// </summary>
+    /// <remarks>
+    /// Returning decorators rather than applying them lets the runtime sort every module's
+    /// decorators together. Applying them per module would make module discovery order outrank the
+    /// order the developer declared.
+    /// </remarks>
+    [Browsable(false)]
+    IEnumerable<DecoratorRegistration> InternalGetDecorators() {
+        return ArraySegment<DecoratorRegistration>.Empty;
+    }
 }

--- a/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
+++ b/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ Rule ID | Category | Severity | Notes
 DM0001 | DependencyModules | Error | The generator failed; registrations may be missing.
 DM0002 | DependencyModules | Warning | A service type cannot be constructed and was not registered.
 DM0003 | DependencyModules | Error | A module marked with [DependencyModule] is not partial.
+DM0007 | DependencyModules | Error | Two decorators of one service share an order.

--- a/src/DependencyModules.SourceGenerator.Impl/DecoratorFileWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DecoratorFileWriter.cs
@@ -1,0 +1,96 @@
+using CSharpAuthor;
+using DependencyModules.SourceGenerator.Impl.Models;
+using DependencyModules.SourceGenerator.Impl.Utilities;
+using static CSharpAuthor.SyntaxHelpers;
+
+namespace DependencyModules.SourceGenerator.Impl;
+
+/// <summary>
+/// Emits the decorator registrations for one module.
+/// </summary>
+/// <remarks>
+/// Each decorator gets its own method and its own registration, because each carries its own order.
+/// The bodies are a single call into <c>DecoratorHelper</c>; the rewrite itself is deliberately not
+/// generated.
+/// </remarks>
+public class DecoratorFileWriter {
+
+    public string Write(
+        ModuleEntryPointModel entryPointModel,
+        DependencyModuleConfigurationModel configurationModel,
+        IReadOnlyList<DecoratorModel> decorators) {
+
+        var csharpFile = new CSharpFileDefinition(entryPointModel.EntryPointType.Namespace);
+
+        var classDefinition = csharpFile.AddClass(entryPointModel.EntryPointType.Name);
+        classDefinition.Modifiers |= ComponentModifier.Partial;
+
+        // Applied per method rather than to the class. ExcludeFromCodeCoverage is not AllowMultiple,
+        // and the same partial class also carries it from the registrations file.
+        for (var i = 0; i < decorators.Count; i++) {
+            WriteDecorator(entryPointModel, classDefinition, decorators[i], i, configurationModel);
+        }
+
+        var outputContext = new OutputContext(new OutputContextOptions {
+            TypeOutputMode = TypeOutputMode.Global
+        });
+
+        csharpFile.WriteOutput(outputContext);
+
+        return outputContext.Output();
+    }
+
+    private static void WriteDecorator(
+        ModuleEntryPointModel entryPointModel,
+        ClassDefinition classDefinition,
+        DecoratorModel decorator,
+        int index,
+        DependencyModuleConfigurationModel configurationModel) {
+
+        var methodName = $"ApplyDecorator{index}";
+
+        var method = classDefinition.AddMethod(methodName);
+        method.Modifiers |= ComponentModifier.Private | ComponentModifier.Static;
+
+        if (configurationModel.ExcludeGeneratedCodeFromCoverage) {
+            method.AddAttribute(TypeDefinition.Get("System.Diagnostics.CodeAnalysis", "ExcludeFromCodeCoverage"));
+        }
+
+        var services = method.AddParameter(
+            KnownTypes.Microsoft.DependencyInjection.IServiceCollection, "services");
+
+        method.AddIndentedStatement(
+            new StaticInvokeStatement(
+                KnownTypes.DependencyModules.Helpers.DecoratorHelper,
+                "Decorate",
+                new List<IOutputComponent> {
+                    CodeOutputComponent.Get(services.Name),
+                    TypeOf(decorator.ServiceType),
+                    TypeOf(decorator.DecoratorType)
+                }));
+
+        // A field initializer registers the method, matching how service registrations are hooked up.
+        // DynamicDependency keeps the trimmer from removing a method only referenced this way.
+        var field = classDefinition.AddField(typeof(int), $"decoratorField{index}");
+        field.Modifiers |= ComponentModifier.Private | ComponentModifier.Static;
+        field.AddAttribute(
+            TypeDefinition.Get("System.Diagnostics.CodeAnalysis", "DynamicDependency"),
+            $"nameof({methodName})");
+
+        var registryType = new GenericTypeDefinition(
+            TypeDefinitionEnum.ClassDefinition,
+            KnownTypes.DependencyModules.Helpers.Namespace,
+            "DependencyRegistry",
+            new[] { entryPointModel.EntryPointType });
+
+        field.InitializeValue = new StaticInvokeStatement(
+            registryType,
+            "AddDecorator",
+            new List<IOutputComponent> {
+                CodeOutputComponent.Get(methodName),
+                CodeOutputComponent.Get(decorator.Order.ToString())
+            }) {
+            Indented = false
+        };
+    }
+}

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
@@ -55,4 +55,18 @@ public static class DependencyModuleDiagnostics {
         category: Category,
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    /// <summary>
+    /// Raised when two decorators of one service share an order. Applying them in an arbitrary order
+    /// would nest them in a way nobody declared, and the two nestings behave differently.
+    /// </summary>
+    public static readonly DiagnosticDescriptor AmbiguousDecoratorOrder = new(
+        id: "DM0007",
+        title: "Decorator order is ambiguous",
+        messageFormat:
+        "'{0}' and '{1}' both decorate '{2}' with order {3}, so the order they nest in is undefined. " +
+        "Give them distinct Order values.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 }

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleWriter.cs
@@ -139,7 +139,9 @@ public class DependencyModuleWriter {
         InternalApplyServicesMethod(classDefinition, model);
 
         InternalGetModulesMethod(classDefinition, model);
-        
+
+        InternalGetDecoratorsMethod(classDefinition, model);
+
         FeatureMethod(classDefinition, model);
 
         if ((model.ModuleFeatures & ModuleEntryPointFeatures.ShouldImplementEquals) == 
@@ -222,6 +224,33 @@ public class DependencyModuleWriter {
         equalMethod.AddParameter(TypeDefinition.Get(typeof(object)).MakeNullable(), "obj");
 
         equalMethod.Return($"obj is {model.EntryPointType.Name}");
+    }
+
+    /// <summary>
+    /// Hands the module's decorators to the runtime rather than applying them, so decorators from
+    /// every module can be sorted together. Emitted unconditionally: a module may gain decorators
+    /// from a source the registrations file never saw, and returning an empty list costs nothing.
+    /// </summary>
+    private void InternalGetDecoratorsMethod(ClassDefinition classDefinition, ModuleEntryPointModel model) {
+        var method = classDefinition.AddMethod("InternalGetDecorators");
+
+        method.AddLeadingTrait(CodeOutputComponent.Get("[Browsable(false)]", true));
+        method.AddUsingNamespace("System.ComponentModel");
+
+        method.InterfaceImplementation = KnownTypes.DependencyModules.Interfaces.IDependencyModule;
+        method.SetReturnType(
+            new GenericTypeDefinition(
+                typeof(IEnumerable<>),
+                new[] { KnownTypes.DependencyModules.Helpers.DecoratorRegistration }));
+
+        var closedType = new GenericTypeDefinition(
+            TypeDefinitionEnum.ClassDefinition, KnownTypes.DependencyModules.Helpers.Namespace, "DependencyRegistry", new[] {
+                model.EntryPointType
+            });
+
+        method.Return(new StaticInvokeStatement(closedType, "GetDecorators", new List<IOutputComponent>()) {
+            Indented = false
+        });
     }
 
     private void InternalGetModulesMethod(ClassDefinition classDefinition, ModuleEntryPointModel model) {

--- a/src/DependencyModules.SourceGenerator.Impl/KnownTypes.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/KnownTypes.cs
@@ -48,6 +48,12 @@ public static class KnownTypes {
 
             public static readonly ITypeDefinition SingletonServiceAttribute =
                 TypeDefinition.Get(TypeDefinitionEnum.ClassDefinition, Namespace, "SingletonServiceAttribute");
+
+            public static readonly ITypeDefinition DecoratorAttribute =
+                TypeDefinition.Get(TypeDefinitionEnum.ClassDefinition, Namespace, "DecoratorAttribute");
+
+            public static readonly ITypeDefinition DecorateAttribute =
+                TypeDefinition.Get(TypeDefinitionEnum.ClassDefinition, Namespace, "DecorateAttribute");
             
             public static readonly ITypeDefinition CrossWireServiceAttribute =
                 TypeDefinition.Get(TypeDefinitionEnum.ClassDefinition, Namespace, "CrossWireServiceAttribute");
@@ -87,6 +93,12 @@ public static class KnownTypes {
 
         public static class Helpers {
             public const string Namespace = "DependencyModules.Runtime.Helpers";
+
+            public static readonly ITypeDefinition DecoratorHelper =
+                TypeDefinition.Get(TypeDefinitionEnum.ClassDefinition, Namespace, "DecoratorHelper");
+
+            public static readonly ITypeDefinition DecoratorRegistration =
+                TypeDefinition.Get(TypeDefinitionEnum.ClassDefinition, Namespace, "DecoratorRegistration");
         }
     }
 }

--- a/src/DependencyModules.SourceGenerator.Impl/Models/DecoratorModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/DecoratorModel.cs
@@ -1,0 +1,66 @@
+using CSharpAuthor;
+
+namespace DependencyModules.SourceGenerator.Impl.Models;
+
+/// <summary>
+/// A decorator to apply to a service, from either <c>[Decorator]</c> on the decorator class or
+/// <c>[Decorate]</c> on a module.
+/// </summary>
+/// <param name="ServiceType">The decorated service. May be an open generic.</param>
+/// <param name="DecoratorType">The decorator wrapping it.</param>
+/// <param name="Order">
+/// Lower values are applied first and sit closer to the implementation. Compared across every
+/// module, not only within the declaring one.
+/// </param>
+/// <param name="Realm">Restricts the decorator to one module, matching the service Realm property.</param>
+public record DecoratorModel(
+    ITypeDefinition ServiceType,
+    ITypeDefinition DecoratorType,
+    int Order,
+    ITypeDefinition? Realm) {
+
+    /// <summary>
+    /// Sentinel for a syntax node that carried the attribute but produced no usable model, matching
+    /// how <see cref="ServiceModel.Ignore"/> is used.
+    /// </summary>
+    public static readonly DecoratorModel Ignore = new(
+        TypeDefinition.Get("", "Ignore"),
+        TypeDefinition.Get("", "Ignore"),
+        0,
+        null);
+
+    public bool IsIgnored => ReferenceEquals(this, Ignore);
+}
+
+/// <summary>
+/// Equality for the incremental pipeline. Every field affects generated output, so all of them are
+/// compared; missing one would serve stale output after an edit to it.
+/// </summary>
+public class DecoratorModelComparer : IEqualityComparer<DecoratorModel> {
+
+    public bool Equals(DecoratorModel? x, DecoratorModel? y) {
+        if (ReferenceEquals(x, y)) {
+            return true;
+        }
+
+        if (x is null || y is null) {
+            return false;
+        }
+
+        return x.Order == y.Order &&
+               x.ServiceType.Equals(y.ServiceType) &&
+               x.DecoratorType.Equals(y.DecoratorType) &&
+               Equals(x.Realm, y.Realm);
+    }
+
+    public int GetHashCode(DecoratorModel obj) {
+        unchecked {
+            var hash = obj.ServiceType.GetHashCode();
+            hash = hash * 31 + obj.DecoratorType.GetHashCode();
+            hash = hash * 31 + obj.Order;
+            hash = hash * 31 + (obj.Realm?.GetHashCode() ?? 0);
+
+            return hash;
+        }
+    }
+}

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/DecoratorModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/DecoratorModelUtility.cs
@@ -1,0 +1,222 @@
+using CSharpAuthor;
+using DependencyModules.SourceGenerator.Impl.Models;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace DependencyModules.SourceGenerator.Impl.Utilities;
+
+/// <summary>
+/// Builds <see cref="DecoratorModel"/> instances from the two declaration surfaces:
+/// <c>[Decorator]</c> on the decorator class, and <c>[Decorate]</c> on a module.
+/// </summary>
+public static class DecoratorModelUtility {
+
+    /// <summary>
+    /// Reads a <c>[Decorator]</c> class declaration.
+    /// </summary>
+    public static DecoratorModel? GetDecoratorModel(GeneratorSyntaxContext context, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (context.Node is not TypeDeclarationSyntax typeDeclarationSyntax) {
+            return null;
+        }
+
+        var attribute = FindAttribute(typeDeclarationSyntax, "Decorator");
+
+        if (attribute == null) {
+            return null;
+        }
+
+        var decoratorType = GetDeclaredType(typeDeclarationSyntax, context);
+        var implemented = GetImplementedInterfaces(typeDeclarationSyntax, context);
+
+        var order = 0;
+        ITypeDefinition? realm = null;
+        ITypeDefinition? explicitService = null;
+
+        if (attribute.ArgumentList != null) {
+            foreach (var argument in attribute.ArgumentList.Arguments) {
+                switch (argument.NameEquals?.Name.ToString()) {
+                    case "Order":
+                        if (int.TryParse(argument.Expression.ToString(), out var parsed)) {
+                            order = parsed;
+                        }
+                        break;
+                    case "Service":
+                        explicitService = GetTypeOfArgument(argument, context);
+                        break;
+                    case "Realm":
+                        realm = GetTypeOfArgument(argument, context);
+                        break;
+                }
+            }
+        }
+
+        var serviceType = explicitService ?? InferDecoratedService(typeDeclarationSyntax, context, implemented);
+
+        if (serviceType == null) {
+            return null;
+        }
+
+        // A generic decorator decorates the open service. Its base list names the service closed over
+        // its own type parameters, as IHandler<T>, which is not a legal typeof argument; the unbound
+        // IHandler<> is what has to be emitted, and what DecoratorHelper matches registrations by.
+        if (decoratorType is GenericTypeDefinition { TypeArguments.Count: > 0 }) {
+            serviceType = ToUnboundGeneric(serviceType);
+        }
+
+        return new DecoratorModel(serviceType, decoratorType, order, realm);
+    }
+
+    /// <summary>
+    /// Reads the <c>[Decorate(service, decorator)]</c> attributes declared on a module.
+    /// </summary>
+    public static IEnumerable<DecoratorModel> GetModuleDeclaredDecorators(ModuleEntryPointModel entryPointModel) {
+        foreach (var attribute in entryPointModel.AttributeModels) {
+            if (attribute.TypeDefinition.Name is not ("DecorateAttribute" or "Decorate")) {
+                continue;
+            }
+
+            if (attribute.Arguments.Count < 2 ||
+                attribute.Arguments[0].Value is not ITypeDefinition service ||
+                attribute.Arguments[1].Value is not ITypeDefinition decorator) {
+                continue;
+            }
+
+            var order = 0;
+
+            foreach (var property in attribute.Properties) {
+                if (property.Name == "Order" && property.Value != null &&
+                    int.TryParse(property.Value.ToString(), out var parsed)) {
+                    order = parsed;
+                }
+            }
+
+            yield return new DecoratorModel(service, decorator, order, entryPointModel.EntryPointType);
+        }
+    }
+
+    /// <summary>
+    /// The decorated service is the interface the decorator both implements and accepts as a
+    /// constructor parameter. That pairing is what makes something a decorator rather than merely a
+    /// class with a dependency.
+    /// </summary>
+    private static ITypeDefinition? InferDecoratedService(
+        TypeDeclarationSyntax typeDeclarationSyntax,
+        GeneratorSyntaxContext context,
+        IReadOnlyList<ITypeDefinition> implemented) {
+
+        if (implemented.Count == 0) {
+            return null;
+        }
+
+        foreach (var parameterType in GetConstructorParameterTypes(typeDeclarationSyntax, context)) {
+            foreach (var candidate in implemented) {
+                if (candidate.Equals(parameterType)) {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<ITypeDefinition> GetConstructorParameterTypes(
+        TypeDeclarationSyntax typeDeclarationSyntax, GeneratorSyntaxContext context) {
+
+        if (typeDeclarationSyntax.ParameterList != null) {
+            foreach (var parameter in typeDeclarationSyntax.ParameterList.Parameters) {
+                var type = parameter.Type?.GetTypeDefinition(context);
+
+                if (type != null) {
+                    yield return type;
+                }
+            }
+        }
+
+        foreach (var constructor in typeDeclarationSyntax.Members.OfType<ConstructorDeclarationSyntax>()) {
+            foreach (var parameter in constructor.ParameterList.Parameters) {
+                var type = parameter.Type?.GetTypeDefinition(context);
+
+                if (type != null) {
+                    yield return type;
+                }
+            }
+        }
+    }
+
+    private static IReadOnlyList<ITypeDefinition> GetImplementedInterfaces(
+        TypeDeclarationSyntax typeDeclarationSyntax, GeneratorSyntaxContext context) {
+
+        var interfaces = new List<ITypeDefinition>();
+
+        if (typeDeclarationSyntax.BaseList == null) {
+            return interfaces;
+        }
+
+        foreach (var baseType in typeDeclarationSyntax.BaseList.Types) {
+            var type = baseType.Type.GetTypeDefinition(context);
+
+            if (type != null) {
+                interfaces.Add(type);
+            }
+        }
+
+        return interfaces;
+    }
+
+    /// <summary>
+    /// Rewrites a generic type so its arguments render as the unbound <c>&lt;&gt;</c> form.
+    /// </summary>
+    private static ITypeDefinition ToUnboundGeneric(ITypeDefinition type) {
+        if (type is not GenericTypeDefinition { TypeArguments.Count: > 0 } generic) {
+            return type;
+        }
+
+        return new GenericTypeDefinition(
+            generic.TypeDefinitionEnum,
+            generic.Namespace,
+            generic.Name,
+            generic.TypeArguments.Select(_ => (ITypeDefinition)TypeDefinition.Get("", "")).ToArray());
+    }
+
+    private static ITypeDefinition GetDeclaredType(TypeDeclarationSyntax typeDeclarationSyntax, GeneratorSyntaxContext context) {
+        var name = typeDeclarationSyntax.Identifier.ToString();
+
+        foreach (var containing in typeDeclarationSyntax.Ancestors().OfType<TypeDeclarationSyntax>()) {
+            name = containing.Identifier + "." + name;
+        }
+
+        var namespaceName = typeDeclarationSyntax.GetNamespace();
+
+        if (typeDeclarationSyntax.TypeParameterList is { Parameters.Count: > 0 } parameters) {
+            return new GenericTypeDefinition(
+                TypeDefinitionEnum.ClassDefinition,
+                namespaceName,
+                name,
+                parameters.Parameters.Select(_ => TypeDefinition.Get("", "")).ToArray());
+        }
+
+        return TypeDefinition.Get(namespaceName, name);
+    }
+
+    private static ITypeDefinition? GetTypeOfArgument(AttributeArgumentSyntax argument, GeneratorSyntaxContext context) {
+        return argument.Expression is TypeOfExpressionSyntax typeOf
+            ? typeOf.Type.GetTypeDefinition(context)
+            : null;
+    }
+
+    private static AttributeSyntax? FindAttribute(TypeDeclarationSyntax typeDeclarationSyntax, string name) {
+        foreach (var attributeList in typeDeclarationSyntax.AttributeLists) {
+            foreach (var attribute in attributeList.Attributes) {
+                var attributeName = attribute.Name.ToString();
+
+                if (attributeName == name || attributeName == name + "Attribute") {
+                    return attribute;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/DependencyModules.SourceGenerator/DecoratorSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/DecoratorSourceGenerator.cs
@@ -1,0 +1,147 @@
+using System.Collections.Immutable;
+using CSharpAuthor;
+using DependencyModules.SourceGenerator.Impl;
+using DependencyModules.SourceGenerator.Impl.Models;
+using DependencyModules.SourceGenerator.Impl.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace DependencyModules.SourceGenerator;
+
+/// <summary>
+/// Emits the decorator registrations declared by <c>[Decorator]</c> on a class and <c>[Decorate]</c>
+/// on a module.
+/// </summary>
+/// <remarks>
+/// The decoration itself lives in <c>DecoratorHelper</c> at run time, so the generated code is a
+/// pair of type references. Emitting the descriptor rewrite would mean reproducing its awkward parts
+/// — capturing the descriptor before replacing the slot, closing an open generic decorator, covering
+/// all three descriptor shapes — at every call site.
+/// </remarks>
+public class DecoratorSourceGenerator : BaseAttributeSourceGenerator<DecoratorModel> {
+    private readonly IEqualityComparer<DecoratorModel> _comparer = new DecoratorModelComparer();
+
+    private static readonly ITypeDefinition[] _attributeTypes = {
+        KnownTypes.DependencyModules.Attributes.DecoratorAttribute
+    };
+
+    protected override string LoggerName => "DecoratorSourceGenerator";
+
+    protected override IEnumerable<ITypeDefinition> AttributeTypes() {
+        return _attributeTypes;
+    }
+
+    protected override IEqualityComparer<DecoratorModel> GetComparer() {
+        return _comparer;
+    }
+
+    protected override DecoratorModel GenerateAttributeModel(GeneratorSyntaxContext context, CancellationToken cancellationToken) {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return DecoratorModelUtility.GetDecoratorModel(context, cancellationToken) ?? DecoratorModel.Ignore;
+    }
+
+    protected override void GenerateSourceOutput(
+        SourceProductionContext context,
+        (ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Left,
+            ImmutableArray<DecoratorModel> Right) inputData,
+        FileLogger logger) {
+
+        if (inputData.Left.Length == 0) {
+            return;
+        }
+
+        var (entryPointList, configurationModel) = EntryModelUtil.ConsolidateEntryPointModels(inputData.Left);
+
+        foreach (var entryPointModel in entryPointList) {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            var decorators = CollectDecorators(context, entryPointModel, inputData.Right, logger);
+
+            if (decorators.Count == 0) {
+                continue;
+            }
+
+            var writer = new DecoratorFileWriter();
+            var output = writer.Write(
+                EntryModelUtil.EnsureNamespace(entryPointModel, configurationModel),
+                configurationModel,
+                decorators);
+
+            context.AddSource(
+                EntryModelUtil.EnsureNamespace(entryPointModel, configurationModel)
+                    .EntryPointType.GetFileNameHint(configurationModel.RootNamespace, "Decorators"),
+                output);
+        }
+    }
+
+    /// <summary>
+    /// The decorators that belong to one module: those declared on a class, filtered by realm, plus
+    /// those the module declares itself with <c>[Decorate]</c>.
+    /// </summary>
+    private static IReadOnlyList<DecoratorModel> CollectDecorators(
+        SourceProductionContext context,
+        ModuleEntryPointModel entryPointModel,
+        ImmutableArray<DecoratorModel> declared,
+        FileLogger logger) {
+
+        var decorators = new List<DecoratorModel>();
+
+        foreach (var decorator in declared) {
+            if (decorator.IsIgnored) {
+                continue;
+            }
+
+            // A realm-scoped decorator belongs only to its realm. An unscoped one belongs to every
+            // module that is not realm-only, matching how service registrations behave.
+            if (decorator.Realm != null) {
+                if (decorator.Realm.Equals(entryPointModel.EntryPointType)) {
+                    decorators.Add(decorator);
+                }
+
+                continue;
+            }
+
+            if (!entryPointModel.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.OnlyRealm)) {
+                decorators.Add(decorator);
+            }
+        }
+
+        decorators.AddRange(DecoratorModelUtility.GetModuleDeclaredDecorators(entryPointModel));
+
+        ReportAmbiguousOrdering(context, decorators, logger);
+
+        return decorators;
+    }
+
+    /// <summary>
+    /// Two decorators of one service sharing an order nest in an order nobody declared, so it is
+    /// reported rather than resolved arbitrarily.
+    /// </summary>
+    private static void ReportAmbiguousOrdering(
+        SourceProductionContext context, IReadOnlyList<DecoratorModel> decorators, FileLogger logger) {
+
+        for (var i = 0; i < decorators.Count; i++) {
+            for (var j = i + 1; j < decorators.Count; j++) {
+                if (decorators[i].Order != decorators[j].Order ||
+                    !decorators[i].ServiceType.Equals(decorators[j].ServiceType)) {
+                    continue;
+                }
+
+                logger.Error(
+                    $"'{decorators[i].DecoratorType.Name}' and '{decorators[j].DecoratorType.Name}' both " +
+                    $"decorate '{decorators[i].ServiceType.Name}' with order {decorators[i].Order}.");
+
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        DependencyModuleDiagnostics.AmbiguousDecoratorOrder,
+                        Location.None,
+                        decorators[i].DecoratorType.Name,
+                        decorators[j].DecoratorType.Name,
+                        decorators[i].ServiceType.Name,
+                        decorators[i].Order));
+            }
+        }
+    }
+}

--- a/src/DependencyModules.SourceGenerator/SourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/SourceGenerator.cs
@@ -10,6 +10,7 @@ public class SourceGenerator : BaseSourceGenerator {
 
     protected override IEnumerable<IDependencyModuleSourceGenerator> AttributeSourceGenerators() {
         yield return new ServiceSourceGenerator();
+        yield return new DecoratorSourceGenerator();
     }
 
     protected override void SetupRootGenerator(IncrementalGeneratorInitializationContext context,

--- a/tests/DependencyModules.Tests/GeneratorTests/DecoratorGenerationTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/DecoratorGenerationTests.cs
@@ -1,0 +1,223 @@
+using DependencyModules.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// Decoration verified by resolving from a real container built from generated code, rather than by
+/// matching the generated text. The registrations are the point; their shape is not.
+/// </summary>
+public class DecoratorGenerationTests {
+
+    [Fact]
+    public void Decorator_WrapsTheRegisteredImplementation() {
+        var generated = GeneratedAssembly.Create(Module(
+            """
+            [Decorator]
+            public class LoudGreeter(IGreeter inner) : IGreeter {
+                public string Greet() => inner.Greet().ToUpperInvariant();
+            }
+            """));
+
+        Assert.Equal("HELLO", Greet(generated));
+    }
+
+    [Fact]
+    public void Decorator_PreservesTheServiceLifetime() {
+        var generated = GeneratedAssembly.Create(Module(
+            """
+            [Decorator]
+            public class LoudGreeter(IGreeter inner) : IGreeter {
+                public string Greet() => inner.Greet();
+            }
+            """));
+
+        Assert.Equal(ServiceLifetime.Singleton, generated.Descriptor("IGreeter").Lifetime);
+    }
+
+    /// <summary>
+    /// Lower order sits closer to the implementation, so the higher-order decorator is outermost.
+    /// </summary>
+    [Fact]
+    public void Decorators_NestByAscendingOrder() {
+        var generated = GeneratedAssembly.Create(Module(
+            """
+            [Decorator(Order = 10)]
+            public class InnerGreeter(IGreeter inner) : IGreeter {
+                public string Greet() => $"inner({inner.Greet()})";
+            }
+
+            [Decorator(Order = 20)]
+            public class OuterGreeter(IGreeter inner) : IGreeter {
+                public string Greet() => $"outer({inner.Greet()})";
+            }
+            """));
+
+        Assert.Equal("outer(inner(hello))", Greet(generated));
+    }
+
+    [Fact]
+    public void Decorator_ReceivesItsOwnDependencies() {
+        var generated = GeneratedAssembly.Create(Module(
+            """
+            public interface IPrefix { string Value { get; } }
+
+            [SingletonService]
+            public class Prefix : IPrefix { public string Value => "pre"; }
+
+            [Decorator]
+            public class PrefixedGreeter(IGreeter inner, IPrefix prefix) : IGreeter {
+                public string Greet() => $"{prefix.Value}-{inner.Greet()}";
+            }
+            """));
+
+        Assert.Equal("pre-hello", Greet(generated));
+    }
+
+    [Fact]
+    public void OpenGenericDecorator_WrapsEveryClosedRegistration() {
+        var generated = GeneratedAssembly.Create(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            public interface IHandler<T> { string Handle(); }
+
+            [SingletonService]
+            public class StringHandler : IHandler<string> { public string Handle() => "string"; }
+
+            [SingletonService]
+            public class IntHandler : IHandler<int> { public string Handle() => "int"; }
+
+            [Decorator]
+            public class ValidatingHandler<T>(IHandler<T> inner) : IHandler<T> {
+                public string Handle() => $"validated({inner.Handle()})";
+            }
+
+            [DependencyModule]
+            public partial class TestModule;
+            """);
+
+        var provider = generated.BuildProvider();
+        var handler = generated.Type("IHandler`1");
+
+        Assert.Equal("validated(string)",
+            Invoke(provider.GetService(handler.MakeGenericType(typeof(string)))!, "Handle"));
+        Assert.Equal("validated(int)",
+            Invoke(provider.GetService(handler.MakeGenericType(typeof(int)))!, "Handle"));
+    }
+
+    [Fact]
+    public void ModuleLevelDecorate_WrapsAServiceTheModuleDoesNotDeclare() {
+        var generated = GeneratedAssembly.Create(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            public interface IGreeter { string Greet(); }
+
+            [SingletonService]
+            public class Greeter : IGreeter { public string Greet() => "hello"; }
+
+            public class LoudGreeter(IGreeter inner) : IGreeter {
+                public string Greet() => inner.Greet().ToUpperInvariant();
+            }
+
+            [DependencyModule]
+            [Decorate(typeof(IGreeter), typeof(LoudGreeter))]
+            public partial class TestModule;
+            """);
+
+        Assert.Equal("HELLO", Greet(generated));
+    }
+
+    [Fact]
+    public void Decorator_WithExplicitService_UsesIt() {
+        var generated = GeneratedAssembly.Create(Module(
+            """
+            [Decorator(Service = typeof(IGreeter))]
+            public class LoudGreeter(IGreeter inner) : IGreeter {
+                public string Greet() => inner.Greet().ToUpperInvariant();
+            }
+            """));
+
+        Assert.Equal("HELLO", Greet(generated));
+    }
+
+    [Fact]
+    public void NoDecorator_LeavesTheServiceAlone() {
+        var generated = GeneratedAssembly.Create(Module(""));
+
+        Assert.Equal("hello", Greet(generated));
+    }
+
+    /// <summary>
+    /// Two decorators of one service with the same order would nest in an order nobody declared.
+    /// </summary>
+    [Fact]
+    public void DecoratorsSharingAnOrder_ReportDM0007() {
+        var result = GeneratorTestHarness.Run(Module(
+            """
+            [Decorator(Order = 5)]
+            public class FirstGreeter(IGreeter inner) : IGreeter {
+                public string Greet() => inner.Greet();
+            }
+
+            [Decorator(Order = 5)]
+            public class SecondGreeter(IGreeter inner) : IGreeter {
+                public string Greet() => inner.Greet();
+            }
+            """));
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0007");
+
+        Assert.Equal(DiagnosticSeverity.Error, diagnostic.Severity);
+        Assert.Contains("IGreeter", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void DecoratorsWithDistinctOrders_ReportNothing() {
+        var result = GeneratorTestHarness.Run(Module(
+            """
+            [Decorator(Order = 1)]
+            public class FirstGreeter(IGreeter inner) : IGreeter {
+                public string Greet() => inner.Greet();
+            }
+
+            [Decorator(Order = 2)]
+            public class SecondGreeter(IGreeter inner) : IGreeter {
+                public string Greet() => inner.Greet();
+            }
+            """));
+
+        result.AssertNoErrors();
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0007");
+    }
+
+    private static string Greet(GeneratedAssembly generated) =>
+        Invoke(generated.ResolveRequired("IGreeter"), "Greet");
+
+    private static string Invoke(object target, string method) =>
+        (string)target.GetType().GetMethod(method)!.Invoke(target, null)!;
+
+    private static string Module(string body) =>
+        $$"""
+          using DependencyModules.Runtime.Attributes;
+
+          namespace TestNamespace;
+
+          public interface IGreeter { string Greet(); }
+
+          [SingletonService]
+          public class Greeter : IGreeter { public string Greet() => "hello"; }
+
+          {{body}}
+
+          [DependencyModule]
+          public partial class TestModule;
+          """;
+}

--- a/tests/DependencyModules.Tests/RuntimeTests/DecoratorHelperTests.cs
+++ b/tests/DependencyModules.Tests/RuntimeTests/DecoratorHelperTests.cs
@@ -1,0 +1,226 @@
+using DependencyModules.Runtime.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DependencyModules.Tests.RuntimeTests;
+
+/// <summary>
+/// The descriptor rewrite is where decoration actually goes wrong, so it is tested directly rather
+/// than only through generated code.
+/// </summary>
+public class DecoratorHelperTests {
+
+    private interface IThing {
+        string Describe();
+    }
+
+    private class Thing : IThing {
+        public string Describe() => "thing";
+    }
+
+    private class OtherThing : IThing {
+        public string Describe() => "other";
+    }
+
+    private class Wrapper(IThing inner) : IThing {
+        public IThing Inner { get; } = inner;
+
+        public string Describe() => $"wrapped({Inner.Describe()})";
+    }
+
+    private class SecondWrapper(IThing inner) : IThing {
+        public string Describe() => $"second({inner.Describe()})";
+    }
+
+    private static IThing Resolve(IServiceCollection services) =>
+        services.BuildServiceProvider().GetRequiredService<IThing>();
+
+    [Fact]
+    public void Decorate_WrapsAnImplementationTypeRegistration() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IThing, Thing>();
+
+        DecoratorHelper.Decorate(services, typeof(IThing), (_, inner) => new Wrapper((IThing)inner));
+
+        Assert.Equal("wrapped(thing)", Resolve(services).Describe());
+    }
+
+    [Fact]
+    public void Decorate_WrapsAFactoryRegistration() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IThing>(_ => new Thing());
+
+        DecoratorHelper.Decorate(services, typeof(IThing), (_, inner) => new Wrapper((IThing)inner));
+
+        Assert.Equal("wrapped(thing)", Resolve(services).Describe());
+    }
+
+    [Fact]
+    public void Decorate_WrapsAnInstanceRegistration() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IThing>(new Thing());
+
+        DecoratorHelper.Decorate(services, typeof(IThing), (_, inner) => new Wrapper((IThing)inner));
+
+        Assert.Equal("wrapped(thing)", Resolve(services).Describe());
+    }
+
+    /// <summary>
+    /// The failure this guards against is not a wrong answer but a stack overflow: if the factory
+    /// reads the collection slot instead of the captured descriptor, it resolves itself forever.
+    /// </summary>
+    [Fact]
+    public void Decorate_DoesNotRecurseIntoItsOwnReplacement() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IThing, Thing>();
+
+        DecoratorHelper.Decorate(services, typeof(IThing), (_, inner) => new Wrapper((IThing)inner));
+
+        var resolved = Assert.IsType<Wrapper>(Resolve(services));
+        Assert.IsType<Thing>(resolved.Inner);
+    }
+
+    [Fact]
+    public void Decorate_WrapsEveryRegistrationOfTheService() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IThing, Thing>();
+        services.AddSingleton<IThing, OtherThing>();
+
+        DecoratorHelper.Decorate(services, typeof(IThing), (_, inner) => new Wrapper((IThing)inner));
+
+        var all = services.BuildServiceProvider().GetServices<IThing>().ToArray();
+
+        Assert.Equal(2, all.Length);
+        Assert.All(all, thing => Assert.IsType<Wrapper>(thing));
+        Assert.Equal(["wrapped(thing)", "wrapped(other)"], all.Select(t => t.Describe()));
+    }
+
+    [Theory]
+    [InlineData(ServiceLifetime.Singleton)]
+    [InlineData(ServiceLifetime.Scoped)]
+    [InlineData(ServiceLifetime.Transient)]
+    public void Decorate_PreservesTheOriginalLifetime(ServiceLifetime lifetime) {
+        IServiceCollection services = new ServiceCollection();
+        services.Add(new ServiceDescriptor(typeof(IThing), typeof(Thing), lifetime));
+
+        DecoratorHelper.Decorate(services, typeof(IThing), (_, inner) => new Wrapper((IThing)inner));
+
+        Assert.Equal(lifetime, Assert.Single(services).Lifetime);
+    }
+
+    [Fact]
+    public void Decorate_LeavesOtherServicesAlone() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IThing, Thing>();
+        services.AddSingleton<IUnrelated, Unrelated>();
+
+        DecoratorHelper.Decorate(services, typeof(IThing), (_, inner) => new Wrapper((IThing)inner));
+
+        Assert.IsType<Unrelated>(services.BuildServiceProvider().GetRequiredService<IUnrelated>());
+    }
+
+    private interface IUnrelated;
+
+    private class Unrelated : IUnrelated;
+
+    [Fact]
+    public void Decorate_WithNoMatchingRegistration_DoesNothing() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IUnrelated, Unrelated>();
+
+        DecoratorHelper.Decorate(services, typeof(IThing), (_, inner) => new Wrapper((IThing)inner));
+
+        Assert.Single(services);
+    }
+
+    [Fact]
+    public void Decorate_AppliedTwice_NestsInApplicationOrder() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IThing, Thing>();
+
+        DecoratorHelper.Decorate(services, typeof(IThing), (_, inner) => new Wrapper((IThing)inner));
+        DecoratorHelper.Decorate(services, typeof(IThing), (_, inner) => new SecondWrapper((IThing)inner));
+
+        // Applied first ends up innermost.
+        Assert.Equal("second(wrapped(thing))", Resolve(services).Describe());
+    }
+
+    [Fact]
+    public void Decorate_ResolvesTheDecoratorsOwnDependencies() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IThing, Thing>();
+        services.AddSingleton<IUnrelated, Unrelated>();
+
+        DecoratorHelper.Decorate(services, typeof(IThing),
+            (provider, inner) => new DependentWrapper((IThing)inner, provider.GetRequiredService<IUnrelated>()));
+
+        var resolved = Assert.IsType<DependentWrapper>(Resolve(services));
+        Assert.NotNull(resolved.Dependency);
+    }
+
+    private class DependentWrapper(IThing inner, IUnrelated dependency) : IThing {
+        public IUnrelated Dependency { get; } = dependency;
+
+        public string Describe() => inner.Describe();
+    }
+
+    private interface IGeneric<T> {
+        string Describe();
+    }
+
+    private class GenericThing<T> : IGeneric<T> {
+        public string Describe() => $"generic<{typeof(T).Name}>";
+    }
+
+    private class GenericWrapper<T>(IGeneric<T> inner) : IGeneric<T> {
+        public string Describe() => $"wrapped({inner.Describe()})";
+    }
+
+    /// <summary>
+    /// Decorating an open generic has to wrap each closed registration of it. This is the shape a
+    /// mediator pipeline behaviour takes.
+    /// </summary>
+    [Fact]
+    public void Decorate_OpenGeneric_WrapsEveryClosedRegistration() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IGeneric<string>, GenericThing<string>>();
+        services.AddSingleton<IGeneric<int>, GenericThing<int>>();
+
+        DecoratorHelper.Decorate(services, typeof(IGeneric<>), (_, inner) => {
+            var argument = inner.GetType().GetInterfaces()
+                .First(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IGeneric<>))
+                .GetGenericArguments()[0];
+
+            return Activator.CreateInstance(typeof(GenericWrapper<>).MakeGenericType(argument), inner)!;
+        });
+
+        var provider = services.BuildServiceProvider();
+
+        Assert.Equal("wrapped(generic<String>)", provider.GetRequiredService<IGeneric<string>>().Describe());
+        Assert.Equal("wrapped(generic<Int32>)", provider.GetRequiredService<IGeneric<int>>().Describe());
+    }
+
+    [Fact]
+    public void Decorate_OpenGeneric_LeavesUnrelatedClosedTypesAlone() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IThing, Thing>();
+        services.AddSingleton<IGeneric<string>, GenericThing<string>>();
+
+        DecoratorHelper.Decorate(services, typeof(IGeneric<>), (_, inner) => inner);
+
+        Assert.IsType<Thing>(Resolve(services));
+    }
+
+    [Fact]
+    public void Decorate_KeyedRegistration_IsWrappedAndKeepsItsKey() {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IThing, Thing>("the-key");
+
+        DecoratorHelper.Decorate(services, typeof(IThing), (_, inner) => new Wrapper((IThing)inner));
+
+        var provider = services.BuildServiceProvider();
+        var resolved = provider.GetRequiredKeyedService<IThing>("the-key");
+
+        Assert.Equal("wrapped(thing)", resolved.Describe());
+    }
+}

--- a/tests/DependencyModules.Tests/RuntimeTests/DecoratorHelperTests.cs
+++ b/tests/DependencyModules.Tests/RuntimeTests/DecoratorHelperTests.cs
@@ -223,4 +223,70 @@ public class DecoratorHelperTests {
 
         Assert.Equal("wrapped(thing)", resolved.Describe());
     }
+
+    // --- the type-based overload generated code calls ---
+
+    [Fact]
+    public void DecorateByType_WrapsAndResolvesTheDecoratorsDependencies() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IThing, Thing>();
+        services.AddSingleton<IUnrelated, Unrelated>();
+
+        DecoratorHelper.Decorate(services, typeof(IThing), typeof(DependentWrapper));
+
+        var resolved = Assert.IsType<DependentWrapper>(Resolve(services));
+        Assert.NotNull(resolved.Dependency);
+    }
+
+    [Fact]
+    public void DecorateByType_PassesTheWrappedInstance() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IThing, Thing>();
+
+        DecoratorHelper.Decorate(services, typeof(IThing), typeof(Wrapper));
+
+        Assert.Equal("wrapped(thing)", Resolve(services).Describe());
+    }
+
+    [Fact]
+    public void DecorateByType_OpenGeneric_ClosesTheDecoratorPerRegistration() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IGeneric<string>, GenericThing<string>>();
+        services.AddSingleton<IGeneric<int>, GenericThing<int>>();
+
+        DecoratorHelper.Decorate(services, typeof(IGeneric<>), typeof(GenericWrapper<>));
+
+        var provider = services.BuildServiceProvider();
+
+        Assert.Equal("wrapped(generic<String>)", provider.GetRequiredService<IGeneric<string>>().Describe());
+        Assert.Equal("wrapped(generic<Int32>)", provider.GetRequiredService<IGeneric<int>>().Describe());
+    }
+
+    /// <summary>
+    /// Stacking open generic decorators means the wrapped instance is itself a decorator, so the
+    /// type arguments have to be discovered from whichever of them implements the service.
+    /// </summary>
+    [Fact]
+    public void DecorateByType_OpenGeneric_Stacks() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IGeneric<string>, GenericThing<string>>();
+
+        DecoratorHelper.Decorate(services, typeof(IGeneric<>), typeof(GenericWrapper<>));
+        DecoratorHelper.Decorate(services, typeof(IGeneric<>), typeof(GenericWrapper<>));
+
+        var provider = services.BuildServiceProvider();
+
+        Assert.Equal("wrapped(wrapped(generic<String>))", provider.GetRequiredService<IGeneric<string>>().Describe());
+    }
+
+    [Fact]
+    public void DecorateByType_StacksInApplicationOrder() {
+        var services = new ServiceCollection();
+        services.AddSingleton<IThing, Thing>();
+
+        DecoratorHelper.Decorate(services, typeof(IThing), typeof(Wrapper));
+        DecoratorHelper.Decorate(services, typeof(IThing), typeof(SecondWrapper));
+
+        Assert.Equal("second(wrapped(thing))", Resolve(services).Describe());
+    }
 }

--- a/tests/DependencyModules.Tests/RuntimeTests/DependencyRegistryTests.cs
+++ b/tests/DependencyModules.Tests/RuntimeTests/DependencyRegistryTests.cs
@@ -78,6 +78,75 @@ public class DependencyRegistryTests {
 
     private class KeyedMarker;
 
+    /// <summary>
+    /// Order controls how decorators nest: lower values are applied first and end up closer to the
+    /// implementation. Pipeline behaviours contributed by different packages rely on this, so the
+    /// ordering has to hold across every decorator in the registry, not just within one group.
+    /// </summary>
+    [Fact]
+    public void ApplyDecorators_AppliesInAscendingOrder() {
+        var applied = new List<string>();
+
+        DependencyRegistry<OrderedDecoratorMarker>.AddDecorator(_ => applied.Add("third"), 30);
+        DependencyRegistry<OrderedDecoratorMarker>.AddDecorator(_ => applied.Add("first"), 10);
+        DependencyRegistry<OrderedDecoratorMarker>.AddDecorator(_ => applied.Add("second"), 20);
+
+        DependencyRegistry<OrderedDecoratorMarker>.ApplyDecorators(new ServiceCollection());
+
+        Assert.Equal(["first", "second", "third"], applied);
+    }
+
+    private class OrderedDecoratorMarker;
+
+    [Fact]
+    public void ApplyDecorators_WithoutAnOrder_AppliesInRegistrationOrder() {
+        var applied = new List<string>();
+
+        DependencyRegistry<UnorderedDecoratorMarker>.AddDecorator(_ => applied.Add("first"));
+        DependencyRegistry<UnorderedDecoratorMarker>.AddDecorator(_ => applied.Add("second"));
+
+        DependencyRegistry<UnorderedDecoratorMarker>.ApplyDecorators(new ServiceCollection());
+
+        Assert.Equal(["first", "second"], applied);
+    }
+
+    private class UnorderedDecoratorMarker;
+
+    /// <summary>
+    /// Equal orders must not nest arbitrarily; the sort has to be stable so the result is
+    /// reproducible between runs.
+    /// </summary>
+    [Fact]
+    public void ApplyDecorators_WithEqualOrders_KeepsRegistrationOrder() {
+        var applied = new List<string>();
+
+        DependencyRegistry<StableDecoratorMarker>.AddDecorator(_ => applied.Add("first"), 5);
+        DependencyRegistry<StableDecoratorMarker>.AddDecorator(_ => applied.Add("second"), 5);
+        DependencyRegistry<StableDecoratorMarker>.AddDecorator(_ => applied.Add("third"), 5);
+
+        DependencyRegistry<StableDecoratorMarker>.ApplyDecorators(new ServiceCollection());
+
+        Assert.Equal(["first", "second", "third"], applied);
+    }
+
+    private class StableDecoratorMarker;
+
+    [Fact]
+    public void ApplyDecorators_MixesOrderedAndUnorderedRegistrations() {
+        var applied = new List<string>();
+
+        // An unordered decorator defaults to 0, so a negative order still sits inside it.
+        DependencyRegistry<MixedDecoratorMarker>.AddDecorator(_ => applied.Add("default"));
+        DependencyRegistry<MixedDecoratorMarker>.AddDecorator(_ => applied.Add("application"), 1000);
+        DependencyRegistry<MixedDecoratorMarker>.AddDecorator(_ => applied.Add("innermost"), -10);
+
+        DependencyRegistry<MixedDecoratorMarker>.ApplyDecorators(new ServiceCollection());
+
+        Assert.Equal(["innermost", "default", "application"], applied);
+    }
+
+    private class MixedDecoratorMarker;
+
     [Fact]
     public void ApplyDecorators_RunsSeparatelyFromServices() {
         DependencyRegistry<DecoratorMarker>.Add(services => services.AddSingleton<IThing, Thing>());

--- a/tests/DependencyModules.Tests/RuntimeTests/ModuleLoadingTests.cs
+++ b/tests/DependencyModules.Tests/RuntimeTests/ModuleLoadingTests.cs
@@ -106,6 +106,45 @@ public class ModuleLoadingTests {
         Assert.True(module.FeatureAppliedBeforeConfigure);
     }
 
+    /// <summary>
+    /// Regression test: ConfigureDecorators was declared on IServiceCollectionConfiguration and
+    /// never invoked by anything, so a module implementing it silently did nothing.
+    /// </summary>
+    [Fact]
+    public void LoadModules_InvokesConfigureDecorators() {
+        var module = new DecoratingModule();
+
+        DependencyRegistry<object>.LoadModules(new ServiceCollection(), module);
+
+        Assert.True(module.ConfigureDecoratorsCalled);
+    }
+
+    /// <summary>
+    /// Decoration rewrites existing registrations, so it has to run after every module has
+    /// registered its services or there would be nothing to decorate.
+    /// </summary>
+    [Fact]
+    public void LoadModules_RunsConfigureDecoratorsAfterAllServices() {
+        var decorating = new DecoratingModule();
+        var registering = new ConfiguringModule();
+
+        var collection = new ServiceCollection();
+        DependencyRegistry<object>.LoadModules(collection, decorating, registering);
+
+        Assert.True(decorating.ConfigureDecoratorsCalled);
+        Assert.Contains(typeof(IThing), decorating.ServicesVisibleWhenDecorating!);
+    }
+
+    [Fact]
+    public void LoadModules_CanDecorateARegistrationFromAnotherModule() {
+        var collection = new ServiceCollection();
+        DependencyRegistry<object>.LoadModules(collection, new DecoratingModule(), new ConfiguringModule());
+
+        var provider = collection.BuildServiceProvider();
+
+        Assert.IsType<DecoratedThing>(provider.GetService<IThing>());
+    }
+
     [Fact]
     public void LoadModules_AppliesFeaturesInOrder() {
         var module = new OrderedFeatureModule();
@@ -176,6 +215,39 @@ public class ModuleLoadingTests {
         public override bool Equals(object? obj) => obj is EquatableModule other && other.Key == Key;
 
         public override int GetHashCode() => Key.GetHashCode();
+    }
+
+    private class DecoratedThing(IThing inner) : IThing {
+        public IThing Inner { get; } = inner;
+    }
+
+    private class DecoratingModule : IDependencyModule, IServiceCollectionConfiguration {
+        public bool ConfigureDecoratorsCalled { get; private set; }
+
+        public IReadOnlyList<Type>? ServicesVisibleWhenDecorating { get; private set; }
+
+        public void PopulateServiceCollection(IServiceCollection serviceCollection) { }
+
+        public void ConfigureServices(IServiceCollection services) { }
+
+        public void ConfigureDecorators(IServiceCollection services) {
+            ConfigureDecoratorsCalled = true;
+            ServicesVisibleWhenDecorating = services.Select(descriptor => descriptor.ServiceType).ToList();
+
+            for (var i = services.Count - 1; i >= 0; i--) {
+                if (services[i].ServiceType != typeof(IThing)) {
+                    continue;
+                }
+
+                // Capture before replacing, or the factory closes over its own replacement.
+                var inner = services[i];
+                services[i] = new ServiceDescriptor(
+                    typeof(IThing),
+                    provider => new DecoratedThing(
+                        (IThing)ActivatorUtilities.CreateInstance(provider, inner.ImplementationType!)),
+                    inner.Lifetime);
+            }
+        }
     }
 
     private class ConfiguringModule : IDependencyModule, IServiceCollectionConfiguration {

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.GenericServiceRegistrations.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.GenericServiceRegistrations.verified.txt
@@ -26,6 +26,7 @@ namespace TestNamespace
 }
 
 // ---- TestModule.Module.g.cs ----
+using DependencyModules.Runtime.Helpers;
 using DependencyModules.Runtime.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
@@ -59,6 +60,12 @@ namespace TestNamespace
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();
+        }
+
+        [Browsable(false)]
+        global::System.Collections.Generic.IEnumerable<global::DependencyModules.Runtime.Helpers.DecoratorRegistration> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetDecorators()
+        {
+            return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetDecorators();
         }
 
         public override bool Equals(object? obj)

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.KeyedAndAsRegistrations.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.KeyedAndAsRegistrations.verified.txt
@@ -27,6 +27,7 @@ namespace TestNamespace
 }
 
 // ---- TestModule.Module.g.cs ----
+using DependencyModules.Runtime.Helpers;
 using DependencyModules.Runtime.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
@@ -60,6 +61,12 @@ namespace TestNamespace
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();
+        }
+
+        [Browsable(false)]
+        global::System.Collections.Generic.IEnumerable<global::DependencyModules.Runtime.Helpers.DecoratorRegistration> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetDecorators()
+        {
+            return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetDecorators();
         }
 
         public override bool Equals(object? obj)

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithAllServiceLifetimes.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithAllServiceLifetimes.verified.txt
@@ -30,6 +30,7 @@ namespace TestNamespace
 }
 
 // ---- TestModule.Module.g.cs ----
+using DependencyModules.Runtime.Helpers;
 using DependencyModules.Runtime.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
@@ -63,6 +64,12 @@ namespace TestNamespace
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();
+        }
+
+        [Browsable(false)]
+        global::System.Collections.Generic.IEnumerable<global::DependencyModules.Runtime.Helpers.DecoratorRegistration> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetDecorators()
+        {
+            return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetDecorators();
         }
 
         public override bool Equals(object? obj)

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithConstructorParametersAndProperties.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithConstructorParametersAndProperties.verified.txt
@@ -22,6 +22,7 @@ namespace TestNamespace
 }
 
 // ---- TestModule.Module.g.cs ----
+using DependencyModules.Runtime.Helpers;
 using DependencyModules.Runtime.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -56,6 +57,12 @@ namespace TestNamespace
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();
+        }
+
+        [Browsable(false)]
+        global::System.Collections.Generic.IEnumerable<global::DependencyModules.Runtime.Helpers.DecoratorRegistration> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetDecorators()
+        {
+            return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetDecorators();
         }
 
         public override bool Equals(object? obj)

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithCoverageExclusionDisabled.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithCoverageExclusionDisabled.verified.txt
@@ -21,6 +21,7 @@ namespace TestNamespace
 }
 
 // ---- TestModule.Module.g.cs ----
+using DependencyModules.Runtime.Helpers;
 using DependencyModules.Runtime.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
@@ -54,6 +55,12 @@ namespace TestNamespace
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();
+        }
+
+        [Browsable(false)]
+        global::System.Collections.Generic.IEnumerable<global::DependencyModules.Runtime.Helpers.DecoratorRegistration> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetDecorators()
+        {
+            return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetDecorators();
         }
 
         public override bool Equals(object? obj)

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.RecordModule.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.RecordModule.verified.txt
@@ -22,6 +22,7 @@ namespace TestNamespace
 }
 
 // ---- TestModule.Module.g.cs ----
+using DependencyModules.Runtime.Helpers;
 using DependencyModules.Runtime.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
@@ -55,6 +56,12 @@ namespace TestNamespace
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();
+        }
+
+        [Browsable(false)]
+        global::System.Collections.Generic.IEnumerable<global::DependencyModules.Runtime.Helpers.DecoratorRegistration> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetDecorators()
+        {
+            return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetDecorators();
         }
     }
     #nullable disable

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.RegistrationTypeVariants.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.RegistrationTypeVariants.verified.txt
@@ -32,6 +32,7 @@ namespace TestNamespace
 }
 
 // ---- TestModule.Module.g.cs ----
+using DependencyModules.Runtime.Helpers;
 using DependencyModules.Runtime.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
@@ -65,6 +66,12 @@ namespace TestNamespace
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();
+        }
+
+        [Browsable(false)]
+        global::System.Collections.Generic.IEnumerable<global::DependencyModules.Runtime.Helpers.DecoratorRegistration> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetDecorators()
+        {
+            return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetDecorators();
         }
 
         public override bool Equals(object? obj)

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.SimpleModule.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.SimpleModule.verified.txt
@@ -22,6 +22,7 @@ namespace TestNamespace
 }
 
 // ---- TestModule.Module.g.cs ----
+using DependencyModules.Runtime.Helpers;
 using DependencyModules.Runtime.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
@@ -55,6 +56,12 @@ namespace TestNamespace
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();
+        }
+
+        [Browsable(false)]
+        global::System.Collections.Generic.IEnumerable<global::DependencyModules.Runtime.Helpers.DecoratorRegistration> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetDecorators()
+        {
+            return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetDecorators();
         }
 
         public override bool Equals(object? obj)

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
@@ -18,6 +18,22 @@ namespace DependencyModules.Runtime.Attributes
         public System.Type? Realm { get; set; }
         public DependencyModules.Runtime.Attributes.RegistrationType Using { get; set; }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public class DecorateAttribute : System.Attribute
+    {
+        public DecorateAttribute(System.Type service, System.Type decorator) { }
+        public System.Type Decorator { get; }
+        public int Order { get; set; }
+        public System.Type Service { get; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public class DecoratorAttribute : System.Attribute
+    {
+        public DecoratorAttribute() { }
+        public int Order { get; set; }
+        public System.Type? Realm { get; set; }
+        public System.Type? Service { get; set; }
+    }
     [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class, Inherited=false)]
     public class DependencyModuleAttribute : System.Attribute
     {
@@ -87,6 +103,16 @@ namespace DependencyModules.Runtime.Features
 }
 namespace DependencyModules.Runtime.Helpers
 {
+    public static class DecoratorHelper
+    {
+        public static void Decorate(Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Type serviceType, System.Func<System.IServiceProvider, object, object> decoratorFactory) { }
+    }
+    public readonly struct DecoratorRegistration
+    {
+        public DecoratorRegistration(int order, DependencyModules.Runtime.Helpers.RegistryFunc registryFunc) { }
+        public int Order { get; }
+        public DependencyModules.Runtime.Helpers.RegistryFunc RegistryFunc { get; }
+    }
     public class DependencyRegistry<T>
     {
         public DependencyRegistry() { }
@@ -99,6 +125,7 @@ namespace DependencyModules.Runtime.Helpers
         public static int AddModule(params DependencyModules.Runtime.Interfaces.IDependencyModule[] modules) { }
         public static void ApplyDecorators(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
         public static void ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
+        public static System.Collections.Generic.IReadOnlyList<DependencyModules.Runtime.Helpers.DecoratorRegistration> GetDecorators() { }
         public static System.Collections.Generic.IEnumerable<object> GetModules(params object[] modules) { }
         public static void LoadModules(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection, params DependencyModules.Runtime.Interfaces.IDependencyModule[] dependencyModules) { }
     }
@@ -114,6 +141,8 @@ namespace DependencyModules.Runtime.Interfaces
         void InternalApplyDecorators(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection);
         [System.ComponentModel.Browsable(false)]
         void InternalApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection);
+        [System.ComponentModel.Browsable(false)]
+        System.Collections.Generic.IEnumerable<DependencyModules.Runtime.Helpers.DecoratorRegistration> InternalGetDecorators();
         [System.ComponentModel.Browsable(false)]
         System.Collections.Generic.IEnumerable<object> InternalGetModules();
         void PopulateServiceCollection(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection);

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
@@ -95,7 +95,7 @@ namespace DependencyModules.Runtime.Helpers
             where TInstance :  class { }
         public static int Add<TInstance>(System.Type implementationType, Microsoft.Extensions.DependencyInjection.ServiceLifetime lifetime = 2, object? serviceKey = null)
             where TInstance :  class { }
-        public static int AddDecorator(DependencyModules.Runtime.Helpers.RegistryFunc registryFunc) { }
+        public static int AddDecorator(DependencyModules.Runtime.Helpers.RegistryFunc registryFunc, int order = 0) { }
         public static int AddModule(params DependencyModules.Runtime.Interfaces.IDependencyModule[] modules) { }
         public static void ApplyDecorators(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
         public static void ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
@@ -106,6 +106,7 @@ namespace DependencyModules.Runtime.Helpers
     public static class DecoratorHelper
     {
         public static void Decorate(Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Type serviceType, System.Func<System.IServiceProvider, object, object> decoratorFactory) { }
+        public static void Decorate(Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.Type serviceType, System.Type decoratorType) { }
     }
     public readonly struct DecoratorRegistration
     {

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -702,6 +702,44 @@ namespace CSharpAuthor
         protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
     }
 }
+namespace DependencyModules.SourceGenerator
+{
+    public class DecoratorSourceGenerator : DependencyModules.SourceGenerator.Impl.BaseAttributeSourceGenerator<DependencyModules.SourceGenerator.Impl.Models.DecoratorModel>
+    {
+        public DecoratorSourceGenerator() { }
+        protected override string LoggerName { get; }
+        protected override System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> AttributeTypes() { }
+        protected override DependencyModules.SourceGenerator.Impl.Models.DecoratorModel GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        protected override void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right",
+                "Left",
+                "Right"})] System.ValueTuple<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>, System.Collections.Immutable.ImmutableArray<DependencyModules.SourceGenerator.Impl.Models.DecoratorModel>> inputData, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
+        protected override System.Collections.Generic.IEqualityComparer<DependencyModules.SourceGenerator.Impl.Models.DecoratorModel> GetComparer() { }
+    }
+    public class ServiceSourceGenerator : DependencyModules.SourceGenerator.Impl.BaseAttributeSourceGenerator<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>
+    {
+        public ServiceSourceGenerator() { }
+        protected override System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> AttributeTypes() { }
+        protected override DependencyModules.SourceGenerator.Impl.Models.ServiceModel GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        protected override void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right",
+                "Left",
+                "Right"})] System.ValueTuple<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>, System.Collections.Immutable.ImmutableArray<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>> inputData, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
+        protected void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext context, DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel, System.Collections.Immutable.ImmutableArray<DependencyModules.SourceGenerator.Impl.Models.ServiceModel> serviceModels, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
+        protected override System.Collections.Generic.IEqualityComparer<DependencyModules.SourceGenerator.Impl.Models.ServiceModel> GetComparer() { }
+    }
+    [Microsoft.CodeAnalysis.Generator]
+    public class SourceGenerator : DependencyModules.SourceGenerator.Impl.BaseSourceGenerator
+    {
+        public SourceGenerator() { }
+        protected override System.Collections.Generic.IEnumerable<DependencyModules.SourceGenerator.Impl.IDependencyModuleSourceGenerator> AttributeSourceGenerators() { }
+        protected override void SetupRootGenerator(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right"})] Microsoft.CodeAnalysis.IncrementalValueProvider<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>> valuesProvider) { }
+    }
+}
 namespace DependencyModules.SourceGenerator.Impl
 {
     public abstract class BaseAttributeSourceGenerator<T> : DependencyModules.SourceGenerator.Impl.IDependencyModuleSourceGenerator
@@ -760,6 +798,11 @@ namespace DependencyModules.SourceGenerator.Impl
         public override int GetHashCode() { }
         protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
     }
+    public class DecoratorFileWriter
+    {
+        public DecoratorFileWriter() { }
+        public string Write(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.DecoratorModel> decorators) { }
+    }
     public class DependencyFileWriter
     {
         public DependencyFileWriter(DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
@@ -767,6 +810,7 @@ namespace DependencyModules.SourceGenerator.Impl
     }
     public static class DependencyModuleDiagnostics
     {
+        public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor AmbiguousDecoratorOrder;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor GeneratorFailure;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ModuleMustBePartial;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ServiceCannotBeConstructed;
@@ -792,6 +836,8 @@ namespace DependencyModules.SourceGenerator.Impl
             {
                 public const string Namespace = "DependencyModules.Runtime.Attributes";
                 public static readonly CSharpAuthor.ITypeDefinition CrossWireServiceAttribute;
+                public static readonly CSharpAuthor.ITypeDefinition DecorateAttribute;
+                public static readonly CSharpAuthor.ITypeDefinition DecoratorAttribute;
                 public static readonly CSharpAuthor.ITypeDefinition DependencyModuleAttribute;
                 public static readonly CSharpAuthor.ITypeDefinition ScopedServiceAttribute;
                 public static readonly CSharpAuthor.ITypeDefinition SingletonServiceAttribute;
@@ -807,6 +853,8 @@ namespace DependencyModules.SourceGenerator.Impl
             public static class Helpers
             {
                 public const string Namespace = "DependencyModules.Runtime.Helpers";
+                public static readonly CSharpAuthor.ITypeDefinition DecoratorHelper;
+                public static readonly CSharpAuthor.ITypeDefinition DecoratorRegistration;
             }
             public static class Interfaces
             {
@@ -880,6 +928,22 @@ namespace DependencyModules.SourceGenerator.Impl.Models
         public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> Parameters { get; init; }
         public virtual bool Equals(DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? other) { }
         public override int GetHashCode() { }
+    }
+    public class DecoratorModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.DecoratorModel>
+    {
+        public static readonly DependencyModules.SourceGenerator.Impl.Models.DecoratorModel Ignore;
+        public DecoratorModel(CSharpAuthor.ITypeDefinition ServiceType, CSharpAuthor.ITypeDefinition DecoratorType, int Order, CSharpAuthor.ITypeDefinition? Realm) { }
+        public CSharpAuthor.ITypeDefinition DecoratorType { get; init; }
+        public bool IsIgnored { get; }
+        public int Order { get; init; }
+        public CSharpAuthor.ITypeDefinition? Realm { get; init; }
+        public CSharpAuthor.ITypeDefinition ServiceType { get; init; }
+    }
+    public class DecoratorModelComparer : System.Collections.Generic.IEqualityComparer<DependencyModules.SourceGenerator.Impl.Models.DecoratorModel>
+    {
+        public DecoratorModelComparer() { }
+        public bool Equals(DependencyModules.SourceGenerator.Impl.Models.DecoratorModel? x, DependencyModules.SourceGenerator.Impl.Models.DecoratorModel? y) { }
+        public int GetHashCode(DependencyModules.SourceGenerator.Impl.Models.DecoratorModel obj) { }
     }
     public class DependencyModuleConfigurationModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>
     {
@@ -1071,6 +1135,11 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities
         protected abstract bool TestForTypes(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken token);
         public bool Where(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken token) { }
     }
+    public static class DecoratorModelUtility
+    {
+        public static DependencyModules.SourceGenerator.Impl.Models.DecoratorModel? GetDecoratorModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Collections.Generic.IEnumerable<DependencyModules.SourceGenerator.Impl.Models.DecoratorModel> GetModuleDeclaredDecorators(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel) { }
+    }
     public class EntryModelUtil
     {
         public EntryModelUtil() { }
@@ -1161,30 +1230,5 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities
     {
         public UsageAttributeComponent(string usage) { }
         protected override void WriteComponentOutput(CSharpAuthor.IOutputContext outputContext) { }
-    }
-}
-namespace DependencyModules.SourceGenerator
-{
-    public class ServiceSourceGenerator : DependencyModules.SourceGenerator.Impl.BaseAttributeSourceGenerator<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>
-    {
-        public ServiceSourceGenerator() { }
-        protected override System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> AttributeTypes() { }
-        protected override DependencyModules.SourceGenerator.Impl.Models.ServiceModel GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
-        protected override void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
-                "Left",
-                "Right",
-                "Left",
-                "Right"})] System.ValueTuple<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>, System.Collections.Immutable.ImmutableArray<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>> inputData, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
-        protected void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext context, DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel, System.Collections.Immutable.ImmutableArray<DependencyModules.SourceGenerator.Impl.Models.ServiceModel> serviceModels, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
-        protected override System.Collections.Generic.IEqualityComparer<DependencyModules.SourceGenerator.Impl.Models.ServiceModel> GetComparer() { }
-    }
-    [Microsoft.CodeAnalysis.Generator]
-    public class SourceGenerator : DependencyModules.SourceGenerator.Impl.BaseSourceGenerator
-    {
-        public SourceGenerator() { }
-        protected override System.Collections.Generic.IEnumerable<DependencyModules.SourceGenerator.Impl.IDependencyModuleSourceGenerator> AttributeSourceGenerators() { }
-        protected override void SetupRootGenerator(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
-                "Left",
-                "Right"})] Microsoft.CodeAnalysis.IncrementalValueProvider<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>> valuesProvider) { }
     }
 }


### PR DESCRIPTION
Adds working decorator support and fixes two defects found along the way. Four commits, each independently reviewable.

```csharp
[SingletonService]
public class Repository : IRepository { public string Get() => "data"; }

[Decorator(Order = 10)]
public class CachingRepository(IRepository inner) : IRepository { ... }

[Decorator(Order = 20)]
public class LoggingRepository(IRepository inner) : IRepository { ... }
```

Resolves to `logged(cached(data))` — lower order nests closer to the implementation.

## Defects fixed

**`IServiceCollectionConfiguration.ConfigureDecorators` was never invoked.** It was declared on the public interface and the only reference to it anywhere was its own declaration, so a module implementing it silently did nothing. `ApplyServices` already invoked `ConfigureServices` the same way. Verified against a real project: the same scenario returned `"hello"` before and `"HELLO!"` after. Fixed now rather than later because the alternative was removing the member, and 1.0 is the last point at which that isn't breaking.

**Decorator order was per-module, not global.** Proven by probe before changing anything: with `Order = 10` in one module and `Order = 1000` in another, they applied in the *opposite* order to their values — module discovery order outranked the declared order. The documented convention of framework packages using `0–999` and applications `1000+` would not have held, and fixing it after 1.0 would silently re-nest existing decorators.

## What was added

| Piece | Notes |
|---|---|
| `AddDecorator(func, order = 0)` | Optional and trailing. It's called by generated code, so a required parameter improves nobody's ergonomics — and this keeps it source-compatible |
| `IDependencyModule.InternalGetDecorators()` | Default interface method. Hands decorators to the runtime so all modules' can be sorted together, mirroring how `ApplyFeatures` already collects and sorts |
| `DecoratorHelper` | The descriptor rewrite, in tested runtime code rather than emitted |
| `[Decorator]` / `[Decorate]` | Class-level and module-level declaration |
| `DecoratorSourceGenerator` | Reuses the existing `BaseAttributeSourceGenerator` pipeline |
| DM0007 | Two decorators of one service sharing an order |

## Why the rewrite is a runtime helper

Generated code emits two type references:

```csharp
DecoratorHelper.Decorate(services, typeof(IRepository), typeof(CachingRepository));
```

The parts that are easy to get wrong are then written and tested once instead of reproduced at each call site:

- **capturing the descriptor before overwriting the slot** — reading the slot inside the factory closes over the replacement and recurses until the stack runs out, far from the cause. Has a dedicated test
- decorating **every** matching registration, not just the first
- **preserving the original lifetime**
- all three descriptor shapes — implementation type, factory, instance — plus keyed registrations
- closing an open generic decorator against whichever type arguments each registration used

It also means `ActivatorUtilities` resolves the decorator's own dependencies, consistent with how the library already lets M.E.DI activate services, so no new reflection is introduced.

This seam is what makes interceptors additive later: they generate a wrapper type and register it through this same rewrite.

## Two things that needed a second pass

**Registrations existed but nothing collected them.** The first end-to-end run returned `data`: the `AddDecorator` calls were generated, but no module emitted `InternalGetDecorators`, so the runtime never saw them. Now emitted unconditionally, since a module can gain decorators from a source the registrations file never saw.

**A generic decorator names its service closed over its own type parameters** — `IHandler<T>`, which is not a legal `typeof` argument. The unbound `IHandler<>` is what gets emitted and what the runtime matches by.

Also `ExcludeFromCodeCoverage` moved onto the generated methods; it isn't `AllowMultiple` and the partial class already carries it from the registrations file.

## Design doc

`docs/design/convention-registration-and-decorators.md` records the decisions, including what was **rejected** and why: scanning referenced assemblies is out of scope because the module system already covers code you own and it contradicts the compile-time goal; carrying the service type on `AddDecorator` was rejected despite being the last cheap moment to add it.

Convention registration, generated forwarding, and interceptors remain design only — all additive to what's here.

## Verification

**428 tests** (354 unit + 72 integration + 2 web), clean build with 0 warnings, coverage **87.7%** gated at 85, package verification green.

Behaviour is asserted by resolving from real containers built from generated code, not by matching generated text. The API approval test caught every public surface change in this branch; each diff was reviewed before being accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012QPG3s4DPZZ6E4qJ6q8kSs