### PR TITLE
Match attributes with ForAttributeWithMetadataName

### DIFF
--- a/src/DependencyModules.SourceGenerator.Impl/BaseAttributeSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/BaseAttributeSourceGenerator.cs
@@ -16,21 +16,101 @@ public abstract class BaseAttributeSourceGenerator<T> : IDependencyModuleSourceG
 
     public void SetupGenerator(IncrementalGeneratorInitializationContext context,
         IncrementalValuesProvider<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> incrementalValueProvider) {
-        var classSelector = new SyntaxSelector<MemberDeclarationSyntax>(AttributeTypes().ToArray());
 
-        var serviceModelProvider = context.SyntaxProvider.CreateSyntaxProvider(
-            classSelector.Where,
-            GenerateAttributeModel
-        ).WithComparer(GetComparer());
+        var attributeTypes = AttributeTypes().ToArray();
 
-        var collection =
-            serviceModelProvider.Collect();
+        if (attributeTypes.Length == 0) {
+            return;
+        }
 
         context.RegisterSourceOutput(
-            incrementalValueProvider.Collect().Combine(collection),
+            incrementalValueProvider.Collect().Combine(CollectModels(context, attributeTypes)),
             WrapGenerateSourceOutput
         );
     }
+
+    /// <summary>
+    /// One provider per attribute, merged.
+    /// </summary>
+    /// <remarks>
+    /// <c>ForAttributeWithMetadataName</c> takes a single name, so an attribute set needs one
+    /// provider each. They share Roslyn's attribute index, so several indexed lookups still cost far
+    /// less than the one visit of every syntax node this replaced.
+    /// </remarks>
+    private IncrementalValueProvider<ImmutableArray<T>> CollectModels(
+        IncrementalGeneratorInitializationContext context, ITypeDefinition[] attributeTypes) {
+
+        IncrementalValueProvider<ImmutableArray<T>>? merged = null;
+
+        foreach (var attributeType in attributeTypes) {
+            var owner = attributeType;
+
+            var provider = context.SyntaxProvider.ForAttributeWithMetadataName(
+                    MetadataName(owner),
+                    static (node, _) => node is MemberDeclarationSyntax,
+                    (syntaxContext, cancellation) =>
+                        GenerateOwnedModel(syntaxContext, cancellation, attributeTypes, owner))
+                .WithComparer(GetComparer())
+                .Collect();
+
+            merged = merged == null
+                ? provider
+                : merged.Value.Combine(provider).Select(static (pair, _) => pair.Left.AddRange(pair.Right));
+        }
+
+        return merged!.Value;
+    }
+
+    /// <summary>
+    /// Builds the model only from the provider that owns the declaration.
+    /// </summary>
+    /// <remarks>
+    /// A declaration carrying two of these attributes — <c>[SingletonService] [CrossWireService]</c>
+    /// is a supported pair — is produced by two providers. The model is built from the whole
+    /// declaration rather than from the attribute that triggered it, so both would be identical and
+    /// every registration would be emitted twice. The first attribute present, in the order the
+    /// generator declares them, is the one that builds it.
+    /// </remarks>
+    private T GenerateOwnedModel(
+        GeneratorAttributeSyntaxContext context,
+        CancellationToken cancellation,
+        ITypeDefinition[] attributeTypes,
+        ITypeDefinition owner) {
+
+        var present = context.TargetSymbol.GetAttributes();
+
+        foreach (var candidate in attributeTypes) {
+            if (!IsPresent(present, candidate)) {
+                continue;
+            }
+
+            return candidate.Equals(owner) ? GenerateAttributeModel(context, cancellation) : IgnoredModel;
+        }
+
+        return GenerateAttributeModel(context, cancellation);
+    }
+
+    private static bool IsPresent(ImmutableArray<AttributeData> present, ITypeDefinition candidate) {
+        foreach (var attribute in present) {
+            if (attribute.AttributeClass is { } attributeClass &&
+                attributeClass.Name == candidate.Name &&
+                NamespaceOf(attributeClass) == candidate.Namespace) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string NamespaceOf(INamedTypeSymbol symbol) =>
+        symbol.ContainingNamespace is { IsGlobalNamespace: false } containing
+            ? containing.ToDisplayString()
+            : "";
+
+    private static string MetadataName(ITypeDefinition attributeType) =>
+        string.IsNullOrEmpty(attributeType.Namespace)
+            ? attributeType.Name
+            : attributeType.Namespace + "." + attributeType.Name;
 
     private void WrapGenerateSourceOutput(SourceProductionContext context,
         (ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Left, ImmutableArray<T> Right) data) {
@@ -62,5 +142,11 @@ public abstract class BaseAttributeSourceGenerator<T> : IDependencyModuleSourceG
 
     protected abstract IEqualityComparer<T> GetComparer();
 
-    protected abstract T GenerateAttributeModel(GeneratorSyntaxContext arg1, CancellationToken arg2);
+    protected abstract T GenerateAttributeModel(GeneratorAttributeSyntaxContext arg1, CancellationToken arg2);
+
+    /// <summary>
+    /// The sentinel this generator emits for a declaration it does not own. Every model type already
+    /// has one, and the writers already skip it.
+    /// </summary>
+    protected abstract T IgnoredModel { get; }
 }

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/AttributeModelHelper.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/AttributeModelHelper.cs
@@ -9,7 +9,7 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities;
 public static class AttributeModelHelper {
 
     public static IReadOnlyList<AttributeModel> GetAttributeModels(
-        GeneratorSyntaxContext context,
+        SyntaxTransformContext context,
         SyntaxNode node,
         CancellationToken cancellationToken,
         Func<AttributeSyntax, bool>? filter = null) {
@@ -36,7 +36,7 @@ public static class AttributeModelHelper {
     }
 
     public static AttributeClassInfo GetAttributeClassInfo(
-        GeneratorSyntaxContext context,
+        SyntaxTransformContext context,
         CancellationToken cancellationToken) {
         var propertyList = new List<PropertyInfoModel>();
 
@@ -69,7 +69,7 @@ public static class AttributeModelHelper {
     }
 
     public static IEnumerable<AttributeModel> GetAttributes(
-        GeneratorSyntaxContext context,
+        SyntaxTransformContext context,
         SyntaxList<AttributeListSyntax> attributeListSyntax,
         CancellationToken cancellationToken,
         Func<AttributeSyntax, bool>? filter = null) {
@@ -88,14 +88,14 @@ public static class AttributeModelHelper {
         }
     }
 
-    public static AttributeModel? GetAttribute(GeneratorSyntaxContext context, AttributeSyntax attribute) {
+    public static AttributeModel? GetAttribute(SyntaxTransformContext context, AttributeSyntax attribute) {
         var operation = ModelExtensions.GetTypeInfo(context.SemanticModel, attribute);
 
         return operation.Type != null ? InternalAttributeModel(context, attribute, operation) : null;
     }
 
     private static AttributeModel InternalAttributeModel(
-        GeneratorSyntaxContext context, AttributeSyntax attribute, TypeInfo operation) {
+        SyntaxTransformContext context, AttributeSyntax attribute, TypeInfo operation) {
         var arguments = new List<AttributeArgumentValue>();
         var properties = new List<AttributeArgumentValue>();
 
@@ -154,7 +154,7 @@ public static class AttributeModelHelper {
             GetInterfaces(context, attribute));
     }
 
-    private static object? GetOperationValue(GeneratorSyntaxContext context, IOperation operationValue) {
+    private static object? GetOperationValue(SyntaxTransformContext context, IOperation operationValue) {
         if (operationValue.ConstantValue.HasValue) {
             return operationValue.ConstantValue.Value;
         }
@@ -162,7 +162,7 @@ public static class AttributeModelHelper {
         return GetOperationValue(context, operationValue.Syntax);
     }
 
-    private static object GetOperationValue(GeneratorSyntaxContext context, SyntaxNode syntaxNode) {
+    private static object GetOperationValue(SyntaxTransformContext context, SyntaxNode syntaxNode) {
 
         if (syntaxNode is CollectionExpressionSyntax collectionExpressionSyntax) {
             var collection = new List<object>();
@@ -194,7 +194,7 @@ public static class AttributeModelHelper {
     }
 
     private static IReadOnlyList<ITypeDefinition> GetInterfaces(
-        GeneratorSyntaxContext context, AttributeSyntax attribute) {
+        SyntaxTransformContext context, AttributeSyntax attribute) {
         var interfaces = new List<ITypeDefinition>();
 
         var symbol =

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/BaseMethodHelper.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/BaseMethodHelper.cs
@@ -8,7 +8,7 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities;
 public static class BaseMethodHelper {
     public static IReadOnlyList<ParameterInfoModel> GetMethodParameters(
         this BaseMethodDeclarationSyntax methodDeclarationSyntax,
-        GeneratorSyntaxContext context,
+        SyntaxTransformContext context,
         CancellationToken cancellationToken
         ) {
         var parameterList = methodDeclarationSyntax.ParameterList;
@@ -16,7 +16,7 @@ public static class BaseMethodHelper {
         return GetParameters(parameterList, context, cancellationToken);
     }
 
-    public static IReadOnlyList<ParameterInfoModel> GetParameters(this ParameterListSyntax? parameterList, GeneratorSyntaxContext context, CancellationToken cancellationToken) {
+    public static IReadOnlyList<ParameterInfoModel> GetParameters(this ParameterListSyntax? parameterList, SyntaxTransformContext context, CancellationToken cancellationToken) {
         if (parameterList == null) {
             return Array.Empty<ParameterInfoModel>();
         }

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/DecoratorModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/DecoratorModelUtility.cs
@@ -14,7 +14,7 @@ public static class DecoratorModelUtility {
     /// <summary>
     /// Reads a <c>[Decorator]</c> class declaration.
     /// </summary>
-    public static DecoratorModel? GetDecoratorModel(GeneratorSyntaxContext context, CancellationToken cancellationToken) {
+    public static DecoratorModel? GetDecoratorModel(SyntaxTransformContext context, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
         if (context.Node is not TypeDeclarationSyntax typeDeclarationSyntax) {
@@ -103,7 +103,7 @@ public static class DecoratorModelUtility {
     /// </summary>
     private static ITypeDefinition? InferDecoratedService(
         TypeDeclarationSyntax typeDeclarationSyntax,
-        GeneratorSyntaxContext context,
+        SyntaxTransformContext context,
         IReadOnlyList<ITypeDefinition> implemented) {
 
         if (implemented.Count == 0) {
@@ -122,7 +122,7 @@ public static class DecoratorModelUtility {
     }
 
     private static IEnumerable<ITypeDefinition> GetConstructorParameterTypes(
-        TypeDeclarationSyntax typeDeclarationSyntax, GeneratorSyntaxContext context) {
+        TypeDeclarationSyntax typeDeclarationSyntax, SyntaxTransformContext context) {
 
         if (typeDeclarationSyntax.ParameterList != null) {
             foreach (var parameter in typeDeclarationSyntax.ParameterList.Parameters) {
@@ -146,7 +146,7 @@ public static class DecoratorModelUtility {
     }
 
     private static IReadOnlyList<ITypeDefinition> GetImplementedInterfaces(
-        TypeDeclarationSyntax typeDeclarationSyntax, GeneratorSyntaxContext context) {
+        TypeDeclarationSyntax typeDeclarationSyntax, SyntaxTransformContext context) {
 
         var interfaces = new List<ITypeDefinition>();
 
@@ -180,7 +180,7 @@ public static class DecoratorModelUtility {
             generic.TypeArguments.Select(_ => (ITypeDefinition)TypeDefinition.Get("", "")).ToArray());
     }
 
-    private static ITypeDefinition GetDeclaredType(TypeDeclarationSyntax typeDeclarationSyntax, GeneratorSyntaxContext context) {
+    private static ITypeDefinition GetDeclaredType(TypeDeclarationSyntax typeDeclarationSyntax, SyntaxTransformContext context) {
         var name = typeDeclarationSyntax.Identifier.ToString();
 
         foreach (var containing in typeDeclarationSyntax.Ancestors().OfType<TypeDeclarationSyntax>()) {
@@ -200,7 +200,7 @@ public static class DecoratorModelUtility {
         return TypeDefinition.Get(namespaceName, name);
     }
 
-    private static ITypeDefinition? GetTypeOfArgument(AttributeArgumentSyntax argument, GeneratorSyntaxContext context) {
+    private static ITypeDefinition? GetTypeOfArgument(AttributeArgumentSyntax argument, SyntaxTransformContext context) {
         return argument.Expression is TypeOfExpressionSyntax typeOf
             ? typeOf.Type.GetTypeDefinition(context)
             : null;

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/InterceptorModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/InterceptorModelUtility.cs
@@ -23,7 +23,7 @@ public static class InterceptorModelUtility {
     /// A diagnostic cannot be raised from here — the transform holds no context that can.
     /// </returns>
     public static InterceptorModel GetInterceptorModel(
-        GeneratorSyntaxContext context, CancellationToken cancellationToken) {
+        SyntaxTransformContext context, CancellationToken cancellationToken) {
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -158,7 +158,7 @@ public static class InterceptorModelUtility {
 
     private static void ReadAttribute(
         AttributeSyntax attribute,
-        GeneratorSyntaxContext context,
+        SyntaxTransformContext context,
         CancellationToken cancellationToken,
         List<INamedTypeSymbol> interceptors,
         ref int order,
@@ -199,7 +199,7 @@ public static class InterceptorModelUtility {
     }
 
     private static INamedTypeSymbol? ResolveType(
-        TypeOfExpressionSyntax typeOf, GeneratorSyntaxContext context, CancellationToken cancellationToken) =>
+        TypeOfExpressionSyntax typeOf, SyntaxTransformContext context, CancellationToken cancellationToken) =>
         context.SemanticModel.GetTypeInfo(typeOf.Type, cancellationToken).Type as INamedTypeSymbol;
 
     /// <summary>

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
@@ -24,7 +24,7 @@ public class ServiceModelUtility {
     };
 
     public static ServiceModel? GetServiceModel(
-        GeneratorSyntaxContext context, CancellationToken cancellationToken) {
+        SyntaxTransformContext context, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
         if (context.Node is ClassDeclarationSyntax or RecordDeclarationSyntax) {
             return GetClassDeclarationServiceModel(context, cancellationToken);
@@ -37,7 +37,7 @@ public class ServiceModelUtility {
         return null;
     }
 
-    private static ServiceModel? MethodDeclarationServiceModel(GeneratorSyntaxContext context, MethodDeclarationSyntax methodDeclarationSyntax, CancellationToken cancellationToken) {
+    private static ServiceModel? MethodDeclarationServiceModel(SyntaxTransformContext context, MethodDeclarationSyntax methodDeclarationSyntax, CancellationToken cancellationToken) {
         // only support public or internal factory methods
         if (methodDeclarationSyntax.Modifiers.Any(
                 m => m.IsKind(SyntaxKind.PrivateKeyword) || m.IsKind(SyntaxKind.ProtectedKeyword))) {
@@ -67,7 +67,7 @@ public class ServiceModelUtility {
             RegistrationFeature.None);
     }
 
-    private static ServiceFactoryModel? GetFactoryModel(GeneratorSyntaxContext context, MethodDeclarationSyntax methodDeclarationSyntax, CancellationToken cancellationToken) {
+    private static ServiceFactoryModel? GetFactoryModel(SyntaxTransformContext context, MethodDeclarationSyntax methodDeclarationSyntax, CancellationToken cancellationToken) {
         var factoryClass = methodDeclarationSyntax.FirstAncestorOrSelf<TypeDeclarationSyntax>();
         if (factoryClass == null) {
             return null;
@@ -102,7 +102,7 @@ public class ServiceModelUtility {
         return features;
     }
 
-    private static ServiceModel? GetClassDeclarationServiceModel(GeneratorSyntaxContext context, CancellationToken cancellationToken) {
+    private static ServiceModel? GetClassDeclarationServiceModel(SyntaxTransformContext context, CancellationToken cancellationToken) {
         var classDefinition = GetClassDefinition(context);
 
         if (classDefinition == null) {
@@ -145,7 +145,7 @@ public class ServiceModelUtility {
             GetConstructionFeatures(context.Node));
     }
 
-    public static ConstructorInfoModel? GetConstructorInfo(GeneratorSyntaxContext context, SyntaxNode node, CancellationToken cancellationToken) {
+    public static ConstructorInfoModel? GetConstructorInfo(SyntaxTransformContext context, SyntaxNode node, CancellationToken cancellationToken) {
         var constructorList = new List<ConstructorDeclarationSyntax>();
 
         foreach (var constructor in node.DescendantNodes().OfType<ConstructorDeclarationSyntax>()) {
@@ -201,7 +201,7 @@ public class ServiceModelUtility {
         return component;
     }
 
-    private static ITypeDefinition? GetClassDefinition(GeneratorSyntaxContext context) {
+    private static ITypeDefinition? GetClassDefinition(SyntaxTransformContext context) {
         ITypeDefinition? classTypeDefinition = null;
 
         if (context.Node is TypeDeclarationSyntax typeDeclarationSyntax) {
@@ -246,7 +246,7 @@ public class ServiceModelUtility {
         return name;
     }
 
-    private static List<ServiceRegistrationModel> GetRegistrations(GeneratorSyntaxContext context, ITypeDefinition classDefinition, IReadOnlyList<AttributeModel> attributes, CancellationToken cancellationToken) {
+    private static List<ServiceRegistrationModel> GetRegistrations(SyntaxTransformContext context, ITypeDefinition classDefinition, IReadOnlyList<AttributeModel> attributes, CancellationToken cancellationToken) {
         var list = new List<ServiceRegistrationModel>();
 
         foreach (var attributeSyntax in
@@ -269,7 +269,7 @@ public class ServiceModelUtility {
         return list;
     }
 
-    private static IEnumerable<ServiceRegistrationModel> GetCrossWiredService(GeneratorSyntaxContext context, AttributeSyntax attributeSyntax, ITypeDefinition classDefinition) {
+    private static IEnumerable<ServiceRegistrationModel> GetCrossWiredService(SyntaxTransformContext context, AttributeSyntax attributeSyntax, ITypeDefinition classDefinition) {
 
         RegistrationType? registrationType = null;
         ITypeDefinition? realm = null;
@@ -346,7 +346,7 @@ public class ServiceModelUtility {
         return ServiceLifestyle.Singleton;
     }
 
-    private static ServiceRegistrationModel GetServiceRegistration(GeneratorSyntaxContext context, AttributeSyntax attributeSyntax, ITypeDefinition classDefinition) {
+    private static ServiceRegistrationModel GetServiceRegistration(SyntaxTransformContext context, AttributeSyntax attributeSyntax, ITypeDefinition classDefinition) {
         var lifestyle = ServiceLifestyle.Transient;
 
         if (attributeSyntax.Name.ToString().StartsWith("Singleton")) {
@@ -413,11 +413,11 @@ public class ServiceModelUtility {
     }
 
     private static ITypeDefinition GetServiceTypeFromClass(
-        GeneratorSyntaxContext context, ITypeDefinition classDefinition) {
+        SyntaxTransformContext context, ITypeDefinition classDefinition) {
         return GetBaseTypeRegistration(context) ?? classDefinition;
     }
 
-    private static ITypeDefinition? GetBaseTypeRegistration(GeneratorSyntaxContext context) {
+    private static ITypeDefinition? GetBaseTypeRegistration(SyntaxTransformContext context) {
         if (context.Node is TypeDeclarationSyntax typeDeclarationSyntax) {
             if (typeDeclarationSyntax.BaseList != null) {
                 INamedTypeSymbol? baseTypeSymbol = null;
@@ -453,7 +453,7 @@ public class ServiceModelUtility {
     }
 
 
-    private static ITypeDefinition? GetBaseInterface(GeneratorSyntaxContext context, INamedTypeSymbol baseTypeSymbol) {
+    private static ITypeDefinition? GetBaseInterface(SyntaxTransformContext context, INamedTypeSymbol baseTypeSymbol) {
         foreach (var interfaceSymbol in baseTypeSymbol.Interfaces) {
             var interfaceType =
                 interfaceSymbol.GetTypeDefinitionFromNamedSymbol();

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/SyntaxTransformContext.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/SyntaxTransformContext.cs
@@ -1,0 +1,37 @@
+using Microsoft.CodeAnalysis;
+
+namespace DependencyModules.SourceGenerator.Impl.Utilities;
+
+/// <summary>
+/// The node being transformed and the semantic model to read it with, independent of which provider
+/// produced it.
+/// </summary>
+/// <remarks>
+/// Roslyn hands a different context type to each kind of provider —
+/// <see cref="GeneratorSyntaxContext"/> from <c>CreateSyntaxProvider</c> and
+/// <see cref="GeneratorAttributeSyntaxContext"/> from <c>ForAttributeWithMetadataName</c> — and
+/// neither is publicly constructible, so a helper written against one cannot be reused by the other.
+/// Everything below the provider takes this instead, and the implicit conversions keep the call sites
+/// identical whichever provider they came from.
+/// </remarks>
+public readonly struct SyntaxTransformContext {
+
+    public SyntaxTransformContext(SyntaxNode node, SemanticModel semanticModel) {
+        Node = node;
+        SemanticModel = semanticModel;
+    }
+
+    public SyntaxNode Node { get; }
+
+    public SemanticModel SemanticModel { get; }
+
+    public static implicit operator SyntaxTransformContext(GeneratorSyntaxContext context) =>
+        new(context.Node, context.SemanticModel);
+
+    /// <summary>
+    /// The target node is the declaration the attribute was found on, which is the node a
+    /// <c>CreateSyntaxProvider</c> predicate would have selected for the same attribute.
+    /// </summary>
+    public static implicit operator SyntaxTransformContext(GeneratorAttributeSyntaxContext context) =>
+        new(context.TargetNode, context.SemanticModel);
+}

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/TypeSyntaxExtensions.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/TypeSyntaxExtensions.cs
@@ -6,7 +6,7 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities;
 
 public static class TypeSyntaxExtensions {
     public static ITypeDefinition? GetTypeDefinition(this SyntaxNode typeSyntax,
-        GeneratorSyntaxContext generatorSyntaxContext) {
+        SyntaxTransformContext generatorSyntaxContext) {
         var symbolInfo = generatorSyntaxContext.SemanticModel.GetSymbolInfo(typeSyntax);
 
         var type = GetTypeDefinitionFromSymbolInfo(symbolInfo);
@@ -18,7 +18,7 @@ public static class TypeSyntaxExtensions {
         return type;
     }
 
-    public static ITypeDefinition? GetTypeDefinition(this MemberAccessExpressionSyntax syntax, GeneratorSyntaxContext generatorSyntaxContext) {
+    public static ITypeDefinition? GetTypeDefinition(this MemberAccessExpressionSyntax syntax, SyntaxTransformContext generatorSyntaxContext) {
         var typeInfo = generatorSyntaxContext.SemanticModel.GetSymbolInfo(syntax.Expression);
         
         if (typeInfo.Symbol is INamedTypeSymbol namedTypeSymbol) {

--- a/src/DependencyModules.SourceGenerator/DecoratorSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/DecoratorSourceGenerator.cs
@@ -32,11 +32,13 @@ public class DecoratorSourceGenerator : BaseAttributeSourceGenerator<DecoratorMo
         return _attributeTypes;
     }
 
+    protected override DecoratorModel IgnoredModel => DecoratorModel.Ignore;
+
     protected override IEqualityComparer<DecoratorModel> GetComparer() {
         return _comparer;
     }
 
-    protected override DecoratorModel GenerateAttributeModel(GeneratorSyntaxContext context, CancellationToken cancellationToken) {
+    protected override DecoratorModel GenerateAttributeModel(GeneratorAttributeSyntaxContext context, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
 
         return DecoratorModelUtility.GetDecoratorModel(context, cancellationToken) ?? DecoratorModel.Ignore;

--- a/src/DependencyModules.SourceGenerator/InterceptorSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/InterceptorSourceGenerator.cs
@@ -29,11 +29,13 @@ public class InterceptorSourceGenerator : BaseAttributeSourceGenerator<Intercept
         return _attributeTypes;
     }
 
+    protected override InterceptorModel IgnoredModel => InterceptorModel.Ignore;
+
     protected override IEqualityComparer<InterceptorModel> GetComparer() {
         return _comparer;
     }
 
-    protected override InterceptorModel GenerateAttributeModel(GeneratorSyntaxContext context, CancellationToken cancellationToken) {
+    protected override InterceptorModel GenerateAttributeModel(GeneratorAttributeSyntaxContext context, CancellationToken cancellationToken) {
         // A refusal travels on the model so the output stage, which owns the diagnostic context, can
         // report it. Reporting from the transform is not possible.
         return InterceptorModelUtility.GetInterceptorModel(context, cancellationToken);

--- a/src/DependencyModules.SourceGenerator/ServiceSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/ServiceSourceGenerator.cs
@@ -164,11 +164,13 @@ public class ServiceSourceGenerator : BaseAttributeSourceGenerator<ServiceModel>
         (serviceModel.Features.HasFlag(RegistrationFeature.AbstractImplementation) ||
          serviceModel.Features.HasFlag(RegistrationFeature.StaticImplementation));
 
+    protected override ServiceModel IgnoredModel => ServiceModel.Ignore;
+
     protected override IEqualityComparer<ServiceModel> GetComparer() {
         return _serviceEqualityComparer;
     }
 
-    protected override ServiceModel GenerateAttributeModel(GeneratorSyntaxContext context, CancellationToken cancellationToken) {
+    protected override ServiceModel GenerateAttributeModel(GeneratorAttributeSyntaxContext context, CancellationToken cancellationToken) {
         var serviceModel = ServiceModelUtility.GetServiceModel(context, cancellationToken);
         
         return serviceModel ?? ServiceModel.Ignore;

--- a/tests/DependencyModules.Tests/GeneratorTests/ConfigurationTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ConfigurationTests.cs
@@ -68,7 +68,7 @@ public class ConfigurationTests {
             OutputKind.ConsoleApplication);
 
         result.AssertNoErrors();
-        Assert.Contains("namespace ConfiguredRoot", result.SourceContaining("ApplicationModule"));
+        Assert.Contains("namespace ConfiguredRoot", result.SourceContaining("ApplicationModule.Module"));
     }
 
     [Fact]

--- a/tests/DependencyModules.Tests/GeneratorTests/ServiceRegistrationTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ServiceRegistrationTests.cs
@@ -94,6 +94,63 @@ public class ServiceRegistrationTests {
         Assert.Contains("global::TestNamespace.IThing", generated);
     }
 
+    /// <summary>
+    /// Both spellings of the same attribute select the declaration.
+    /// </summary>
+    /// <remarks>
+    /// A namespace-qualified usage is selected too, but the model builder still classifies
+    /// attributes by their written name, so it produces no registrations from one. That is a
+    /// separate limitation and not asserted here.
+    /// </remarks>
+    [Theory]
+    [InlineData("[SingletonService]")]
+    [InlineData("[SingletonServiceAttribute]")]
+    public void ServiceAttribute_IsMatchedHoweverItIsWritten(string attribute) {
+        var generated = GeneratedAssembly.Create(
+            $$"""
+              using DependencyModules.Runtime.Attributes;
+
+              namespace TestNamespace;
+
+              public interface IThing;
+
+              {{attribute}}
+              public class Thing : IThing;
+
+              [DependencyModule]
+              public partial class TestModule;
+              """);
+
+        Assert.NotNull(generated.ResolveRequired("IThing"));
+    }
+
+    /// <summary>
+    /// And an attribute that merely shares a name is not one of ours.
+    /// </summary>
+    [Fact]
+    public void SameNamedAttributeFromAnotherNamespace_IsIgnored() {
+        var generated = GeneratedAssembly.Create(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace Other {
+                public class SingletonServiceAttribute : System.Attribute;
+            }
+
+            namespace TestNamespace {
+                public interface IThing;
+
+                [Other.SingletonService]
+                public class Thing : IThing;
+
+                [DependencyModule]
+                public partial class TestModule;
+            }
+            """);
+
+        Assert.Empty(generated.Descriptors("IThing"));
+    }
+
     [Fact]
     public void OpenGenericService_RegistersOpenGenericTypes() {
         var result = GeneratorTestHarness.Run(

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -775,9 +775,10 @@ namespace DependencyModules.SourceGenerator
     public class DecoratorSourceGenerator : DependencyModules.SourceGenerator.Impl.BaseAttributeSourceGenerator<DependencyModules.SourceGenerator.Impl.Models.DecoratorModel>
     {
         public DecoratorSourceGenerator() { }
+        protected override DependencyModules.SourceGenerator.Impl.Models.DecoratorModel IgnoredModel { get; }
         protected override string LoggerName { get; }
         protected override System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> AttributeTypes() { }
-        protected override DependencyModules.SourceGenerator.Impl.Models.DecoratorModel GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        protected override DependencyModules.SourceGenerator.Impl.Models.DecoratorModel GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorAttributeSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
         protected override void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "Left",
                 "Right",
@@ -788,9 +789,10 @@ namespace DependencyModules.SourceGenerator
     public class InterceptorSourceGenerator : DependencyModules.SourceGenerator.Impl.BaseAttributeSourceGenerator<DependencyModules.SourceGenerator.Impl.Models.InterceptorModel>
     {
         public InterceptorSourceGenerator() { }
+        protected override DependencyModules.SourceGenerator.Impl.Models.InterceptorModel IgnoredModel { get; }
         protected override string LoggerName { get; }
         protected override System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> AttributeTypes() { }
-        protected override DependencyModules.SourceGenerator.Impl.Models.InterceptorModel GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        protected override DependencyModules.SourceGenerator.Impl.Models.InterceptorModel GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorAttributeSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
         protected override void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "Left",
                 "Right",
@@ -801,8 +803,9 @@ namespace DependencyModules.SourceGenerator
     public class ServiceSourceGenerator : DependencyModules.SourceGenerator.Impl.BaseAttributeSourceGenerator<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>
     {
         public ServiceSourceGenerator() { }
+        protected override DependencyModules.SourceGenerator.Impl.Models.ServiceModel IgnoredModel { get; }
         protected override System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> AttributeTypes() { }
-        protected override DependencyModules.SourceGenerator.Impl.Models.ServiceModel GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        protected override DependencyModules.SourceGenerator.Impl.Models.ServiceModel GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorAttributeSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
         protected override void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "Left",
                 "Right",
@@ -826,9 +829,10 @@ namespace DependencyModules.SourceGenerator.Impl
     public abstract class BaseAttributeSourceGenerator<T> : DependencyModules.SourceGenerator.Impl.IDependencyModuleSourceGenerator
     {
         protected BaseAttributeSourceGenerator() { }
+        protected abstract T IgnoredModel { get; }
         protected virtual string LoggerName { get; }
         protected abstract System.Collections.Generic.IEnumerable<CSharpAuthor.ITypeDefinition> AttributeTypes();
-        protected abstract T GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext arg1, System.Threading.CancellationToken arg2);
+        protected abstract T GenerateAttributeModel(Microsoft.CodeAnalysis.GeneratorAttributeSyntaxContext arg1, System.Threading.CancellationToken arg2);
         protected abstract void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext arg1, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "Left",
                 "Right",
@@ -1328,10 +1332,10 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities
 {
     public static class AttributeModelHelper
     {
-        public static DependencyModules.SourceGenerator.Impl.Models.AttributeModel? GetAttribute(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax attribute) { }
-        public static DependencyModules.SourceGenerator.Impl.Models.AttributeClassInfo GetAttributeClassInfo(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
-        public static System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.AttributeModel> GetAttributeModels(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken, System.Func<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax, bool>? filter = null) { }
-        public static System.Collections.Generic.IEnumerable<DependencyModules.SourceGenerator.Impl.Models.AttributeModel> GetAttributes(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax> attributeListSyntax, System.Threading.CancellationToken cancellationToken, System.Func<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax, bool>? filter = null) { }
+        public static DependencyModules.SourceGenerator.Impl.Models.AttributeModel? GetAttribute(DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext context, Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax attribute) { }
+        public static DependencyModules.SourceGenerator.Impl.Models.AttributeClassInfo GetAttributeClassInfo(DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext context, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.AttributeModel> GetAttributeModels(DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext context, Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken, System.Func<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax, bool>? filter = null) { }
+        public static System.Collections.Generic.IEnumerable<DependencyModules.SourceGenerator.Impl.Models.AttributeModel> GetAttributes(DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext context, Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax> attributeListSyntax, System.Threading.CancellationToken cancellationToken, System.Func<Microsoft.CodeAnalysis.CSharp.Syntax.AttributeSyntax, bool>? filter = null) { }
     }
     public abstract class BaseAttributeWriter<T>
         where T : DependencyModules.SourceGenerator.Impl.Models.IClassModel
@@ -1344,8 +1348,8 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities
     }
     public static class BaseMethodHelper
     {
-        public static System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> GetMethodParameters(this Microsoft.CodeAnalysis.CSharp.Syntax.BaseMethodDeclarationSyntax methodDeclarationSyntax, Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
-        public static System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> GetParameters(this Microsoft.CodeAnalysis.CSharp.Syntax.ParameterListSyntax? parameterList, Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> GetMethodParameters(this Microsoft.CodeAnalysis.CSharp.Syntax.BaseMethodDeclarationSyntax methodDeclarationSyntax, DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext context, System.Threading.CancellationToken cancellationToken) { }
+        public static System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ParameterInfoModel> GetParameters(this Microsoft.CodeAnalysis.CSharp.Syntax.ParameterListSyntax? parameterList, DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext context, System.Threading.CancellationToken cancellationToken) { }
     }
     public abstract class BaseSyntaxSelector
     {
@@ -1357,7 +1361,7 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities
     }
     public static class DecoratorModelUtility
     {
-        public static DependencyModules.SourceGenerator.Impl.Models.DecoratorModel? GetDecoratorModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        public static DependencyModules.SourceGenerator.Impl.Models.DecoratorModel? GetDecoratorModel(DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext context, System.Threading.CancellationToken cancellationToken) { }
         public static System.Collections.Generic.IEnumerable<DependencyModules.SourceGenerator.Impl.Models.DecoratorModel> GetModuleDeclaredDecorators(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel) { }
     }
     public class EntryModelUtil
@@ -1392,13 +1396,13 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities
     }
     public static class InterceptorModelUtility
     {
-        public static DependencyModules.SourceGenerator.Impl.Models.InterceptorModel GetInterceptorModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        public static DependencyModules.SourceGenerator.Impl.Models.InterceptorModel GetInterceptorModel(DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext context, System.Threading.CancellationToken cancellationToken) { }
     }
     public class ServiceModelUtility
     {
         public ServiceModelUtility() { }
-        public static DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? GetConstructorInfo(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) { }
-        public static DependencyModules.SourceGenerator.Impl.Models.ServiceModel? GetServiceModel(Microsoft.CodeAnalysis.GeneratorSyntaxContext context, System.Threading.CancellationToken cancellationToken) { }
+        public static DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? GetConstructorInfo(DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext context, Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) { }
+        public static DependencyModules.SourceGenerator.Impl.Models.ServiceModel? GetServiceModel(DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext context, System.Threading.CancellationToken cancellationToken) { }
     }
     public static class SyntaxNodeExtensions
     {
@@ -1430,12 +1434,20 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities
         public SyntaxSelector(params CSharpAuthor.ITypeDefinition[] attributes) { }
         protected override bool TestForTypes(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken token) { }
     }
+    public readonly struct SyntaxTransformContext
+    {
+        public SyntaxTransformContext(Microsoft.CodeAnalysis.SyntaxNode node, Microsoft.CodeAnalysis.SemanticModel semanticModel) { }
+        public Microsoft.CodeAnalysis.SyntaxNode Node { get; }
+        public Microsoft.CodeAnalysis.SemanticModel SemanticModel { get; }
+        public static DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext op_Implicit(Microsoft.CodeAnalysis.GeneratorAttributeSyntaxContext context) { }
+        public static DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext op_Implicit(Microsoft.CodeAnalysis.GeneratorSyntaxContext context) { }
+    }
     public static class TypeSyntaxExtensions
     {
         public static string GetFullName(this Microsoft.CodeAnalysis.INamespaceSymbol? namespaceSymbol) { }
         public static CSharpAuthor.ITypeDefinition GetTypeDefinition(this Microsoft.CodeAnalysis.ITypeSymbol typeSymbol) { }
-        public static CSharpAuthor.ITypeDefinition? GetTypeDefinition(this Microsoft.CodeAnalysis.CSharp.Syntax.MemberAccessExpressionSyntax syntax, Microsoft.CodeAnalysis.GeneratorSyntaxContext generatorSyntaxContext) { }
-        public static CSharpAuthor.ITypeDefinition? GetTypeDefinition(this Microsoft.CodeAnalysis.SyntaxNode typeSyntax, Microsoft.CodeAnalysis.GeneratorSyntaxContext generatorSyntaxContext) { }
+        public static CSharpAuthor.ITypeDefinition? GetTypeDefinition(this Microsoft.CodeAnalysis.CSharp.Syntax.MemberAccessExpressionSyntax syntax, DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext generatorSyntaxContext) { }
+        public static CSharpAuthor.ITypeDefinition? GetTypeDefinition(this Microsoft.CodeAnalysis.SyntaxNode typeSyntax, DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext generatorSyntaxContext) { }
         public static CSharpAuthor.ITypeDefinition? GetTypeDefinitionFromNamedSymbol(this Microsoft.CodeAnalysis.INamedTypeSymbol? namedTypeSymbol) { }
         public static CSharpAuthor.ITypeDefinition? GetTypeDefinitionFromSymbolInfo(Microsoft.CodeAnalysis.SymbolInfo symbolInfo) { }
     }


### PR DESCRIPTION
The three attribute-driven providers visited every syntax node of every changed tree and string-compared attribute names. They now use Roslyn's attribute index, which is shared across providers, so several indexed lookups replace three full visits.

## Measured

Timing only `RunGeneratorsAndUpdateCompilation` — the test harness also runs `GetDiagnostics` on the output compilation, a full semantic analysis that buries the number. Median of 15 fresh-driver runs, GC forced between, baseline re-measured with the identical harness:

| classes | before | after | |
|---|---|---|---|
| 500 | 9.4–10.9 ms | **3.7–4.0 ms** | ~2.6× |
| 2000 | 36.0–37.3 ms | **15.8–18.5 ms** | ~2.2× |

For scale, the generator is a few percent of total compile time — this matters most per-keystroke in the IDE, and as headroom for a convention scanner that cannot use FAWMN.

## What did not move

Module discovery stays a `CreateSyntaxProvider`: it auto-approves the compilation unit of `Program.cs`, which is not attribute-driven and has no FAWMN equivalent. Its predicate rejects on node type first, so it is the cheap kind of scan.

## Supporting changes

**`SyntaxTransformContext`** carries the node and the semantic model. Neither `GeneratorSyntaxContext` nor `GeneratorAttributeSyntaxContext` is publicly constructible, so a helper written against one cannot be reused by the other. Implicit conversions from both mean the ~40 call sites did not change.

**Attribute ownership.** FAWMN takes one name, so a generator matching several attributes needs one provider each — and a declaration carrying two of them is produced twice. The model is built from the whole declaration rather than from the attribute that triggered it, so both would be identical and every registration would be emitted twice. `[SingletonService] [CrossWireService]` is a supported pair, so this is real. The first attribute present, in the order the generator declares them, owns the declaration; the rest return the model type's existing `Ignore` sentinel, which the writers already skip.

## One bug fixed, one exposed

Matching is now by what the attribute resolves to rather than how it is written.

**Fixed:** `SyntaxSelector` built three name forms — `SingletonServiceAttribute`, the fully-qualified name *with* the suffix, and `SingletonService`. A namespace-qualified usage *without* the suffix matched none of them, so `[DependencyModules.Runtime.Attributes.SingletonService]` silently never registered. A test in `ConfigurationTests` was using exactly that form and had been quietly generating nothing.

**Exposed, and deliberately not fixed:** `ServiceModelUtility` still classifies by written name — it compares `attributeSyntax.Name.ToString()` against type names and does `StartsWith("Singleton")` to choose a lifetime. So a namespace-qualified usage is now selected but yields no registrations. Same outcome for the developer as before, but it is the same family of bug in the code that decides every service's lifetime, and it deserves its own change rather than riding along here.

## Also

A test pins that an attribute merely *sharing a name* from another namespace is ignored, so the stricter matching is recorded as intent.

`BaseAttributeWithConfigSourceGenerator` turns out to be dead — nothing derives from it. Left alone.

388 tests pass, 0 warnings, 87.1% coverage, `verify-packages.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EgLfDy82CnQZiuU5j8byu9