### PR TITLE
Environment-conditional registration

### DIFF
--- a/docs/design/convention-registration-and-decorators.md
+++ b/docs/design/convention-registration-and-decorators.md
@@ -1,8 +1,14 @@
 # Design: convention registration and decorators
 
-Status: part 2 phase A is implemented — typed decorators, module-level `[Decorate]`, open generic
-decorators, and global ordering. Convention registration (part 1), generated forwarding (phase B),
-and interceptors (part 3) remain design only.
+Status: convention registration (part 1) is implemented and unshipped, in its own analyzer package.
+Part 2 phase A is implemented — typed decorators, module-level `[Decorate]`, open generic decorators,
+and global ordering. Interceptors (part 3) are implemented, and the shipped model is the pipeline
+described in `docs/HANDOFF.md` rather than the two tiers sketched here. Generated forwarding
+(phase B) remains design only.
+
+Part 1 now also carries a **plan for scanning referenced assemblies**, which earlier revisions of
+this document ruled out. That reversal is recorded in *Scanning referenced assemblies* below,
+together with the probe that produced it.
 
 Two features that would close the functional gap with [Scrutor](https://github.com/khellang/Scrutor)
 without giving up what makes this library different: everything resolved at compile time, no
@@ -12,6 +18,9 @@ They are described together because they share machinery and because the orderin
 agreed once for both.
 
 - [Part 1: convention registration](#part-1-convention-registration)
+  - [What shipped](#what-shipped)
+  - [Scanning referenced assemblies — planned](#scanning-referenced-assemblies--planned)
+- [Scrutor parity](#scrutor-parity)
 - [Part 2: decorators](#part-2-decorators)
 - [Part 3: interceptors](#part-3-interceptors)
 - [Sequencing](#sequencing)
@@ -66,13 +75,16 @@ services.Scan(scan => scan
     .WithScopedLifetime());
 ```
 
-The attributes in this library already solve the same problem at compile time. The gap is narrower
-than it looks: developers who do not want to annotate every class individually.
+The attributes in this library already solve the same problem at compile time, for developers willing
+to annotate every class individually. Everything else Scrutor offers is measured against what shipped
+in *Scrutor parity* below — the gap is wider than "annotation avoidance", and almost none of it is
+about other assemblies.
 
-**Do not port Scrutor's API.** A fluent scanning DSL means runtime reflection over assemblies, which
-is exactly what this library exists to remove, and would give the package two registration
-mechanisms with different trimming characteristics. The compile-time equivalent is a pattern
-evaluated by the generator.
+**Do not port Scrutor's API.** A scanning DSL *evaluated at run time* means reflection over
+assemblies, which is exactly what this library exists to remove, and would give the package two
+registration mechanisms with different trimming characteristics. The compile-time equivalent is the
+same declaration **read** by the generator rather than executed — which is what shipped, and what
+makes scanning a referenced assembly a compile-time operation rather than a runtime one.
 
 Note also that `IServiceCollectionConfiguration.ConfigureServices` already provides unrestricted
 fluent access to `IServiceCollection` for anything a convention cannot express.
@@ -137,6 +149,61 @@ One incidental point for the shipped shape: explicit implementations cannot be s
 the only form CA1822 does not flag. Every alternative needs `static` on the method to stay clean
 under `AnalysisMode=All`.
 
+### What shipped
+
+Four verbs, and that is the entire API:
+
+```csharp
+conventions.RegisterAll<IRepository>().AsScoped();
+conventions.RegisterAll(typeof(IHandler<,>)).AsTransient().IncludeBaseClasses();
+```
+
+`RegisterAll<T>()` / `RegisterAll(typeof(...))`, the three `As*` lifetimes, and `IncludeBaseClasses()`.
+**One selector axis — assignability — and one registration shape, "as the interface that matched."**
+Everything in *Selector priority* below except assignability is unimplemented, and the *Glob
+semantics* section describes a selector that does not exist yet.
+
+Three structural decisions worth not re-deriving:
+
+- **`DependencyModules.Conventions` is its own analyzer package**, sharing `Impl` by compiling in its
+  sources rather than by declaring a second `[Generator]` there. A project that never references it
+  never loads the class-scanning provider — which matters, because that predicate is the one thing
+  here that visits every type node.
+- **Matching runs at output time, not in a transform.** That is why it can report diagnostics at all,
+  and why it does not have to be cacheable. The transform stays syntax-shaped and the expensive part
+  stays out of the incremental graph.
+- **It produces `ServiceModel`/`ServiceRegistrationModel` indistinguishable from the attribute path**,
+  so `DependencyFileWriter` needed no changes. That seam is what makes the parity work below cheap.
+
+`ConventionCandidateUtility` deliberately does not materialise the transitive interface closure: only
+interfaces written on the declaration plus what those extend, with base-class-reached interfaces held
+in a separate list behind `IncludeBaseClasses()`. The cached model stays proportional to what was
+written rather than to hierarchy depth. The opt-in is also stricter than Scrutor's `AssignableTo`,
+which always walks base classes and silently enrols every subclass added later.
+
+### Known defect: partial classes produce a false DM0004
+
+**Proven by running it.** A partial class that reaches the scanned interface from more than one part
+is reported as ambiguous and registers nothing:
+
+```
+error DM0004: 'Foo' is matched by more than one convention in 'TestModule'
+              — as 'IFoo' and as 'IFoo'. Narrow one of them, or move it to another module.
+```
+
+One convention, named twice. The candidate provider is per *declaration* — `CreateSyntaxProvider`
+over `ClassDeclarationSyntax` — while `RemoveAmbiguous` groups by `ImplementationType` and assumes one
+model per type. Two syntax declarations of one partial type yield two `ConventionCandidateModel`s with
+equal `ImplementationType`.
+
+The shape that will actually hit users is not the duplicated interface in the reproduction. It is
+`partial class Foo : IFoo` in one file and `partial class Foo : FooBase` in another under
+`IncludeBaseClasses()`, where both parts reach `IFoo`.
+
+Fix by merging candidates on `ImplementationType` before matching, or by deduping on the
+`(convention, candidate)` pair inside `RemoveAmbiguous`. Note this fails loudly rather than silently,
+which is the better failure mode, but the registration is still lost.
+
 ### Selector priority
 
 Name globbing is the weakest of the available selectors and is listed last deliberately. The one
@@ -161,19 +228,120 @@ must register the *closed* interface against the implementation. Emission for th
 a class closing an open generic registers and resolves correctly today, and only for its own type
 argument. What is new is the selector, not the code generation.
 
-### Explicitly out of scope: scanning referenced assemblies
+### Scanning referenced assemblies — planned
 
-Scrutor's `FromApplicationDependencies()` registers types from packages you do not own. That is
-**not** planned, for two reasons:
+**This reverses an earlier position in this document.** The previous revision ruled out all
+cross-assembly scanning on the grounds that it "contradicts the compile-time goal" and is "the one
+Scrutor capability that has no honest compile-time equivalent." That conflated three different
+things, and it is true of only one of them.
 
-- It contradicts the compile-time goal. It is the one Scrutor capability that has no honest
-  compile-time equivalent.
-- The module system already covers the case that actually matters. Cross-assembly scanning is largely
-  a workaround for having no way to compose registrations across projects; here each project declares
-  its own module and composes through module attributes.
+Scrutor's eight source methods collapse into three capabilities:
 
-If demand appears, a separate runtime-scanning package could provide it without compromising the
-core. It should not live in this library.
+| | Capability | Compile-time answer |
+|---|---|---|
+| 1 | Types in the compilation being built | what ships today |
+| 2 | Types in assemblies **referenced at compile time** — project references and NuGet packages | **yes — proven, see below** |
+| 3 | Assemblies discovered at run time from the deps file or from disk | none, ever |
+
+Only (3) is genuinely out of reach, and it is also the part of Scrutor that already fails under
+trimming and Native AOT. So the gap this library has against Scrutor is not "cannot see other
+assemblies"; it is "cannot see assemblies that were not there at build time."
+
+#### Verified, do not re-derive
+
+Probed end to end with a standalone Roslyn harness, not reasoned about. A library was compiled to a
+real DLL, then a **second compilation referencing it and containing no handlers in any syntax tree**
+was run through an `IIncrementalGenerator`, which emitted:
+
+```csharp
+private static void ModuleDependencies(IServiceCollection services) {
+    services.AddScoped(typeof(global::TheLibrary.IHandler<global::TheLibrary.CreateOrder, global::TheLibrary.OrderId>), typeof(global::TheLibrary.CreateOrderHandler));
+    services.AddScoped(typeof(global::TheLibrary.IHandler<global::TheLibrary.RenameOrder, global::TheLibrary.OrderId>), typeof(global::TheLibrary.RenameOrderHandler));
+}
+```
+
+That is the whole convention feature working across an assembly boundary: an open generic matched
+against metadata, each implementation registered against the **closed** construction it actually
+implements, constructors read from metadata, and two exclusions applied correctly — an `internal`
+handler, invisible across the boundary, and one whose only constructor is private.
+
+Reproduce it by compiling a library to an in-memory DLL, referencing it from a second
+`CSharpCompilation` whose only syntax tree declares a module, and running a generator that resolves
+`compilation.GetAssemblyOrModuleSymbol(reference)` and walks `IAssemblySymbol.GlobalNamespace`.
+Assignability is `type.AllInterfaces` compared on `OriginalDefinition`; constructors are
+`type.InstanceConstructors`. The probe was standalone and is not retained.
+
+**This is what makes it AOT-safe rather than AOT-hostile.** Scrutor enumerates an assembly's types by
+reflection, which the trimmer cannot follow: it has no way to know those types are needed, removes
+them, and the scan finds nothing at run time. Doing the same work at compile time emits a literal
+`typeof()` for every implementation into the consumer's assembly. That is a static reference the
+trimmer roots, and — the part that actually matters — it lets the
+`[DynamicallyAccessedMembers(PublicConstructors)]` annotation on `ServiceDescriptor`'s
+implementation-type parameter flow to a known type, so the constructor survives too. Neither works
+when the type is only discovered at run time. **The capability that breaks Scrutor under AOT is the
+capability that works here.**
+
+#### Cost, measured
+
+The naive shape — walk every referenced assembly — is not viable, and the numbers say so:
+
+| | types visited | time |
+|---|---|---|
+| Every referenced assembly | 5,350 | 13 ms |
+| One assembly named by the convention | 10 | 0.019 ms |
+
+Roughly 700× apart, on the same keystroke. And 13 ms is a *minimal* eleven-reference compilation;
+a real application carries an order of magnitude more references, so the naive path only gets worse.
+
+**Correction to an assumption that was wrong.** `context.MetadataReferencesProvider` does *not* buy
+per-reference caching. It must be combined with `CompilationProvider` to resolve
+`GetAssemblyOrModuleSymbol`, and the compilation changes on every keystroke, so every reference is
+re-visited on every edit — measured, all eleven. What bounds the cost is not the provider shape. It is
+the convention naming the assembly, so a reference is rejected on its name before any symbol work
+happens.
+
+#### The API this forces
+
+```csharp
+conventions.RegisterAll(typeof(IHandler<,>)).InAssemblyOf<SomeTypeInThatPackage>().AsScoped();
+```
+
+- **The assembly is named, always.** There is no `InAllDependencies()` and there should never be one.
+  This is deliberately narrower than Scrutor, and the measurement above is the reason.
+- **`InAssemblyOf<T>()` rather than a string name.** A type argument cannot be written unless the
+  assembly is already referenced, so "you named an assembly that is not referenced" becomes
+  impossible to express rather than a diagnostic to report. Prefer the shape that deletes the error.
+- **Absent the call, a convention scans the compilation being built** — existing behaviour, unchanged.
+
+#### Implementation constraints
+
+1. **Model equality is not optional here.** `ImmutableArray<T>` compares by reference of the
+   underlying array, so an unchanged walk still re-runs everything downstream — measured. The result
+   has to be wrapped the way `ModelEquality.ListEquals` already does it elsewhere in this codebase.
+2. **Visibility differs by reach.** Referenced assemblies expose only `public` types; the
+   in-compilation path also takes `internal`. One verb with two reaches has to be documented, because
+   nothing can detect the `internal` type it cannot see.
+3. **Constructor info needs a symbol-driven path.** `ServiceModelUtility.GetConstructorInfo` is
+   syntax-driven. Metadata types need an equivalent that reads `IMethodSymbol`. This is the one
+   genuinely new piece of code, and the probe confirms the information is all there.
+4. **DM0010 loses its location.** "Registered as `IFoo`, reported at the class" is the best affordance
+   conventions have, and there is no class to squiggle inside a referenced DLL. Matches from a
+   referenced assembly have to report at the `RegisterAll` line instead.
+5. **No new diagnostic IDs are required.** DM0004, DM0005, DM0006, DM0009 and DM0010 all generalise
+   unchanged.
+
+#### What stays out, and why the module system still comes first
+
+`FromApplicationDependencies()`, `FromDependencyContext()` and `FromAssemblyDependencies(Assembly)`
+load runtime libraries by name, including assemblies that were never compile-time references. There
+is no compile-time answer and no way to fake one. If demand ever appears, a separate runtime-scanning
+package could provide it; it should not live in this library.
+
+Note also that (2) is not the first tool to reach for. Any referenced project **you own** is better
+served by declaring its own module with its own conventions and composing through module attributes —
+explicit, ordered, and cross-assembly by construction. Referenced-assembly scanning earns its keep on
+assemblies you **do not** own, where you cannot add a module: third-party packages whose handlers,
+validators or policies you want registered.
 
 ### Glob semantics
 
@@ -251,11 +419,31 @@ full visit. Worth doing independently of this proposal.
 
 ### Diagnostics
 
+Shipped, and the reason this feature is worth having over a runtime scanner:
+
 | ID | Severity | Condition |
 |---|---|---|
 | DM0004 | Error | Two conventions in one module match the same type |
 | DM0005 | Warning | A convention matched no types |
 | DM0006 | Warning | A convention matched a type that cannot be constructed, e.g. no accessible constructor |
+| DM0009 | Error | A convention declaration could not be read |
+| DM0010 | Info | A service is registered by convention, reported at the class |
+
+**Canonical allocation across the whole library** — the tables in parts 2 and 3 below predate several
+of these and are wrong where they disagree. Next free ID is **DM0011**.
+
+| ID | Severity | Meaning |
+|---|---|---|
+| DM0001 | Error | The generator failed; registrations may be missing |
+| DM0002 | Warning | A service type cannot be constructed and was not registered |
+| DM0003 | Error | A module marked `[DependencyModule]` is not partial |
+| DM0004 | Error | Two conventions in one module match the same type |
+| DM0005 | Warning | A convention matched no types |
+| DM0006 | Warning | A convention matched a type with no accessible constructor |
+| DM0007 | Error | Two decorators of one service share an order |
+| DM0008 | Warning | A service marked for interception cannot be wrapped |
+| DM0009 | Error | A convention declaration could not be read |
+| DM0010 | Info | A service is registered by convention |
 
 Add to `DependencyModuleDiagnostics`, and record them in `AnalyzerReleases.Unshipped.md` or the
 build fails RS2008.
@@ -273,6 +461,96 @@ Behavioural, using `GeneratedAssembly` — compile, load, resolve. Do not assert
 - DM0004/DM0005/DM0006 fire; a valid convention reports nothing
 - incremental: editing an unrelated method body reuses cached output
   (`GeneratorTestHarness.RunIncremental`)
+
+---
+
+## Scrutor parity
+
+Scrutor's surface, read off its interfaces rather than its README, is three axes and a strategy:
+
+| Axis | Scrutor |
+|---|---|
+| Source | `FromEntryAssembly`, `FromAssemblyOf<T>`, `FromAssembliesOf`, `FromAssemblies`, `FromApplicationDependencies(+predicate)`, `FromAssemblyDependencies(Assembly)`, `FromDependencyContext(+predicate)`, `AddTypes` |
+| Filter | `AssignableTo`, `AssignableToAny`, `WithAttribute`×3, `WithoutAttribute`×3, `InNamespaceOf`, `InNamespaces`, `InExactNamespaces`, `NotInNamespaceOf`, `NotInNamespaces`, `Where(Func<Type,bool>)` |
+| Shape | `AsSelf`, `As<T>`, `As(Type[])`, `AsImplementedInterfaces(+predicate)`, `AsSelfWithInterfaces(+predicate)`, `AsMatchingInterface(+action)`, `As(Func<Type,IEnumerable<Type>>)`, `UsingAttributes` |
+| Lifetime / strategy | `WithSingleton/Scoped/TransientLifetime`, `WithLifetime(ServiceLifetime)`, `WithLifetime(Func<Type,ServiceLifetime>)`, `WithServiceKey(object \| Func)`, `RegistrationStrategy.Skip/Append/Throw/Replace(ReplacementBehavior)` |
+
+### The mapping
+
+**Have it, sometimes better.**
+
+| Scrutor | Here |
+|---|---|
+| `AssignableTo`, including open generics | `RegisterAll` — and cheaper, assignability being a symbol question at compile time |
+| base-class reach inside `AssignableTo` | `IncludeBaseClasses()`, opt-in rather than always-on |
+| `UsingAttributes` | the attribute path, which is this library's *primary* API rather than a scanning afterthought |
+| `WithSingleton/Scoped/TransientLifetime`, `WithLifetime(ServiceLifetime)` | `AsSingleton`/`AsScoped`/`AsTransient` |
+| `RegistrationStrategy.Throw` | becomes a **build error**, not a runtime exception |
+
+**Missing, fully buildable at compile time, no philosophical cost.** This is the bulk of the gap, and
+none of it involves other assemblies:
+
+| Scrutor | Notes |
+|---|---|
+| `AsSelf`, `AsSelfWithInterfaces`, `As<T>`, `As(Type[])` | **The largest single hole.** A concrete type with no interface cannot be registered by convention at all today — `ConventionCandidateUtility.IsCandidate` rejects anything with no base list |
+| `AsImplementedInterfaces` proper | `FirstMatchingInterface` returns one interface per candidate per convention. `ServiceModel.Registrations` is already a list, so multi-registration is emission-ready |
+| `InNamespaceOf`, `InNamespaces`, `InExactNamespaces`, `NotIn*` | Syntax-only. The cheapest thing on this list |
+| `WithAttribute<T>`, `WithoutAttribute<T>` | Syntax, and `ForAttributeWithMetadataName`-indexable |
+| `WithAttribute<T>(predicate)` | Partial — literal argument matching yes, arbitrary lambda no |
+| name globbing | Semantics already specified in *Glob semantics* above; never implemented |
+| `AsMatchingInterface` (`Foo` → `IFoo`) | A symbol lookup |
+| `AssignableToAny` | An overload, or repeated `RegisterAll` |
+| `WithServiceKey(object)` | **`ServiceRegistrationModel.Key` already exists**; the matcher passes null |
+| `RegistrationStrategy.Skip/Append/Replace` | **`ServiceRegistrationModel.RegistrationType` already exists**; the matcher passes null |
+| `FromAssemblyOf<T>` against a referenced assembly | *Scanning referenced assemblies*, above |
+
+**No compile-time equivalent — every lambda-taking overload.** `Where(Func<Type,bool>)`,
+`AsImplementedInterfaces(predicate)`, `As(Func<Type,IEnumerable<Type>>)`,
+`WithLifetime(Func<Type,ServiceLifetime>)`, `WithServiceKey(Func<Type,object?>)`. A generator cannot
+run user code over types it is describing. **The escape hatch already exists and should be named in
+the documentation rather than left to be discovered:** `IServiceCollectionConfiguration.ConfigureServices`
+gives unrestricted fluent access to `IServiceCollection` for anything a convention cannot express.
+
+**Runtime-only, will not be built.** `FromApplicationDependencies`, `FromDependencyContext`,
+`FromAssemblyDependencies`. See *What stays out* above.
+
+### Plan, in order
+
+Ordered by value per unit of work. Everything above the line is in-compilation and needs no new
+pipeline shape.
+
+| # | Work | Notes |
+|---|---|---|
+| 1 | Fix the partial-class DM0004 | Defect, loses registrations today |
+| 2 | `AsSelf()` / `AsSelfWithInterfaces()` | Needs `IsCandidate` to stop requiring a base list |
+| 3 | Namespace filters | Syntax-only, cheapest on the list |
+| 4 | Multi-interface registration | `Registrations` is already a list |
+| 5 | `RegistrationType` and `Key` pass-through | Both fields already exist and are being passed null |
+| 6 | Attribute filters (`WithAttribute` / `WithoutAttribute`) | FAWMN-indexable |
+| 7 | `AsMatchingInterface`, `As<T>`, name globbing | Rounds out the shape axis |
+| | — | |
+| 8 | Scanning referenced assemblies | New pipeline shape; see the constraints above |
+
+**Sequencing note.** Steps 2 and 4 change what a `ServiceModel` may contain, and step 8 changes where
+candidates come from. Doing 8 first would mean building the referenced-assembly path against a
+one-interface-per-candidate model and then reworking it. Keep 8 last.
+
+### What Scrutor structurally cannot do
+
+Worth holding on to, because it is the actual competitive position and none of it is about feature
+count:
+
+- **DM0005 answers Scrutor's most common failure.** A renamed interface or a typo'd filter registers
+  zero services, the build stays green, and the application throws at resolve time. Scrutor cannot
+  report it: its scan does not run until startup, by which point the build is long over.
+- **DM0006 catches an unconstructable match at build time**, where Scrutor surfaces it as an
+  `ActivatorUtilities` failure at resolve.
+- **DM0004 refuses ambiguity**, where Scrutor silently appends or last-wins.
+- **DM0010 reports provenance at the class**: "this type is in the container as `IFoo`, via
+  `IAuditedFoo`." This is the standing complaint about assembly scanning — *where did this
+  registration come from* — answered in the IDE, at the type, with no tooling.
+- **Zero startup cost, no reflection, trimming and Native AOT safe**, including for referenced
+  assemblies once the plan above lands.
 
 ---
 
@@ -398,12 +676,16 @@ on a cache hit, so this cannot be left implicit.
 
 #### Diagnostics
 
+**Stale — only DM0007 shipped as written.** DM0008, DM0009 and DM0010 were subsequently allocated to
+interception and to convention registration; see the canonical allocation in part 1. The three
+decorator conditions below are still worth reporting, but they need IDs from DM0011 upward.
+
 | ID | Severity | Condition |
 |---|---|---|
-| DM0007 | Error | Multiple decorators target one service and `Order` is ambiguous |
-| DM0008 | Error | Decorator does not implement the service type it decorates |
-| DM0009 | Warning | Decorator targets a service no module registers |
-| DM0010 | Error | Decorator has no constructor parameter of the decorated type |
+| DM0007 | Error | Multiple decorators target one service and `Order` is ambiguous — **shipped** |
+| ~~DM0008~~ | Error | Decorator does not implement the service type it decorates — *needs a new ID* |
+| ~~DM0009~~ | Warning | Decorator targets a service no module registers — *needs a new ID* |
+| ~~DM0010~~ | Error | Decorator has no constructor parameter of the decorated type — *needs a new ID* |
 
 ### Phase B: generated forwarding
 
@@ -469,6 +751,12 @@ every row above, and confirm DM0011 fires for the refused shapes.
 ---
 
 ## Part 3: interceptors
+
+> **Superseded where it disagrees with what shipped.** Interception is implemented, and the two-tier
+> hook model below (`OnEnter`/`OnExit`/`OnError`, plus an opt-in `IInvocation`) was **rejected** in
+> favour of a pipeline in which one `Intercept` method receives the call and decides whether to
+> `Proceed()`. `docs/HANDOFF.md` records the shipped model and the reasoning. The section below is
+> kept for *The constraint that forces the design* and *Async*, which still hold.
 
 ### The constraint that forces the design
 
@@ -580,21 +868,26 @@ It should ship as a **separate package** depending on the core, never fused into
 
 Each step is independently shippable and makes the next cheaper.
 
+**Done.**
+
+| Step | Notes |
+|---|---|
+| `AddDecorator` order parameter | Source-compatible; optional and trailing |
+| Global decorator ordering | `InternalGetDecorators` collects across modules; sorted together |
+| `DecoratorHelper` descriptor rewrite | All three descriptor shapes, open generics, keyed, lifetime preserved |
+| `[Decorator]` / `[Decorate]` attributes | Runtime surface and generator emission; DM0007 for ambiguous order |
+| Wire `ConfigureDecorators` | Was a public no-op; now invoked after all services are registered |
+| Convention registration | Own analyzer package. Assignability axis only — see *What shipped* |
+| Interceptors | Shipped as a pipeline, not the two tiers in part 3. See `docs/HANDOFF.md` |
+
+**Remaining**, most valuable first. Steps 1–7 are the Scrutor parity plan and are detailed above.
+
 | Step | Effort | Notes |
 |---|---|---|
-| `AddDecorator` order parameter | done | Implemented; source-compatible |
-| Global decorator ordering | done | `InternalGetDecorators` collects across modules; sorted together |
-| `DecoratorHelper` descriptor rewrite | done | All three descriptor shapes, open generics, keyed, lifetime preserved |
-| `[Decorator]` / `[Decorate]` attributes | done | Runtime surface only; the generator does not read them yet |
-| Generator emission for decorators | done | `[Decorator]` and `[Decorate]` are read and emitted; DM0007 for ambiguous order |
-| Phase B: generated forwarding | remaining | Opt-in via `partial`; additive |
-| Interceptors | remaining | Reuses the same descriptor rewrite |
-| Wire `ConfigureDecorators` | done | Was a public no-op; now invoked after all services are registered |
-| Convention registration | days | Independent of decorators; can proceed in parallel |
-| Phase A, typed decorators | ~1 day | Closes the Scrutor gap. Emit the body through a template |
-| Phase B, generated forwarding | 4–6× A | Only worth it if C is plausible; keep signature and body separate |
-| Tier 1 interceptors | moderate | Reuses B's signature rendering |
-| Tier 2 interceptors | moderate | Only if demand appears |
+| Partial-class DM0004 fix | small | Defect; loses registrations today |
+| Parity steps 2–7 | days | In-compilation, no new pipeline shape; several are pass-through of fields that already exist |
+| Scanning referenced assemblies | moderate | Proven feasible. New pipeline shape; keep it after the parity steps |
+| Phase B, generated forwarding | 4–6× phase A | Only worth it if the member matrix is worth it; keep signature and body separate |
 
-Nothing beyond the first row is 1.0 work. The one decision that is live now is the architectural
-constraint in phase B: keep signature rendering separate from body emission.
+The one architectural constraint still live: in phase B, keep signature rendering separate from body
+emission.

--- a/integ-tests/SutProject.Tests/EnvironmentTests/EnvironmentConfigurationTests.cs
+++ b/integ-tests/SutProject.Tests/EnvironmentTests/EnvironmentConfigurationTests.cs
@@ -31,8 +31,8 @@ public class EnvironmentDependency(string environmentName) : IEnvironmentDepende
 
 [DependencyModule]
 public partial class EnvironmentAwareModule : IEnvironmentServiceCollectionConfiguration {
-    public void ConfigureServices(IServiceCollection services, IModuleEnvironment? environment) {
-        var envName = environment?.EnvironmentName ?? "Unknown";
+    public void ConfigureServices(IServiceCollection services, IModuleEnvironment environment) {
+        var envName = environment.EnvironmentName;
         services.AddSingleton<IEnvironmentDependency>(new EnvironmentDependency(envName));
     }
 }
@@ -43,8 +43,8 @@ public partial class DualConfigModule : IServiceCollectionConfiguration, IEnviro
         services.AddSingleton(new StringMarker("from-configure"));
     }
 
-    public void ConfigureServices(IServiceCollection services, IModuleEnvironment? environment) {
-        var envName = environment?.EnvironmentName ?? "Unknown";
+    public void ConfigureServices(IServiceCollection services, IModuleEnvironment environment) {
+        var envName = environment.EnvironmentName;
         services.AddSingleton<IEnvironmentDependency>(new EnvironmentDependency(envName));
     }
 }
@@ -67,8 +67,11 @@ public class EnvironmentConfigurationTests {
         Assert.Equal("Production", dependency.EnvironmentName);
     }
 
+    /// <summary>
+    /// No environment supplied means the process default rather than null.
+    /// </summary>
     [Fact]
-    public void NullEnvironment_WhenNotRegistered() {
+    public void ProcessEnvironment_WhenNotRegistered() {
         var serviceCollection = new ServiceCollection();
 
         serviceCollection.AddModules(new EnvironmentAwareModule());
@@ -76,7 +79,23 @@ public class EnvironmentConfigurationTests {
         var serviceProvider = serviceCollection.BuildServiceProvider();
         var dependency = serviceProvider.GetRequiredService<IEnvironmentDependency>();
 
-        Assert.Equal("Unknown", dependency.EnvironmentName);
+        Assert.Equal(ModuleEnvironment.Default.EnvironmentName, dependency.EnvironmentName);
+    }
+
+    /// <summary>
+    /// An application with genuinely no environment says so, and gets a real object rather than a
+    /// null to branch on.
+    /// </summary>
+    [Fact]
+    public void ModuleEnvironmentNone_HasNoNameAndNoValues() {
+        var serviceCollection = new ServiceCollection();
+
+        serviceCollection.AddModules(ModuleEnvironment.None, new EnvironmentAwareModule());
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        var dependency = serviceProvider.GetRequiredService<IEnvironmentDependency>();
+
+        Assert.Equal("", dependency.EnvironmentName);
     }
 
     [Fact]
@@ -126,15 +145,34 @@ public class EnvironmentConfigurationTests {
         Assert.Equal("from-configure", marker.Value);
     }
 
+    /// <summary>
+    /// Nothing supplied registers the process default, so the environment that decided the
+    /// registrations is the same one that resolves.
+    /// </summary>
     [Fact]
-    public void NullEnvironmentParameter_DoesNotRegisterSingleton() {
+    public void NullEnvironmentParameter_RegistersTheProcessDefault() {
         var serviceCollection = new ServiceCollection();
 
         serviceCollection.AddModules((IModuleEnvironment?)null, new EnvironmentAwareModule());
 
         var serviceProvider = serviceCollection.BuildServiceProvider();
-        var resolved = serviceProvider.GetService<IModuleEnvironment>();
 
-        Assert.Null(resolved);
+        Assert.Same(ModuleEnvironment.Default, serviceProvider.GetRequiredService<IModuleEnvironment>());
+    }
+
+    /// <summary>
+    /// An environment the application supplied is never displaced by the default.
+    /// </summary>
+    [Fact]
+    public void SuppliedEnvironmentIsNotReplacedByTheDefault() {
+        var serviceCollection = new ServiceCollection();
+        var environment = new TestEnvironment("Staging");
+
+        serviceCollection.AddModules(environment, new EnvironmentAwareModule());
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+
+        Assert.Same(environment, serviceProvider.GetRequiredService<IModuleEnvironment>());
+        Assert.Single(serviceCollection, d => d.ServiceType == typeof(IModuleEnvironment));
     }
 }

--- a/src/DependencyModules.Conventions/Models/ConventionCandidateModel.cs
+++ b/src/DependencyModules.Conventions/Models/ConventionCandidateModel.cs
@@ -42,7 +42,17 @@ public record ConventionCandidateModel(
     IReadOnlyList<ImplementedInterfaceModel> BaseClassInterfaces,
     ConstructorInfoModel? Constructor,
     bool HasAccessibleConstructor,
-    LocationModel Location) {
+    LocationModel Location,
+    /// <summary>
+    /// Environment conditions declared on the candidate, carried through so that a convention
+    /// registers it on the same terms the attribute path would.
+    /// </summary>
+    /// <remarks>
+    /// A class with a service attribute is never a convention candidate, so these can only appear
+    /// on a class whose conditions have no other way to be honoured. Dropping them would register a
+    /// development-only service in production with nothing anywhere saying why.
+    /// </remarks>
+    IReadOnlyList<EnvironmentConditionModel>? Conditions = null) {
 
     public static readonly ConventionCandidateModel Ignore = new(
         TypeDefinition.Get("", "Ignore"),
@@ -67,7 +77,11 @@ public record ConventionCandidateModel(
         Location == other.Location &&
         ModelEquality.ListEquals(DeclaredInterfaces, other.DeclaredInterfaces) &&
         ModelEquality.ListEquals(BaseClassInterfaces, other.BaseClassInterfaces) &&
-        CompareConstructor(Constructor, other.Constructor);
+        CompareConstructor(Constructor, other.Constructor) &&
+        // Null and empty both mean unconditional and have to compare equal, or an edit elsewhere
+        // in the file would miss the incremental cache.
+        ((Conditions?.Count ?? 0) == 0 && (other.Conditions?.Count ?? 0) == 0 ||
+         ModelEquality.ListEquals(Conditions, other.Conditions));
 
     private static bool CompareConstructor(ConstructorInfoModel? x, ConstructorInfoModel? y) {
         if (x is null && y is null) return true;

--- a/src/DependencyModules.Conventions/Utilities/ConventionCandidateUtility.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionCandidateUtility.cs
@@ -122,7 +122,8 @@ public static class ConventionCandidateUtility {
             viaBaseClass,
             ServiceModelUtility.GetConstructorInfo(context, typeDeclaration, cancellationToken),
             HasAccessibleConstructor(symbol),
-            LocationModel.From(typeDeclaration));
+            LocationModel.From(typeDeclaration),
+            EnvironmentConditionUtility.GetConditions(context, typeDeclaration, cancellationToken));
     }
 
     /// <summary>

--- a/src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs
@@ -250,7 +250,8 @@ public static class ConventionMatcher {
                         // registration with no realm when the module declares one.
                         Realm: entryPointModel.EntryPointType)
                 },
-                RegistrationFeature.None));
+                RegistrationFeature.None,
+                match.Candidate.Conditions));
         }
 
         return models;

--- a/src/DependencyModules.Runtime/Attributes/IfEnvironmentAttribute.cs
+++ b/src/DependencyModules.Runtime/Attributes/IfEnvironmentAttribute.cs
@@ -1,0 +1,39 @@
+namespace DependencyModules.Runtime.Attributes;
+
+/// <summary>
+/// Registers the service only when the environment name matches one of the given names.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Read at compile time and turned into a run-time test around the registration, so the type is
+/// still compiled and still referenced — a condition changes what is registered, not what ships.
+/// Trimming a service out of a build is a compile-time decision and belongs to <c>#if</c>.
+/// </para>
+/// <para>
+/// Names are compared case-insensitively, matching <c>IHostEnvironment.IsDevelopment()</c>.
+/// Alternatives go in one attribute rather than several: conditions of different kinds combine with
+/// <b>and</b>, so two of these could never both hold.
+/// </para>
+/// <example>
+/// <code>
+/// [SingletonService]
+/// [IfEnvironment("Development", "Staging")]
+/// public class FakeEmailSender : IEmailSender { }
+/// </code>
+/// </example>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public class IfEnvironmentAttribute : Attribute {
+    /// <summary>
+    /// Registers the service only in the given environments.
+    /// </summary>
+    /// <param name="environmentNames">The environment names to register in.</param>
+    public IfEnvironmentAttribute(params string[] environmentNames) {
+        EnvironmentNames = environmentNames;
+    }
+
+    /// <summary>
+    /// The environment names this registration is limited to.
+    /// </summary>
+    public string[] EnvironmentNames { get; }
+}

--- a/src/DependencyModules.Runtime/Attributes/IfEnvironmentValueAttribute.cs
+++ b/src/DependencyModules.Runtime/Attributes/IfEnvironmentValueAttribute.cs
@@ -1,0 +1,54 @@
+namespace DependencyModules.Runtime.Attributes;
+
+/// <summary>
+/// Registers the service only when the environment carries a given value.
+/// </summary>
+/// <remarks>
+/// <para>
+/// With one argument the key only has to be present; with two it has to equal the given value.
+/// Values are compared exactly, unlike environment names, because a value is data rather than a
+/// well-known label.
+/// </para>
+/// <para>
+/// This one is <c>AllowMultiple</c>: several keys on one service combine with <b>and</b>, which is
+/// how a registration gated on more than one switch is written.
+/// </para>
+/// <example>
+/// <code>
+/// [SingletonService]
+/// [IfEnvironmentValue("FEATURE_BILLING", "on")]
+/// public class BillingService : IBillingService { }
+/// </code>
+/// </example>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public class IfEnvironmentValueAttribute : Attribute {
+    /// <summary>
+    /// Registers the service only when the environment has any value for <paramref name="key"/>.
+    /// </summary>
+    /// <param name="key">The key that has to be present.</param>
+    public IfEnvironmentValueAttribute(string key) {
+        Key = key;
+    }
+
+    /// <summary>
+    /// Registers the service only when the environment's value for <paramref name="key"/> equals
+    /// <paramref name="value"/>.
+    /// </summary>
+    /// <param name="key">The key to read.</param>
+    /// <param name="value">The value it has to equal.</param>
+    public IfEnvironmentValueAttribute(string key, string value) {
+        Key = key;
+        Value = value;
+    }
+
+    /// <summary>
+    /// The environment key this registration is gated on.
+    /// </summary>
+    public string Key { get; }
+
+    /// <summary>
+    /// The value the key has to equal, or null when presence alone is enough.
+    /// </summary>
+    public string? Value { get; }
+}

--- a/src/DependencyModules.Runtime/Attributes/IfNotEnvironmentAttribute.cs
+++ b/src/DependencyModules.Runtime/Attributes/IfNotEnvironmentAttribute.cs
@@ -1,0 +1,31 @@
+namespace DependencyModules.Runtime.Attributes;
+
+/// <summary>
+/// Registers the service except when the environment name matches one of the given names.
+/// </summary>
+/// <remarks>
+/// The inverse of <see cref="IfEnvironmentAttribute"/>, and the shape most developer tooling wants:
+/// register everywhere but production.
+/// <example>
+/// <code>
+/// [SingletonService]
+/// [IfNotEnvironment("Production")]
+/// public class RequestProfiler : IRequestProfiler { }
+/// </code>
+/// </example>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public class IfNotEnvironmentAttribute : Attribute {
+    /// <summary>
+    /// Registers the service except in the given environments.
+    /// </summary>
+    /// <param name="environmentNames">The environment names to exclude.</param>
+    public IfNotEnvironmentAttribute(params string[] environmentNames) {
+        EnvironmentNames = environmentNames;
+    }
+
+    /// <summary>
+    /// The environment names this registration is excluded from.
+    /// </summary>
+    public string[] EnvironmentNames { get; }
+}

--- a/src/DependencyModules.Runtime/Attributes/IfNotEnvironmentValueAttribute.cs
+++ b/src/DependencyModules.Runtime/Attributes/IfNotEnvironmentValueAttribute.cs
@@ -1,0 +1,48 @@
+namespace DependencyModules.Runtime.Attributes;
+
+/// <summary>
+/// Registers the service except when the environment carries a given value.
+/// </summary>
+/// <remarks>
+/// The inverse of <see cref="IfEnvironmentValueAttribute"/>. With one argument the service is
+/// skipped when the key is present at all; with two, only when it equals the given value.
+/// <example>
+/// <code>
+/// [SingletonService]
+/// [IfNotEnvironmentValue("DISABLE_CACHE")]
+/// public class CachingRepository : IRepository { }
+/// </code>
+/// </example>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public class IfNotEnvironmentValueAttribute : Attribute {
+    /// <summary>
+    /// Registers the service except when the environment has any value for
+    /// <paramref name="key"/>.
+    /// </summary>
+    /// <param name="key">The key whose presence skips the registration.</param>
+    public IfNotEnvironmentValueAttribute(string key) {
+        Key = key;
+    }
+
+    /// <summary>
+    /// Registers the service except when the environment's value for <paramref name="key"/> equals
+    /// <paramref name="value"/>.
+    /// </summary>
+    /// <param name="key">The key to read.</param>
+    /// <param name="value">The value that skips the registration.</param>
+    public IfNotEnvironmentValueAttribute(string key, string value) {
+        Key = key;
+        Value = value;
+    }
+
+    /// <summary>
+    /// The environment key this registration is gated on.
+    /// </summary>
+    public string Key { get; }
+
+    /// <summary>
+    /// The value that skips the registration, or null when presence alone skips it.
+    /// </summary>
+    public string? Value { get; }
+}

--- a/src/DependencyModules.Runtime/Helpers/DependencyRegistry.cs
+++ b/src/DependencyModules.Runtime/Helpers/DependencyRegistry.cs
@@ -12,6 +12,21 @@ namespace DependencyModules.Runtime.Helpers;
 public delegate void RegistryFunc(IServiceCollection serviceCollection);
 
 /// <summary>
+/// Delegate representing a function responsible for registering dependencies into an
+/// IServiceCollection, with the environment those registrations may be conditional on.
+/// </summary>
+/// <remarks>
+/// Generated code uses this form only when a module declares an environment condition. Everything
+/// registered through <see cref="RegistryFunc"/> is adapted to it, so both kinds keep their
+/// declaration order relative to each other — which matters, because the container resolves a
+/// single service from the last matching descriptor.
+/// </remarks>
+/// <param name="serviceCollection">The IServiceCollection to which dependencies will be added.</param>
+/// <param name="environment">The environment conditions are evaluated against. Never null.</param>
+public delegate void EnvironmentRegistryFunc(
+    IServiceCollection serviceCollection, IModuleEnvironment environment);
+
+/// <summary>
 ///     Static class used to store dependency registration functions
 ///     per type
 /// </summary>
@@ -20,7 +35,7 @@ public delegate void RegistryFunc(IServiceCollection serviceCollection);
 public class DependencyRegistry<T> {
     // ReSharper disable StaticMemberInGenericType
     private static readonly object SyncLock = new();
-    private static readonly List<RegistryFunc> RegistryFuncs = [];
+    private static readonly List<EnvironmentRegistryFunc> RegistryFuncs = [];
     private static readonly List<DecoratorRegistration> Decorators = [];
     private static readonly List<IDependencyModule> Modules = [];
 
@@ -30,6 +45,19 @@ public class DependencyRegistry<T> {
     /// <param name="registryFunc"></param>
     /// <returns></returns>
     public static int Add(RegistryFunc registryFunc) {
+        lock (SyncLock) {
+            RegistryFuncs.Add((serviceCollection, _) => registryFunc(serviceCollection));
+        }
+
+        return 1;
+    }
+
+    /// <summary>
+    ///     Add registration func whose registrations may depend on the environment
+    /// </summary>
+    /// <param name="registryFunc"></param>
+    /// <returns></returns>
+    public static int Add(EnvironmentRegistryFunc registryFunc) {
         lock (SyncLock) {
             RegistryFuncs.Add(registryFunc);
         }
@@ -49,7 +77,7 @@ public class DependencyRegistry<T> {
         ServiceLifetime lifetime = ServiceLifetime.Transient) where TInstance : class {
         lock (SyncLock) {
             RegistryFuncs.Add(
-                registry => registry.Add(
+                (registry, _) => registry.Add(
                     new ServiceDescriptor(
                         typeof(TInstance),
                         provider,
@@ -70,7 +98,7 @@ public class DependencyRegistry<T> {
     public static int Add<TInstance>(Type implementationType, ServiceLifetime lifetime = ServiceLifetime.Transient, object? serviceKey = null) where TInstance : class {
         lock (SyncLock) {
             RegistryFuncs.Add(
-                registry => registry.Add(
+                (registry, _) => registry.Add(
                     new ServiceDescriptor(
                         typeof(TInstance),
                         serviceKey,
@@ -135,13 +163,23 @@ public class DependencyRegistry<T> {
     /// </summary>
     /// <param name="serviceCollection"></param>
     public static void ApplyServices(IServiceCollection serviceCollection) {
-        RegistryFunc[] snapshot;
+        ApplyServices(serviceCollection, ModuleEnvironment.Default);
+    }
+
+    /// <summary>
+    ///     Apply all registration for a given type to the service collection, evaluating any
+    ///     environment conditions against the supplied environment
+    /// </summary>
+    /// <param name="serviceCollection"></param>
+    /// <param name="environment"></param>
+    public static void ApplyServices(IServiceCollection serviceCollection, IModuleEnvironment environment) {
+        EnvironmentRegistryFunc[] snapshot;
         lock (SyncLock) {
             snapshot = RegistryFuncs.ToArray();
         }
 
         foreach (var registryFunc in snapshot) {
-            registryFunc(serviceCollection);
+            registryFunc(serviceCollection, environment);
         }
     }
 
@@ -226,23 +264,38 @@ public class DependencyRegistry<T> {
     }
 
     private static void ApplyServices(IServiceCollection serviceCollection, IReadOnlyList<IDependencyModule> modules) {
-        IModuleEnvironment? environment = null;
-        var hasEnvironmentModules = false;
-
-        for (var i = 0; i < modules.Count; i++) {
-            if (modules[i] is IEnvironmentServiceCollectionConfiguration) {
-                hasEnvironmentModules = true;
-                break;
-            }
+        // Always looked for now. Attribute conditions live on generated modules, which do not
+        // implement IEnvironmentServiceCollectionConfiguration, so the old "only if some module
+        // asked for it" gate would have missed them. It costs one scan of the collection per
+        // AddModules call.
+        // One environment for the whole call, and never null. Handing attribute conditions the
+        // process default while handing IEnvironmentServiceCollectionConfiguration a null would let
+        // one module see two different answers to "what environment is this" — the conditions
+        // evaluating against Production while its own ConfigureServices was told there is no
+        // environment at all. An application with no environment says so with ModuleEnvironment.None.
+        // Nothing to apply means nothing to decide, so the collection is left exactly as it was
+        // rather than picking up an environment nobody asked for.
+        if (modules.Count == 0) {
+            return;
         }
 
-        if (hasEnvironmentModules) {
-            environment = FindModuleEnvironment(serviceCollection);
+        var environment = FindModuleEnvironment(serviceCollection);
+
+        if (environment == null) {
+            RefuseUnusableEnvironment(serviceCollection);
+
+            environment = ModuleEnvironment.Default;
+
+            // Registered, not just used. Otherwise conditions would be decided by an environment
+            // that GetRequiredService<IModuleEnvironment>() then throws for, which is the same
+            // inconsistency one layer out. Only when nothing supplied one, so an application's own
+            // environment is never displaced.
+            serviceCollection.AddSingleton(environment);
         }
 
         for (var i = 0; i < modules.Count; i++) {
             var module = modules[i];
-            module.InternalApplyServices(serviceCollection);
+            module.InternalApplyServices(serviceCollection, environment);
 
             if (module is IServiceCollectionConfiguration serviceCollectionConfigure) {
                 serviceCollectionConfigure.ConfigureServices(serviceCollection);
@@ -251,6 +304,33 @@ public class DependencyRegistry<T> {
             if (module is IEnvironmentServiceCollectionConfiguration environmentConfigure) {
                 environmentConfigure.ConfigureServices(serviceCollection, environment);
             }
+        }
+    }
+
+    /// <summary>
+    /// Refuses an <see cref="IModuleEnvironment"/> registered in a form that cannot decide
+    /// registrations.
+    /// </summary>
+    /// <remarks>
+    /// The environment is read while the collection is still being populated, so there is no
+    /// provider to construct it from and only an instance can be used. Registered by type or by
+    /// factory it was previously ignored without a word, the process default was used instead, and
+    /// the registration that was ignored got shadowed by the one added in its place — a service
+    /// gated on "Development" quietly took its production branch.
+    /// </remarks>
+    private static void RefuseUnusableEnvironment(IServiceCollection serviceCollection) {
+        for (var i = serviceCollection.Count - 1; i >= 0; i--) {
+            if (serviceCollection[i].ServiceType != typeof(IModuleEnvironment)) {
+                continue;
+            }
+
+            throw new InvalidOperationException(
+                "An IModuleEnvironment is registered, but not as a singleton instance, so it cannot " +
+                "be used. The environment decides which services are registered, which happens " +
+                "while the service collection is being populated and before any provider exists to " +
+                "construct it from. Register the instance directly with " +
+                "AddSingleton<IModuleEnvironment>(new MyEnvironment()), or pass it to " +
+                "AddModules(environment, modules).");
         }
     }
 

--- a/src/DependencyModules.Runtime/Helpers/EnvironmentConditions.cs
+++ b/src/DependencyModules.Runtime/Helpers/EnvironmentConditions.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel;
+using DependencyModules.Runtime.Interfaces;
+
+namespace DependencyModules.Runtime.Helpers;
+
+/// <summary>
+/// The tests generated code performs for <c>[IfEnvironment]</c> and <c>[IfEnvironmentValue]</c>.
+/// </summary>
+/// <remarks>
+/// The comparison rules live here rather than in emitted text so that they are testable in one
+/// place and so that fixing one does not require every consumer to rebuild against a new generator.
+/// The negative forms of the attributes emit a <c>!</c> around these rather than adding methods.
+/// </remarks>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class EnvironmentConditions {
+
+    /// <summary>
+    /// True when the environment name matches any of <paramref name="names"/>.
+    /// </summary>
+    /// <remarks>
+    /// Compared with <see cref="StringComparison.OrdinalIgnoreCase"/>, matching
+    /// <c>IHostEnvironment.IsDevelopment()</c>. An environment name is a well-known label rather
+    /// than data, and "development" should not be a different environment from "Development".
+    /// </remarks>
+    /// <param name="environment">The environment to test.</param>
+    /// <param name="names">The names to accept.</param>
+    /// <returns>True when any name matches.</returns>
+    public static bool NameIs(IModuleEnvironment environment, params string[] names) {
+        if (environment == null) {
+            return false;
+        }
+
+        for (var i = 0; i < names.Length; i++) {
+            if (string.Equals(environment.EnvironmentName, names[i], StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True when the environment has any value for <paramref name="key"/>.
+    /// </summary>
+    /// <remarks>
+    /// A key set to an empty string counts as set. Setting a variable to nothing is a deliberate
+    /// act, and treating it as unset would make the two indistinguishable.
+    /// </remarks>
+    /// <param name="environment">The environment to test.</param>
+    /// <param name="key">The key to look for.</param>
+    /// <returns>True when a value is present.</returns>
+    public static bool HasValue(IModuleEnvironment environment, string key) =>
+        environment?.Value(key) != null;
+
+    /// <summary>
+    /// True when the environment's value for <paramref name="key"/> equals
+    /// <paramref name="value"/>.
+    /// </summary>
+    /// <remarks>
+    /// Compared with <see cref="StringComparison.Ordinal"/>, unlike the environment name. Values
+    /// are data, and a comparison that quietly ignored case would be wrong as often as it was
+    /// convenient.
+    /// </remarks>
+    /// <param name="environment">The environment to test.</param>
+    /// <param name="key">The key to read.</param>
+    /// <param name="value">The value to compare against.</param>
+    /// <returns>True when the value matches exactly.</returns>
+    public static bool ValueIs(IModuleEnvironment environment, string key, string value) =>
+        string.Equals(environment?.Value(key), value, StringComparison.Ordinal);
+}

--- a/src/DependencyModules.Runtime/Interfaces/IDependencyModule.cs
+++ b/src/DependencyModules.Runtime/Interfaces/IDependencyModule.cs
@@ -44,7 +44,22 @@ public interface IDependencyModule {
     [Browsable(false)]
     void InternalApplyServices(IServiceCollection serviceCollection) { }
 
-    
+    /// <summary>
+    /// Internal method not intended to be called by general developers
+    /// </summary>
+    /// <remarks>
+    /// The overload generated modules implement once any of their registrations carries an
+    /// environment condition. It forwards to the collection-only overload by default, so a module
+    /// compiled against an earlier generator keeps registering exactly what it did before.
+    /// </remarks>
+    /// <param name="serviceCollection"></param>
+    /// <param name="environment">Never null; see <c>ModuleEnvironment.Default</c>.</param>
+    [Browsable(false)]
+    void InternalApplyServices(IServiceCollection serviceCollection, IModuleEnvironment environment) {
+        InternalApplyServices(serviceCollection);
+    }
+
+
     /// <summary>
     /// Internal method not intended to be called by general developers
     /// </summary>

--- a/src/DependencyModules.Runtime/Interfaces/IServiceCollectionConfiguration.cs
+++ b/src/DependencyModules.Runtime/Interfaces/IServiceCollectionConfiguration.cs
@@ -26,7 +26,14 @@ public interface IEnvironmentServiceCollectionConfiguration {
     /// <summary>
     /// Configure services with access to the module environment.
     /// </summary>
+    /// <remarks>
+    /// The environment is never null. An application that supplies none gets
+    /// <c>ModuleEnvironment.Default</c>, read from the process, and one that has no environment says
+    /// so with <c>ModuleEnvironment.None</c>. That is the same environment the
+    /// <c>[IfEnvironment]</c> attributes are evaluated against, so a module cannot see one answer
+    /// here and a different one in its own conditional registrations.
+    /// </remarks>
     /// <param name="services"></param>
-    /// <param name="environment"></param>
-    void ConfigureServices(IServiceCollection services, IModuleEnvironment? environment);
+    /// <param name="environment">The environment for this AddModules call. Never null.</param>
+    void ConfigureServices(IServiceCollection services, IModuleEnvironment environment);
 }

--- a/src/DependencyModules.Runtime/ModuleEnvironment.cs
+++ b/src/DependencyModules.Runtime/ModuleEnvironment.cs
@@ -1,0 +1,73 @@
+using DependencyModules.Runtime.Interfaces;
+
+namespace DependencyModules.Runtime;
+
+/// <summary>
+/// A ready-made <see cref="IModuleEnvironment"/> for the common cases.
+/// </summary>
+/// <remarks>
+/// Registration is decided while the service collection is being populated, so the environment has
+/// to be known before the provider exists. That is why this is a plain object handed to
+/// <c>AddModules</c> rather than something resolved from the container.
+/// </remarks>
+public class ModuleEnvironment : IModuleEnvironment {
+    // Declared before None, which constructs an instance during static initialization and would
+    // otherwise capture this field before it is assigned. Static field initializers run in
+    // declaration order, so the order here is load-bearing.
+    private static readonly IReadOnlyDictionary<string, string?> EmptyValues =
+        new Dictionary<string, string?>(0);
+
+    private readonly IReadOnlyDictionary<string, string?> _values;
+
+    /// <summary>
+    /// Creates an environment with a fixed name and an optional set of values.
+    /// </summary>
+    /// <param name="environmentName">The environment name conditions compare against.</param>
+    /// <param name="values">Values reachable through <see cref="Value"/>; null means none.</param>
+    public ModuleEnvironment(string environmentName, IReadOnlyDictionary<string, string?>? values = null) {
+        EnvironmentName = environmentName ?? throw new ArgumentNullException(nameof(environmentName));
+        _values = values ?? EmptyValues;
+    }
+
+    /// <inheritdoc />
+    public string EnvironmentName { get; }
+
+    /// <inheritdoc />
+    public string? Value(string name) =>
+        _values.TryGetValue(name, out var value) ? value : null;
+
+    /// <summary>
+    /// Reads the environment from the process: <c>ASPNETCORE_ENVIRONMENT</c>, then
+    /// <c>DOTNET_ENVIRONMENT</c>, then <c>"Production"</c>, with values read as environment
+    /// variables.
+    /// </summary>
+    /// <remarks>
+    /// This is what a module gets when <c>AddModules</c> is called without one, so
+    /// <c>[IfEnvironment("Development")]</c> works with nothing wired up beyond the variable every
+    /// .NET developer already sets. The default of <c>"Production"</c> matches
+    /// <c>IHostEnvironment</c>, and means a service gated on a non-production environment stays
+    /// unregistered unless something says otherwise.
+    ///
+    /// Values are read on each call rather than captured, so a variable set after startup is still
+    /// seen. Registration happens once, so the cost does not repeat.
+    /// </remarks>
+    public static IModuleEnvironment Default { get; } = new ProcessModuleEnvironment();
+
+    /// <summary>
+    /// An environment with no name and no values, so every condition evaluates false.
+    /// </summary>
+    /// <remarks>
+    /// Pass this to <c>AddModules</c> to state that this application has no environment, rather
+    /// than leaving it unset and picking up <see cref="Default"/>.
+    /// </remarks>
+    public static IModuleEnvironment None { get; } = new ModuleEnvironment("");
+
+    private sealed class ProcessModuleEnvironment : IModuleEnvironment {
+        public string EnvironmentName =>
+            Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ??
+            Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT") ??
+            "Production";
+
+        public string? Value(string name) => Environment.GetEnvironmentVariable(name);
+    }
+}

--- a/src/DependencyModules.Runtime/ServiceCollectionExtensions.cs
+++ b/src/DependencyModules.Runtime/ServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using DependencyModules.Runtime.Helpers;
 using DependencyModules.Runtime.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace DependencyModules.Runtime;
 
@@ -51,8 +52,17 @@ public static class ServiceCollectionExtensions {
     /// <param name="environment"></param>
     /// <param name="modules"></param>
     /// <returns></returns>
+    /// <remarks>
+    /// An environment passed here replaces any already in the collection rather than joining it.
+    /// The environment decides what gets registered, and that is a single question with a single
+    /// answer — several of them would need a rule for which one the <c>[IfEnvironment]</c>
+    /// attributes read, and the rule would come out of module ordering rather than out of anything
+    /// written down. To layer one on another, read the existing one and combine before calling this;
+    /// the collection is right there.
+    /// </remarks>
     public static IServiceCollection AddModules(this IServiceCollection services, IModuleEnvironment? environment, params IDependencyModule[] modules) {
         if (environment != null) {
+            services.RemoveAll<IModuleEnvironment>();
             services.AddSingleton(environment);
         }
 

--- a/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
+++ b/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
@@ -15,3 +15,5 @@ DM0007 | DependencyModules | Error | Two decorators of one service share an orde
 DM0008 | DependencyModules | Warning | A service marked for interception cannot be wrapped.
 DM0009 | DependencyModules | Error | A convention declaration could not be read.
 DM0010 | DependencyModules | Info | A service is registered by convention.
+DM0011 | DependencyModules | Info | A service is registered only when an environment condition holds.
+DM0012 | DependencyModules | Warning | An environment condition names nothing to test.

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyFileWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyFileWriter.cs
@@ -134,6 +134,13 @@ public class DependencyFileWriter {
         var autoRegisterGenerators =
             entryPointModel.RegisterJsonSerializers ?? configurationModel.RegisterSourceGenerator;
 
+        // The parameter is added only when something in this module is conditional, so a module
+        // without conditions generates exactly the method it always has and its Add call still
+        // binds to the RegistryFunc overload.
+        var environment = sortedServiceModels.Any(model => model.Conditions is { Count: > 0 })
+            ? method.AddParameter(KnownTypes.DependencyModules.Interfaces.IModuleEnvironment, "environment")
+            : null;
+
         foreach (var serviceModel in sortedServiceModels) {
             if (serviceModel.Equals(ServiceModel.Ignore)) {
                 continue;
@@ -143,6 +150,12 @@ public class DependencyFileWriter {
                 RegistrationFeature.AutoRegisterSourceGenerator && !autoRegisterGenerators) {
                 continue;
             }
+
+            // One guard around everything the service registers. The attributes are declared on the
+            // class, so every registration it produces shares them.
+            var block = environment != null && serviceModel.Conditions is { Count: > 0 } conditions
+                ? method.If(CodeOutputComponent.Get(BuildCondition(conditions, environment.Name)))
+                : (BaseBlockDefinition)method;
 
             var crossWire = false;
 
@@ -180,7 +193,7 @@ public class DependencyFileWriter {
                             registrationType,
                             registrationModel,
                             serviceModel,
-                            method,
+                            block,
                             services,
                             uniqueId);
                         break;
@@ -194,7 +207,7 @@ public class DependencyFileWriter {
                             registrationType,
                             registrationModel,
                             serviceModel,
-                            method,
+                            block,
                             services,
                             uniqueId);
 
@@ -207,7 +220,7 @@ public class DependencyFileWriter {
                     configurationModel,
                     entryPointModel,
                     classDefinition,
-                    method,
+                    block,
                     services,
                     serviceModel,
                     uniqueId);
@@ -217,11 +230,52 @@ public class DependencyFileWriter {
         return method.Name;
     }
 
+    /// <summary>
+    /// The guard for one service's conditions, as it is written into the generated method.
+    /// </summary>
+    /// <remarks>
+    /// Composed as text rather than through CSharpAuthor because the library has no combinators for
+    /// <c>&amp;&amp;</c> or <c>!</c>, and nesting an if per condition to avoid them would emit a
+    /// staircase for something that reads as one line. The calls themselves are static, so the
+    /// generated file needs no using.
+    /// </remarks>
+    private static string BuildCondition(
+        IReadOnlyList<EnvironmentConditionModel> conditions, string environmentParameter) {
+
+        var parts = new List<string>(conditions.Count);
+
+        foreach (var condition in conditions) {
+            // An empty condition tests nothing; it is reported as DM0012 and left out rather than
+            // emitted as a call that is constant either way.
+            if (EnvironmentConditionUtility.IsEmpty(condition)) {
+                continue;
+            }
+
+            var call = condition.Kind == EnvironmentConditionKind.Name
+                ? $"{ConditionsType}.NameIs({environmentParameter}, {QuoteAll(condition.Values)})"
+                : condition.Values.Count > 0
+                    ? $"{ConditionsType}.ValueIs({environmentParameter}, {QuoteString(condition.Key!)}, {QuoteString(condition.Values[0])})"
+                    : $"{ConditionsType}.HasValue({environmentParameter}, {QuoteString(condition.Key!)})";
+
+            parts.Add(condition.Negate ? "!" + call : call);
+        }
+
+        // Every condition was empty, so there is nothing left to test and the registration is
+        // unconditional. The diagnostic has already said so.
+        return parts.Count == 0 ? "true" : string.Join(" && ", parts);
+    }
+
+    private static string QuoteAll(IReadOnlyList<string> values) =>
+        string.Join(", ", values.Select(QuoteString));
+
+    private const string ConditionsType =
+        "global::" + KnownTypes.DependencyModules.Helpers.Namespace + ".EnvironmentConditions";
+
     private void CrossWireRegisterImplementation(
         DependencyModuleConfigurationModel configurationModel,
         ModuleEntryPointModel entryPointModel,
         ClassDefinition classDefinition,
-        MethodDefinition method,
+        BaseBlockDefinition block,
         ParameterDefinition services,
         ServiceModel serviceModel,
         string uniqueId) {
@@ -288,7 +342,7 @@ public class DependencyFileWriter {
                 KnownTypes.Microsoft.DependencyInjection.ServiceDescriptor,
                 parameters.ToArray());
 
-        method.AddIndentedStatement(
+        block.AddIndentedStatement(
             services.Invoke(
                 invokeMethod,
                 serviceDescriptor
@@ -313,7 +367,7 @@ public class DependencyFileWriter {
         RegistrationType registrationType,
         ServiceRegistrationModel registrationModel,
         ServiceModel serviceModel,
-        MethodDefinition method,
+        BaseBlockDefinition block,
         ParameterDefinition services, string uniqueId) {
         var invokeMethod =
             registrationType == RegistrationType.Replace ? "Replace" : "TryAddEnumerable";
@@ -367,7 +421,7 @@ public class DependencyFileWriter {
                 KnownTypes.Microsoft.DependencyInjection.ServiceDescriptor,
                 parameters.ToArray());
 
-        method.AddIndentedStatement(
+        block.AddIndentedStatement(
             services.Invoke(
                 invokeMethod,
                 serviceDescriptor
@@ -378,7 +432,7 @@ public class DependencyFileWriter {
         RegistrationType registrationType,
         ServiceRegistrationModel registrationModel,
         ServiceModel serviceModel,
-        MethodDefinition method,
+        BaseBlockDefinition block,
         ParameterDefinition services,
         string uniqueId) {
         stringBuilder.Length = 0;
@@ -436,7 +490,7 @@ public class DependencyFileWriter {
             AddFactoryParameter(serviceModel, classDefinition, parameters, uniqueId);
         }
 
-        method.AddIndentedStatement(
+        block.AddIndentedStatement(
             services.Invoke(
                 stringBuilder.ToString(),
                 parameters.ToArray()
@@ -577,12 +631,44 @@ public class DependencyFileWriter {
         return configurationModel.RegistrationType;
     }
 
+    /// <summary>
+    /// Emission order: unconditional registrations first, then conditional ones, each group by name.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The container resolves a single service from the <b>last</b> matching descriptor, so a
+    /// conditional registration can only override an unconditional default for the same service type
+    /// if it is emitted after it. Ordering by name alone made that depend on the class names: a
+    /// <c>[IfEnvironment("Development")] FakeEmailSender</c> sorts before an unconditional
+    /// <c>SmtpEmailSender</c>, so the default landed last and won in every environment.
+    /// </para>
+    /// <para>
+    /// This orders within one module. A default and its override living in different modules are
+    /// ordered by the sequence the modules are applied in, which is the caller's.
+    /// </para>
+    /// <para>
+    /// Note the interaction with <c>RegistrationType.Try</c>, which is first-wins rather than
+    /// last-wins: a conditional <c>Try</c> registration cannot override an unconditional one,
+    /// because by the time it runs the service type is already registered. That is what <c>Try</c>
+    /// means, and the override pattern wants the default <c>Add</c>.
+    /// </para>
+    /// </remarks>
     private List<ServiceModel> GetSortedServiceModels(IEnumerable<ServiceModel> serviceModels) {
         var list = new List<ServiceModel>(serviceModels);
 
-        list.Sort((x, y) =>
-            string.Compare(x.ImplementationType.Name, y.ImplementationType.Name, StringComparison.Ordinal));
+        list.Sort((x, y) => {
+            var byCondition = IsConditional(x).CompareTo(IsConditional(y));
+
+            // Name is the tie-break rather than the only key, so the order stays total and the
+            // output stays deterministic under List.Sort, which is not stable.
+            return byCondition != 0
+                ? byCondition
+                : string.Compare(x.ImplementationType.Name, y.ImplementationType.Name, StringComparison.Ordinal);
+        });
 
         return list;
     }
+
+    private static bool IsConditional(ServiceModel serviceModel) =>
+        serviceModel.Conditions is { Count: > 0 };
 }

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
@@ -164,4 +164,41 @@ public static class DependencyModuleDiagnostics {
         category: Category,
         defaultSeverity: DiagnosticSeverity.Info,
         isEnabledByDefault: true);
+
+    /// <summary>
+    /// Reports, on the class itself, that its registration is conditional and on what.
+    /// </summary>
+    /// <remarks>
+    /// An environment condition is evaluated at run time, so the compiler cannot say whether it will
+    /// hold and no build-time error is available. The failure that follows is a service that does not
+    /// resolve, several layers from the attribute that excluded it. This puts the condition where the
+    /// developer is already looking.
+    ///
+    /// Informational, so it stays out of the build the same way DM0010 does. Silence it with
+    /// dotnet_diagnostic.DM0011.severity = none.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor RegisteredConditionally = new(
+        id: "DM0011",
+        title: "Service is registered conditionally",
+        messageFormat: "Registered only when {0}",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true);
+
+    /// <summary>
+    /// Raised for a condition that names nothing to test.
+    /// </summary>
+    /// <remarks>
+    /// <c>[IfEnvironment()]</c> and <c>[IfEnvironmentValue("")]</c> compile. Written plain they mean
+    /// the service never registers anywhere; written as the <c>IfNot</c> form they mean the attribute
+    /// does nothing at all. Neither is what anybody intended, and both are invisible until something
+    /// fails to resolve in an environment nobody tested.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor EmptyEnvironmentCondition = new(
+        id: "DM0012",
+        title: "Environment condition tests nothing",
+        messageFormat: "{0} names no {1} to test, so it does not depend on the environment",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
 }

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleWriter.cs
@@ -314,34 +314,60 @@ public class DependencyModuleWriter {
         return attributeModels;
     }
 
+    /// <summary>
+    /// Emits both overloads of <c>InternalApplyServices</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The runtime calls the environment-taking overload, and that is the one that has to exist:
+    /// this module's registrations may include conditional ones, and routing them through the
+    /// collection-only overload would evaluate them against the process environment rather than the
+    /// one the caller passed to <c>AddModules</c>.
+    /// </para>
+    /// <para>
+    /// The collection-only overload is emitted as well rather than left to the interface default,
+    /// which does nothing. The generator package declares no dependency on the runtime package, so
+    /// a consumer can pair a new generator with an older runtime that only knows to call the
+    /// one-argument form — and would then register nothing at all.
+    /// </para>
+    /// </remarks>
     private void InternalApplyServicesMethod(
         ClassDefinition classDefinition,
         ModuleEntryPointModel model) {
-
-        var loadDependenciesMethod = classDefinition.AddMethod("InternalApplyServices");
-
-        loadDependenciesMethod.AddLeadingTrait(CodeOutputComponent.Get("[Browsable(false)]", true));
-        loadDependenciesMethod.AddUsingNamespace("System.ComponentModel");
-        
-        loadDependenciesMethod.InterfaceImplementation =
-            KnownTypes.DependencyModules.Interfaces.IDependencyModule;
-
-        var parameter =
-            loadDependenciesMethod.AddParameter(
-                KnownTypes.Microsoft.DependencyInjection.IServiceCollection, "services");
 
         var closedType = new GenericTypeDefinition(
             TypeDefinitionEnum.ClassDefinition, KnownTypes.DependencyModules.Helpers.Namespace, "DependencyRegistry", new[] {
                 model.EntryPointType
             });
 
+        ApplyServicesOverload(classDefinition, closedType, withEnvironment: false);
+        ApplyServicesOverload(classDefinition, closedType, withEnvironment: true);
+    }
+
+    private static void ApplyServicesOverload(
+        ClassDefinition classDefinition, ITypeDefinition closedType, bool withEnvironment) {
+
+        var loadDependenciesMethod = classDefinition.AddMethod("InternalApplyServices");
+
+        loadDependenciesMethod.AddLeadingTrait(CodeOutputComponent.Get("[Browsable(false)]", true));
+        loadDependenciesMethod.AddUsingNamespace("System.ComponentModel");
+
+        loadDependenciesMethod.InterfaceImplementation =
+            KnownTypes.DependencyModules.Interfaces.IDependencyModule;
+
+        var arguments = new List<IOutputComponent> {
+            loadDependenciesMethod.AddParameter(
+                KnownTypes.Microsoft.DependencyInjection.IServiceCollection, "services")
+        };
+
+        if (withEnvironment) {
+            arguments.Add(
+                loadDependenciesMethod.AddParameter(
+                    KnownTypes.DependencyModules.Interfaces.IModuleEnvironment, "environment"));
+        }
+
         loadDependenciesMethod.AddIndentedStatement(
-            new StaticInvokeStatement(
-                closedType,
-                "ApplyServices",
-                new IOutputComponent[] {
-                    parameter
-                }) {
+            new StaticInvokeStatement(closedType, "ApplyServices", arguments) {
                 Indented = false
             });
     }

--- a/src/DependencyModules.SourceGenerator.Impl/KnownTypes.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/KnownTypes.cs
@@ -82,6 +82,10 @@ public static class KnownTypes {
             // ReSharper disable once InconsistentNaming
             public static readonly ITypeDefinition IDependencyModuleProvider =
                 TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition, Namespace, "IDependencyModuleProvider");
+
+            // ReSharper disable once InconsistentNaming
+            public static readonly ITypeDefinition IModuleEnvironment =
+                TypeDefinition.Get(TypeDefinitionEnum.InterfaceDefinition, Namespace, "IModuleEnvironment");
         }
 
         public static class Features {
@@ -111,6 +115,13 @@ public static class KnownTypes {
 
             public static readonly ITypeDefinition DecoratorRegistration =
                 TypeDefinition.Get(TypeDefinitionEnum.ClassDefinition, Namespace, "DecoratorRegistration");
+
+            /// <summary>
+            /// The tests a generated environment condition calls. Invoked statically, so the
+            /// generated file needs no using.
+            /// </summary>
+            public static readonly ITypeDefinition EnvironmentConditions =
+                TypeDefinition.Get(TypeDefinitionEnum.ClassDefinition, Namespace, "EnvironmentConditions");
         }
 
         /// <summary>

--- a/src/DependencyModules.SourceGenerator.Impl/Models/EnvironmentConditionModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/EnvironmentConditionModel.cs
@@ -1,0 +1,63 @@
+namespace DependencyModules.SourceGenerator.Impl.Models;
+
+/// <summary>
+/// What an environment condition tests.
+/// </summary>
+public enum EnvironmentConditionKind {
+    /// <summary>
+    /// The environment's name, against one or more accepted names.
+    /// </summary>
+    Name,
+
+    /// <summary>
+    /// A value the environment carries, either for presence or against an exact value.
+    /// </summary>
+    Value,
+}
+
+/// <summary>
+/// One <c>[IfEnvironment]</c>-family attribute, read from source.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Conditions on one service combine with <b>and</b>; alternatives live inside a single condition's
+/// <see cref="Values"/>, which is why <c>IfEnvironment</c> takes <c>params</c> and is not
+/// <c>AllowMultiple</c>. There is deliberately no way to write a boolean expression: a registration
+/// whose condition cannot be read off the declaration is one nobody can predict from the source.
+/// </para>
+/// <para>
+/// Strings rather than symbols, so the model stays equatable and the incremental cache holds.
+/// </para>
+/// </remarks>
+/// <param name="Kind">What is being tested.</param>
+/// <param name="Negate">True for the <c>IfNot</c> forms, which emit the same test behind a <c>!</c>.</param>
+/// <param name="Key">The environment key for <see cref="EnvironmentConditionKind.Value"/>; null otherwise.</param>
+/// <param name="Values">
+/// Accepted names for <see cref="EnvironmentConditionKind.Name"/>. For
+/// <see cref="EnvironmentConditionKind.Value"/> this holds the single value to compare against, or
+/// is empty when presence of the key is enough.
+/// </param>
+public record EnvironmentConditionModel(
+    EnvironmentConditionKind Kind,
+    bool Negate,
+    string? Key,
+    IReadOnlyList<string> Values) {
+
+    // Structural equality over Values; see ModelEquality.
+    public virtual bool Equals(EnvironmentConditionModel? other) =>
+        other is not null &&
+        Kind == other.Kind &&
+        Negate == other.Negate &&
+        Key == other.Key &&
+        ModelEquality.ListEquals(Values, other.Values);
+
+    public override int GetHashCode() {
+        unchecked {
+            var hash = (int)Kind;
+            hash = hash * 31 + Negate.GetHashCode();
+            hash = hash * 31 + (Key?.GetHashCode() ?? 0);
+            hash = hash * 31 + ModelEquality.ListHashCode(Values);
+            return hash;
+        }
+    }
+}

--- a/src/DependencyModules.SourceGenerator.Impl/Models/ServiceModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/ServiceModel.cs
@@ -72,7 +72,14 @@ public record ServiceModel(
     ServiceFactoryModel? Factory,
     FactoryOutputDelegate? FactoryOutput,
     IReadOnlyList<ServiceRegistrationModel> Registrations,
-    RegistrationFeature Features) {
+    RegistrationFeature Features,
+    /// <summary>
+    /// Environment conditions declared on the implementation, or null when it registers
+    /// unconditionally. They sit on the service rather than on each registration because the
+    /// attributes are declared on the class, so every registration it produces shares them and the
+    /// writer emits one guard around the lot.
+    /// </summary>
+    IReadOnlyList<EnvironmentConditionModel>? Conditions = null) {
     public static ServiceModel Ignore = new ServiceModel(
         TypeDefinition.Get("", "Ignore"),
         null,
@@ -94,9 +101,10 @@ public class ServiceModelComparer : IEqualityComparer<ServiceModel> {
             x.Features == y.Features &&
             x.ImplementationType.Equals(y.ImplementationType) &&
             CompareConstructor(x.Constructor, y.Constructor) &&
-            CompareRegistrations(x.Registrations, y.Registrations) && 
-            CompareFactory(x.Factory, y.Factory) && 
-            CompareFactoryOutput(x.FactoryOutput, y.FactoryOutput);
+            CompareRegistrations(x.Registrations, y.Registrations) &&
+            CompareFactory(x.Factory, y.Factory) &&
+            CompareFactoryOutput(x.FactoryOutput, y.FactoryOutput) &&
+            CompareConditions(x.Conditions, y.Conditions);
     }
 
     private bool CompareConstructor(ConstructorInfoModel? xConstructor, ConstructorInfoModel? yConstructor) {
@@ -109,6 +117,20 @@ public class ServiceModelComparer : IEqualityComparer<ServiceModel> {
         if (xFactoryOutput is null && yFactoryOutput is null) return true;
         if (xFactoryOutput is null || yFactoryOutput is null) return false;
         return true;
+    }
+
+    /// <summary>
+    /// Null and empty are the same thing here — both mean "registers unconditionally" — so they
+    /// have to compare equal or a model rebuilt from an edit elsewhere would miss the cache.
+    /// </summary>
+    private bool CompareConditions(
+        IReadOnlyList<EnvironmentConditionModel>? xConditions,
+        IReadOnlyList<EnvironmentConditionModel>? yConditions) {
+        if ((xConditions?.Count ?? 0) == 0 && (yConditions?.Count ?? 0) == 0) {
+            return true;
+        }
+
+        return ModelEquality.ListEquals(xConditions, yConditions);
     }
 
     private bool CompareFactory(ServiceFactoryModel? xFactory, ServiceFactoryModel? yFactory) {

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/EnvironmentConditionUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/EnvironmentConditionUtility.cs
@@ -1,0 +1,157 @@
+using DependencyModules.SourceGenerator.Impl.Models;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace DependencyModules.SourceGenerator.Impl.Utilities;
+
+/// <summary>
+/// Reads the <c>[IfEnvironment]</c> family off a service declaration.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The attribute type is resolved through the semantic model rather than matched on the name as
+/// written. Matching written names is how a namespace-qualified usage came to be silently ignored
+/// once already in this generator, and a condition that is silently ignored registers a service the
+/// developer asked to keep out of production.
+/// </para>
+/// <para>
+/// Only the resulting strings reach the model. Symbols are not equatable, and holding one breaks
+/// the incremental cache.
+/// </para>
+/// </remarks>
+public static class EnvironmentConditionUtility {
+
+    private const string IfEnvironment = "IfEnvironmentAttribute";
+    private const string IfNotEnvironment = "IfNotEnvironmentAttribute";
+    private const string IfEnvironmentValue = "IfEnvironmentValueAttribute";
+    private const string IfNotEnvironmentValue = "IfNotEnvironmentValueAttribute";
+
+    /// <summary>
+    /// Reads every environment condition declared on a service.
+    /// </summary>
+    /// <returns>
+    /// Null when the service carries none, so that an unconditional registration keeps the model it
+    /// has always had and existing snapshots do not move.
+    /// </returns>
+    public static IReadOnlyList<EnvironmentConditionModel>? GetConditions(
+        SyntaxTransformContext context, SyntaxNode node, CancellationToken cancellationToken) {
+
+        if (node is not MemberDeclarationSyntax memberDeclaration) {
+            return null;
+        }
+
+        List<EnvironmentConditionModel>? conditions = null;
+
+        foreach (var attributeList in memberDeclaration.AttributeLists) {
+            foreach (var attribute in attributeList.Attributes) {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var condition = ReadCondition(context, attribute);
+
+                if (condition == null) {
+                    continue;
+                }
+
+                conditions ??= new List<EnvironmentConditionModel>();
+                conditions.Add(condition);
+            }
+        }
+
+        return conditions;
+    }
+
+    private static EnvironmentConditionModel? ReadCondition(
+        SyntaxTransformContext context, AttributeSyntax attribute) {
+
+        if (ModelExtensions.GetTypeInfo(context.SemanticModel, attribute).Type is not { } attributeType ||
+            attributeType.ContainingNamespace.GetFullName() != KnownTypes.DependencyModules.Attributes.Namespace) {
+            return null;
+        }
+
+        var kind = attributeType.Name switch {
+            IfEnvironment or IfNotEnvironment => EnvironmentConditionKind.Name,
+            IfEnvironmentValue or IfNotEnvironmentValue => EnvironmentConditionKind.Value,
+            _ => (EnvironmentConditionKind?)null,
+        };
+
+        if (kind == null) {
+            return null;
+        }
+
+        var negate = attributeType.Name is IfNotEnvironment or IfNotEnvironmentValue;
+        var arguments = ReadStringArguments(context, attribute);
+
+        if (kind == EnvironmentConditionKind.Name) {
+            return new EnvironmentConditionModel(
+                EnvironmentConditionKind.Name, negate, null, arguments);
+        }
+
+        // The key is the first argument; a second, when present, is the value it has to equal.
+        // Nothing at all is left as an empty key so the caller can report it rather than emit a
+        // test that can never pass.
+        var key = arguments.Count > 0 ? arguments[0] : "";
+        var values = arguments.Count > 1 ? new[] { arguments[1] } : Array.Empty<string>();
+
+        return new EnvironmentConditionModel(
+            EnvironmentConditionKind.Value, negate, key, values);
+    }
+
+    /// <summary>
+    /// The positional arguments, as constants. Named arguments are skipped — none of these
+    /// attributes has a settable property, so one can only be a mistake.
+    /// </summary>
+    private static IReadOnlyList<string> ReadStringArguments(
+        SyntaxTransformContext context, AttributeSyntax attribute) {
+
+        if (attribute.ArgumentList == null) {
+            return Array.Empty<string>();
+        }
+
+        var values = new List<string>();
+
+        foreach (var argument in attribute.ArgumentList.Arguments) {
+            if (argument.NameEquals != null) {
+                continue;
+            }
+
+            // GetConstantValue rather than the literal text, so nameof(...) and a const declared
+            // elsewhere both read as the string they evaluate to.
+            if (context.SemanticModel.GetConstantValue(argument.Expression).Value is string value) {
+                values.Add(value);
+            }
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    /// True when a condition names nothing to test, so its result never depends on the environment.
+    /// </summary>
+    /// <remarks>
+    /// <c>[IfEnvironment()]</c> and <c>[IfEnvironmentValue("")]</c> both compile. Written plain they
+    /// mean the service never registers; written as the <c>IfNot</c> form they mean the condition
+    /// does nothing at all. Either way the developer wrote a condition that does not condition on
+    /// anything, so it is reported rather than emitted.
+    /// </remarks>
+    public static bool IsEmpty(EnvironmentConditionModel condition) =>
+        condition.Kind switch {
+            EnvironmentConditionKind.Name => condition.Values.Count == 0,
+            EnvironmentConditionKind.Value => string.IsNullOrEmpty(condition.Key),
+            _ => false,
+        };
+
+    /// <summary>
+    /// A condition as it would read in a diagnostic message.
+    /// </summary>
+    public static string Describe(EnvironmentConditionModel condition) {
+        var not = condition.Negate ? "not " : "";
+
+        if (condition.Kind == EnvironmentConditionKind.Name) {
+            return $"environment is {not}{string.Join(" or ", condition.Values)}";
+        }
+
+        return condition.Values.Count > 0
+            ? $"'{condition.Key}' is {not}'{condition.Values[0]}'"
+            : $"'{condition.Key}' is {not}set";
+    }
+}

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
@@ -142,7 +142,8 @@ public class ServiceModelUtility {
             null,
             factoryOutput,
             registrations,
-            GetConstructionFeatures(context.Node));
+            GetConstructionFeatures(context.Node),
+            EnvironmentConditionUtility.GetConditions(context, context.Node, cancellationToken));
     }
 
     public static ConstructorInfoModel? GetConstructorInfo(SyntaxTransformContext context, SyntaxNode node, CancellationToken cancellationToken) {

--- a/src/DependencyModules.SourceGenerator/ServiceSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/ServiceSourceGenerator.cs
@@ -44,6 +44,8 @@ public class ServiceSourceGenerator : BaseAttributeSourceGenerator<ServiceModel>
             return;
         }
 
+        ReportEnvironmentConditions(context, serviceModels, logger);
+
         var (entryPointList, configurationModel) =
             EntryModelUtil.ConsolidateEntryPointModels(inputData.Left);
 
@@ -156,6 +158,64 @@ public class ServiceSourceGenerator : BaseAttributeSourceGenerator<ServiceModel>
         }
 
         return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Reports what each conditional registration depends on, and refuses conditions that name
+    /// nothing to test.
+    /// </summary>
+    /// <remarks>
+    /// Whether a condition holds is a run-time question, so there is no build error to raise for the
+    /// ordinary case and DM0011 is informational. DM0012 is the case that is decidable here: a
+    /// condition with no name or no key does not depend on the environment at all, whatever it was
+    /// meant to say.
+    /// </remarks>
+    private static void ReportEnvironmentConditions(
+        SourceProductionContext context, ImmutableArray<ServiceModel> serviceModels, FileLogger logger) {
+
+        foreach (var serviceModel in serviceModels) {
+            if (serviceModel.Conditions is not { Count: > 0 } conditions) {
+                continue;
+            }
+
+            var typeName = serviceModel.ImplementationType.Name;
+
+            foreach (var condition in conditions) {
+                if (!EnvironmentConditionUtility.IsEmpty(condition)) {
+                    continue;
+                }
+
+                var kind = condition.Kind == EnvironmentConditionKind.Name ? "environment name" : "key";
+
+                logger.Error($"'{typeName}' has an environment condition that names no {kind}.");
+
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        DependencyModuleDiagnostics.EmptyEnvironmentCondition,
+                        Location.None,
+                        typeName,
+                        kind));
+            }
+
+            var described = conditions
+                .Where(condition => !EnvironmentConditionUtility.IsEmpty(condition))
+                .Select(EnvironmentConditionUtility.Describe)
+                .ToArray();
+
+            if (described.Length == 0) {
+                continue;
+            }
+
+            var summary = string.Join(" and ", described);
+
+            logger.Info($"'{typeName}' registers only when {summary}.");
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    DependencyModuleDiagnostics.RegisteredConditionally,
+                    Location.None,
+                    summary));
+        }
     }
 
     private static bool IsUnconstructable(ServiceModel serviceModel) =>

--- a/tests/DependencyModules.Tests/GeneratorTests/ConventionRegistrationTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ConventionRegistrationTests.cs
@@ -1,3 +1,4 @@
+using DependencyModules.Runtime;
 using DependencyModules.Tests.Infrastructure;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,6 +31,44 @@ public class ConventionRegistrationTests {
 
     private static GeneratorResult Run(string source) =>
         GeneratorTestHarness.Run(Preamble + source, withConventions: true);
+
+    /// <summary>
+    /// A convention candidate carrying an environment condition registers on the same terms the
+    /// attribute path would.
+    /// </summary>
+    /// <remarks>
+    /// A class with a service attribute is never a convention candidate, so a condition on a
+    /// convention-matched class has no other route. Ignoring it would put a development-only
+    /// service into production with nothing at the declaration saying why.
+    /// </remarks>
+    [Theory]
+    [InlineData("Development", 2)]
+    [InlineData("Production", 1)]
+    public void ConventionsHonourEnvironmentConditions(string environmentName, int expected) {
+        const string source =
+            """
+            public interface IFoo { }
+
+            public class AlwaysFoo : IFoo { }
+
+            [IfEnvironment("Development")]
+            public class DevOnlyFoo : IFoo { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSingleton();
+                }
+            }
+            """;
+
+        var assembly = GeneratedAssembly.Create(
+            Preamble + source,
+            withConventions: true,
+            environment: new ModuleEnvironment(environmentName));
+
+        Assert.Equal(expected, assembly.Descriptors("IFoo").Count);
+    }
 
     [Fact]
     public void RegistersEveryTypeDeclaringTheServiceInterface() {

--- a/tests/DependencyModules.Tests/GeneratorTests/EnvironmentConditionTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/EnvironmentConditionTests.cs
@@ -1,0 +1,480 @@
+using DependencyModules.Runtime;
+using DependencyModules.Runtime.Interfaces;
+using DependencyModules.Tests.Infrastructure;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// Behavioural tests for environment-conditional registration.
+/// </summary>
+/// <remarks>
+/// Each case compiles, loads and applies the module under a given environment, then asserts what is
+/// actually in the collection. A condition emitted into the wrong branch still produces plausible
+/// generated text, so text assertions would pass while the service registered in production.
+/// </remarks>
+public class EnvironmentConditionTests {
+
+    private const string Preamble =
+        """
+        using System;
+        using DependencyModules.Runtime.Attributes;
+
+        namespace TestNamespace;
+
+        """;
+
+    private static GeneratedAssembly Compile(string source, IModuleEnvironment? environment) =>
+        GeneratedAssembly.Create(Preamble + source, environment: environment);
+
+    private static IModuleEnvironment Env(string name) => new ModuleEnvironment(name);
+
+    private static IModuleEnvironment Env(string name, params (string Key, string? Value)[] values) =>
+        new ModuleEnvironment(name, values.ToDictionary(v => v.Key, v => v.Value));
+
+    private const string NameGated =
+        """
+        public interface IEmailSender { }
+
+        [SingletonService]
+        [IfEnvironment("Development", "Staging")]
+        public class FakeEmailSender : IEmailSender { }
+        """;
+
+    private const string Module =
+        """
+
+        [DependencyModule]
+        public partial class TestModule;
+        """;
+
+    [Theory]
+    [InlineData("Development", true)]
+    [InlineData("Staging", true)]
+    [InlineData("development", true)]
+    [InlineData("Production", false)]
+    [InlineData("", false)]
+    public void IfEnvironmentRegistersOnlyInTheNamedEnvironments(string environmentName, bool expected) {
+        var assembly = Compile(NameGated + Module, Env(environmentName));
+
+        Assert.Equal(expected, assembly.Descriptors("IEmailSender").Count == 1);
+    }
+
+    [Fact]
+    public void IfNotEnvironmentRegistersEverywhereElse() {
+        const string source =
+            """
+            public interface IProfiler { }
+
+            [SingletonService]
+            [IfNotEnvironment("Production")]
+            public class RequestProfiler : IProfiler { }
+            """;
+
+        Assert.Single(Compile(source + Module, Env("Development")).Descriptors("IProfiler"));
+        Assert.Empty(Compile(source + Module, Env("Production")).Descriptors("IProfiler"));
+    }
+
+    [Fact]
+    public void IfEnvironmentValueTestsPresenceWhenGivenOnlyAKey() {
+        const string source =
+            """
+            public interface IBilling { }
+
+            [SingletonService]
+            [IfEnvironmentValue("FEATURE_BILLING")]
+            public class Billing : IBilling { }
+            """;
+
+        Assert.Single(Compile(source + Module, Env("Any", ("FEATURE_BILLING", "anything"))).Descriptors("IBilling"));
+
+        // Set to empty is still set; only absence is absence.
+        Assert.Single(Compile(source + Module, Env("Any", ("FEATURE_BILLING", ""))).Descriptors("IBilling"));
+
+        Assert.Empty(Compile(source + Module, Env("Any")).Descriptors("IBilling"));
+    }
+
+    [Fact]
+    public void IfEnvironmentValueComparesTheValueExactly() {
+        const string source =
+            """
+            public interface IBilling { }
+
+            [SingletonService]
+            [IfEnvironmentValue("MODE", "on")]
+            public class Billing : IBilling { }
+            """;
+
+        Assert.Single(Compile(source + Module, Env("Any", ("MODE", "on"))).Descriptors("IBilling"));
+
+        // Values are data, so unlike environment names they are compared ordinally.
+        Assert.Empty(Compile(source + Module, Env("Any", ("MODE", "On"))).Descriptors("IBilling"));
+        Assert.Empty(Compile(source + Module, Env("Any", ("MODE", "off"))).Descriptors("IBilling"));
+    }
+
+    [Fact]
+    public void ConditionsOfDifferentKindsCombineWithAnd() {
+        const string source =
+            """
+            public interface IThing { }
+
+            [SingletonService]
+            [IfEnvironment("Development")]
+            [IfEnvironmentValue("MODE", "on")]
+            public class Thing : IThing { }
+            """;
+
+        Assert.Single(Compile(source + Module, Env("Development", ("MODE", "on"))).Descriptors("IThing"));
+        Assert.Empty(Compile(source + Module, Env("Development", ("MODE", "off"))).Descriptors("IThing"));
+        Assert.Empty(Compile(source + Module, Env("Production", ("MODE", "on"))).Descriptors("IThing"));
+    }
+
+    [Fact]
+    public void SeveralValueConditionsAllHaveToHold() {
+        const string source =
+            """
+            public interface IThing { }
+
+            [SingletonService]
+            [IfEnvironmentValue("A", "1")]
+            [IfEnvironmentValue("B", "2")]
+            public class Thing : IThing { }
+            """;
+
+        Assert.Single(Compile(source + Module, Env("Any", ("A", "1"), ("B", "2"))).Descriptors("IThing"));
+        Assert.Empty(Compile(source + Module, Env("Any", ("A", "1"))).Descriptors("IThing"));
+    }
+
+    /// <summary>
+    /// A conditional registration has to be able to override an unconditional default for the same
+    /// service type.
+    /// </summary>
+    /// <remarks>
+    /// The container resolves a single service from the last matching descriptor, so this only works
+    /// if conditional registrations are emitted after unconditional ones. Both orderings compile and
+    /// both look right in the generated file; only one of them registers the override.
+    ///
+    /// The names are deliberate. Service models are emitted in name order, so "Fake" sorts before
+    /// "Smtp" and the default would land last and win in every environment.
+    /// </remarks>
+    [Fact]
+    public void AConditionalRegistrationOverridesAnUnconditionalDefault() {
+        const string source =
+            """
+            public interface IEmailSender { }
+
+            [SingletonService]
+            public class SmtpEmailSender : IEmailSender { }
+
+            [SingletonService]
+            [IfEnvironment("Development")]
+            public class FakeEmailSender : IEmailSender { }
+            """;
+
+        var development = Compile(source + Module, Env("Development"));
+        var production = Compile(source + Module, Env("Production"));
+
+        Assert.Equal(
+            development.Type("FakeEmailSender"),
+            development.BuildProvider().GetService(development.Type("IEmailSender"))!.GetType());
+
+        Assert.Equal(
+            production.Type("SmtpEmailSender"),
+            production.BuildProvider().GetService(production.Type("IEmailSender"))!.GetType());
+    }
+
+    /// <summary>
+    /// The motivating case: one service type, two implementations, exactly one registered.
+    /// </summary>
+    [Fact]
+    public void TwoImplementationsOfOneServiceSelectByEnvironment() {
+        const string source =
+            """
+            public interface IEmailSender { string Name { get; } }
+
+            [SingletonService]
+            [IfEnvironment("Development")]
+            public class FakeEmailSender : IEmailSender { public string Name => "fake"; }
+
+            [SingletonService]
+            [IfNotEnvironment("Development")]
+            public class SmtpEmailSender : IEmailSender { public string Name => "smtp"; }
+            """;
+
+        var development = Compile(source + Module, Env("Development"));
+        var production = Compile(source + Module, Env("Production"));
+
+        Assert.Equal(development.Type("FakeEmailSender"), development.Descriptor("IEmailSender").ImplementationType);
+        Assert.Equal(production.Type("SmtpEmailSender"), production.Descriptor("IEmailSender").ImplementationType);
+    }
+
+    [Fact]
+    public void UnconditionalServicesInTheSameModuleAreUnaffected() {
+        const string source =
+            """
+            public interface IAlways { }
+            public interface ISometimes { }
+
+            [SingletonService]
+            public class Always : IAlways { }
+
+            [SingletonService]
+            [IfEnvironment("Development")]
+            public class Sometimes : ISometimes { }
+            """;
+
+        var production = Compile(source + Module, Env("Production"));
+
+        Assert.Single(production.Descriptors("IAlways"));
+        Assert.Empty(production.Descriptors("ISometimes"));
+    }
+
+    [Fact]
+    public void ModuleEnvironmentNoneRegistersNothingConditional() {
+        var assembly = Compile(NameGated + Module, ModuleEnvironment.None);
+
+        Assert.Empty(assembly.Descriptors("IEmailSender"));
+    }
+
+    /// <summary>
+    /// No environment supplied behaves exactly as if the process environment had been passed.
+    /// </summary>
+    /// <remarks>
+    /// Compared against <see cref="ModuleEnvironment.Default"/> rather than against "Production", so
+    /// that this does not depend on what the variables happen to be while the suite runs — which
+    /// ModuleEnvironmentDefaultNameTests moves on purpose.
+    /// </remarks>
+    [Fact]
+    public void NoEnvironmentSuppliedUsesTheProcessEnvironment() {
+        var supplied = Compile(NameGated + Module, ModuleEnvironment.Default);
+        var omitted = Compile(NameGated + Module, environment: null);
+
+        Assert.Equal(
+            supplied.Descriptors("IEmailSender").Count,
+            omitted.Descriptors("IEmailSender").Count);
+    }
+
+    /// <summary>
+    /// Across modules, module order decides — a referenced module's conditional registration does
+    /// not jump ahead of the registrations of the module that references it.
+    /// </summary>
+    /// <remarks>
+    /// This is what makes a global "apply all conditionals last" phase, like the one decorators get,
+    /// the wrong shape. Modules are expanded dependencies-first, so the referencing module applies
+    /// last and its registrations win. A conditional phase would let a library's
+    /// <c>[IfEnvironment]</c> beat an application's own implementation, inverting a precedence the
+    /// application controls and can see.
+    ///
+    /// A condition says "instead of my other registration, here". It does not say "instead of
+    /// yours".
+    /// </remarks>
+    [Theory]
+    [InlineData("Development")]
+    [InlineData("Production")]
+    public void AReferencedModuleConditionalDoesNotOverrideTheReferencingModule(string environmentName) {
+        const string source =
+            """
+            public interface IEmailSender { }
+
+            [SingletonService(Realm = typeof(LibraryModule))]
+            [IfEnvironment("Development")]
+            public class LibraryFake : IEmailSender { }
+
+            [SingletonService(Realm = typeof(TestModule))]
+            public class ApplicationOwn : IEmailSender { }
+
+            [DependencyModule]
+            public partial class LibraryModule;
+
+            [LibraryModule]
+            [DependencyModule]
+            public partial class TestModule;
+            """;
+
+        var assembly = Compile(source, Env(environmentName));
+
+        Assert.Equal(
+            assembly.Type("ApplicationOwn"),
+            assembly.BuildProvider().GetService(assembly.Type("IEmailSender"))!.GetType());
+    }
+
+    /// <summary>
+    /// The direction that has to work: a referenced module registers the default, and the
+    /// application conditionally overrides it.
+    /// </summary>
+    [Theory]
+    [InlineData("Development", "ApplicationFake")]
+    [InlineData("Production", "LibrarySmtp")]
+    public void AnApplicationConditionalOverridesAReferencedModuleDefault(
+        string environmentName, string expected) {
+
+        const string source =
+            """
+            public interface IEmailSender { }
+
+            [SingletonService(Realm = typeof(LibraryModule))]
+            public class LibrarySmtp : IEmailSender { }
+
+            [SingletonService(Realm = typeof(TestModule))]
+            [IfEnvironment("Development")]
+            public class ApplicationFake : IEmailSender { }
+
+            [DependencyModule]
+            public partial class LibraryModule;
+
+            [LibraryModule]
+            [DependencyModule]
+            public partial class TestModule;
+            """;
+
+        var assembly = Compile(source, Env(environmentName));
+
+        Assert.Equal(
+            assembly.Type(expected),
+            assembly.BuildProvider().GetService(assembly.Type("IEmailSender"))!.GetType());
+    }
+
+    /// <summary>
+    /// A conditional registration is additive: it shadows the default for a single resolve, and
+    /// both are still in the enumerable.
+    /// </summary>
+    [Fact]
+    public void AConditionalOverrideLeavesTheDefaultInTheEnumerable() {
+        const string source =
+            """
+            public interface IEmailSender { }
+
+            [SingletonService]
+            public class SmtpEmailSender : IEmailSender { }
+
+            [SingletonService]
+            [IfEnvironment("Development")]
+            public class FakeEmailSender : IEmailSender { }
+            """;
+
+        var assembly = Compile(source + Module, Env("Development"));
+
+        Assert.Equal(2, assembly.Descriptors("IEmailSender").Count);
+    }
+
+    /// <summary>
+    /// "When" and "how" are separate. A condition says when a registration happens; Using says what
+    /// kind of registration it is, and the two compose.
+    /// </summary>
+    [Fact]
+    public void AConditionCombinesWithReplace() {
+        const string source =
+            """
+            public interface IEmailSender { }
+
+            [SingletonService]
+            public class SmtpEmailSender : IEmailSender { }
+
+            [SingletonService(Using = RegistrationType.Replace)]
+            [IfEnvironment("Development")]
+            public class FakeEmailSender : IEmailSender { }
+            """;
+
+        var development = Compile(source + Module, Env("Development"));
+        var production = Compile(source + Module, Env("Production"));
+
+        Assert.Single(development.Descriptors("IEmailSender"));
+        Assert.Equal(development.Type("FakeEmailSender"), development.Descriptor("IEmailSender").ImplementationType);
+
+        Assert.Single(production.Descriptors("IEmailSender"));
+        Assert.Equal(production.Type("SmtpEmailSender"), production.Descriptor("IEmailSender").ImplementationType);
+    }
+
+    [Fact]
+    public void ConditionsAreReportedAtBuildTime() {
+        var result = GeneratorTestHarness.Run(Preamble + NameGated + Module);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0011");
+
+        Assert.Contains("Development or Staging", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void UnconditionalServicesReportNothing() {
+        const string source =
+            """
+            public interface IThing { }
+
+            [SingletonService]
+            public class Thing : IThing { }
+            """;
+
+        var result = GeneratorTestHarness.Run(Preamble + source + Module);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id is "DM0011" or "DM0012");
+    }
+
+    [Theory]
+    [InlineData("[IfEnvironment]", "environment name")]
+    [InlineData("[IfNotEnvironment]", "environment name")]
+    [InlineData("[IfEnvironmentValue(\"\")]", "key")]
+    public void AConditionThatTestsNothingIsRefused(string attribute, string expectedKind) {
+        var source =
+            $$"""
+              public interface IThing { }
+
+              [SingletonService]
+              {{attribute}}
+              public class Thing : IThing { }
+              """;
+
+        var result = GeneratorTestHarness.Run(Preamble + source + Module);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0012");
+
+        Assert.Contains(expectedKind, diagnostic.GetMessage());
+
+        // Reported, not silently dropped: the service still registers rather than vanishing.
+        Assert.Single(
+            GeneratedAssembly.Create(Preamble + source + Module, environment: ModuleEnvironment.None)
+                .Descriptors("IThing"));
+    }
+
+    /// <summary>
+    /// A const rather than a literal has to read as the string it evaluates to, or a codebase that
+    /// keeps its environment names in one place would silently never match.
+    /// </summary>
+    [Fact]
+    public void ConditionArgumentsMayBeConstants() {
+        const string source =
+            """
+            public static class Environments {
+                public const string Development = "Development";
+            }
+
+            public interface IThing { }
+
+            [SingletonService]
+            [IfEnvironment(Environments.Development)]
+            public class Thing : IThing { }
+            """;
+
+        Assert.Single(Compile(source + Module, Env("Development")).Descriptors("IThing"));
+        Assert.Empty(Compile(source + Module, Env("Production")).Descriptors("IThing"));
+    }
+
+    /// <summary>
+    /// The attribute resolved through the semantic model rather than matched on how it was written.
+    /// A namespace-qualified usage silently matching nothing is a bug this generator has had once
+    /// already, and here it would register a development service in production.
+    /// </summary>
+    [Fact]
+    public void ANamespaceQualifiedConditionStillApplies() {
+        const string source =
+            """
+            public interface IThing { }
+
+            [SingletonService]
+            [DependencyModules.Runtime.Attributes.IfEnvironment("Development")]
+            public class Thing : IThing { }
+            """;
+
+        Assert.Single(Compile(source + Module, Env("Development")).Descriptors("IThing"));
+        Assert.Empty(Compile(source + Module, Env("Production")).Descriptors("IThing"));
+    }
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/ModuleGenerationSnapshotTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ModuleGenerationSnapshotTests.cs
@@ -35,6 +35,50 @@ public class ModuleGenerationSnapshotTests {
         Snapshot.Match(result.ToSnapshot());
     }
 
+    /// <summary>
+    /// The shape of an environment-conditional registration: the guard, the environment parameter
+    /// that appears only because something in the module needs it, and the unconditional service
+    /// staying outside the guard.
+    ///
+    /// Also the ordering rule. FakeEmailSender sorts before SmtpEmailSender by name, but has to be
+    /// emitted after it, because the container resolves a single service from the last matching
+    /// descriptor and the conditional registration is the override.
+    /// </summary>
+    [Fact]
+    public void ModuleWithEnvironmentConditions() {
+        var result = GeneratorTestHarness.Run(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            public interface IAlways;
+            public interface IEmailSender;
+            public interface IBilling;
+
+            [SingletonService]
+            public class Always : IAlways;
+
+            [SingletonService]
+            public class SmtpEmailSender : IEmailSender;
+
+            [SingletonService]
+            [IfEnvironment("Development", "Staging")]
+            public class FakeEmailSender : IEmailSender;
+
+            [SingletonService]
+            [IfNotEnvironment("Production")]
+            [IfEnvironmentValue("FEATURE_BILLING", "on")]
+            public class Billing : IBilling;
+
+            [DependencyModule]
+            public partial class TestModule;
+            """);
+
+        result.AssertNoErrors();
+        Snapshot.Match(result.ToSnapshot());
+    }
+
     [Fact]
     public void ModuleWithAllServiceLifetimes() {
         var result = GeneratorTestHarness.Run(

--- a/tests/DependencyModules.Tests/Infrastructure/GeneratedAssembly.cs
+++ b/tests/DependencyModules.Tests/Infrastructure/GeneratedAssembly.cs
@@ -41,11 +41,16 @@ public class GeneratedAssembly {
     /// <param name="moduleName">Name of the module type to apply, without its namespace.</param>
     /// <param name="buildProperties">MSBuild properties visible to the generator.</param>
     /// <param name="withConventions">Also runs the convention generator, which ships separately.</param>
+    /// <param name="environment">
+    /// The environment conditional registrations are evaluated against. Null takes the path an
+    /// application takes when it calls AddModules without one, which is the process environment.
+    /// </param>
     public static GeneratedAssembly Create(
         string source,
         string moduleName = "TestModule",
         IReadOnlyDictionary<string, string>? buildProperties = null,
-        bool withConventions = false) {
+        bool withConventions = false,
+        IModuleEnvironment? environment = null) {
 
         var assemblyName = "GeneratedAssemblyTest" + Interlocked.Increment(ref _assemblyCounter);
 
@@ -71,7 +76,10 @@ public class GeneratedAssembly {
         }
 
         var services = new ServiceCollection();
-        services.AddModule(module);
+
+        // AddModules rather than AddModule so an environment can be supplied; both reach
+        // DependencyRegistry.LoadModules, and AddModules is the call an application makes.
+        services.AddModules(environment, module);
 
         return new GeneratedAssembly(assembly, services);
     }

--- a/tests/DependencyModules.Tests/RuntimeTests/ModuleEnvironmentTests.cs
+++ b/tests/DependencyModules.Tests/RuntimeTests/ModuleEnvironmentTests.cs
@@ -1,0 +1,220 @@
+using Microsoft.Extensions.DependencyInjection;
+using DependencyModules.Runtime;
+using DependencyModules.Runtime.Helpers;
+using DependencyModules.Runtime.Interfaces;
+using Xunit;
+
+namespace DependencyModules.Tests.RuntimeTests;
+
+public class ModuleEnvironmentTests {
+
+    [Fact]
+    public void ValuesComeBackByName() {
+        var environment = new ModuleEnvironment(
+            "Development",
+            new Dictionary<string, string?> { ["A"] = "1", ["Empty"] = "" });
+
+        Assert.Equal("Development", environment.EnvironmentName);
+        Assert.Equal("1", environment.Value("A"));
+        Assert.Equal("", environment.Value("Empty"));
+        Assert.Null(environment.Value("Missing"));
+    }
+
+    [Fact]
+    public void ValuesAreOptional() {
+        var environment = new ModuleEnvironment("Production");
+
+        Assert.Null(environment.Value("Anything"));
+    }
+
+    [Fact]
+    public void NoneHasNoNameAndNoValues() {
+        Assert.Equal("", ModuleEnvironment.None.EnvironmentName);
+        Assert.Null(ModuleEnvironment.None.Value("Anything"));
+    }
+
+    [Fact]
+    public void DefaultReadsValuesFromTheProcess() {
+        // Uniquely named so nothing else in the suite can be looking at it.
+        var key = "DM_TEST_" + Guid.NewGuid().ToString("N");
+
+        Assert.Null(ModuleEnvironment.Default.Value(key));
+
+        try {
+            Environment.SetEnvironmentVariable(key, "set-after-startup");
+
+            // Read on each call rather than captured, so a variable set later is still seen.
+            Assert.Equal("set-after-startup", ModuleEnvironment.Default.Value(key));
+        } finally {
+            Environment.SetEnvironmentVariable(key, null);
+        }
+    }
+}
+
+/// <summary>
+/// The name fallback, which can only be exercised by moving process-wide variables.
+/// </summary>
+/// <remarks>
+/// In its own collection so these do not run alongside each other. Nothing else in the suite reads
+/// these two variables — the generator tests that involve a default environment compare against
+/// <see cref="ModuleEnvironment.Default"/> rather than against a literal name, for this reason.
+/// </remarks>
+[Collection("ProcessEnvironment")]
+public class ModuleEnvironmentDefaultNameTests {
+
+    private const string AspNetCore = "ASPNETCORE_ENVIRONMENT";
+    private const string DotNet = "DOTNET_ENVIRONMENT";
+
+    [Theory]
+    [InlineData(null, null, "Production")]
+    [InlineData("Development", null, "Development")]
+    [InlineData(null, "Staging", "Staging")]
+    // ASPNETCORE_ENVIRONMENT wins, matching how a web host resolves it.
+    [InlineData("Development", "Staging", "Development")]
+    public void DefaultResolvesTheEnvironmentName(string? aspNetCore, string? dotNet, string expected) {
+        var originalAspNetCore = Environment.GetEnvironmentVariable(AspNetCore);
+        var originalDotNet = Environment.GetEnvironmentVariable(DotNet);
+
+        try {
+            Environment.SetEnvironmentVariable(AspNetCore, aspNetCore);
+            Environment.SetEnvironmentVariable(DotNet, dotNet);
+
+            Assert.Equal(expected, ModuleEnvironment.Default.EnvironmentName);
+        } finally {
+            Environment.SetEnvironmentVariable(AspNetCore, originalAspNetCore);
+            Environment.SetEnvironmentVariable(DotNet, originalDotNet);
+        }
+    }
+}
+
+/// <summary>
+/// How the one environment for an AddModules call is arrived at.
+/// </summary>
+/// <remarks>
+/// One environment, not several. It decides what gets registered, which is a single question with a
+/// single answer; several would need a rule for which one the conditions read, and that rule would
+/// fall out of module ordering rather than out of anything the developer wrote.
+/// </remarks>
+public class EnvironmentDiscoveryTests {
+
+    private class StubEnvironment(string name) : IModuleEnvironment {
+        public string EnvironmentName => name;
+        public string? Value(string valueName) => null;
+    }
+
+    private class ProbeModule : IDependencyModule, IEnvironmentServiceCollectionConfiguration {
+        public IModuleEnvironment? Seen { get; private set; }
+
+        public void PopulateServiceCollection(IServiceCollection serviceCollection) { }
+
+        public void ConfigureServices(IServiceCollection services, IModuleEnvironment environment) =>
+            Seen = environment;
+    }
+
+    [Fact]
+    public void AnInstanceRegisteredBeforeAddModulesIsUsed() {
+        var environment = new StubEnvironment("Staging");
+        var module = new ProbeModule();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton<IModuleEnvironment>(environment);
+        collection.AddModules(module);
+
+        Assert.Same(environment, module.Seen);
+        Assert.Single(collection, d => d.ServiceType == typeof(IModuleEnvironment));
+    }
+
+    [Fact]
+    public void AnEnvironmentPassedToAddModulesReplacesOneAlreadyRegistered() {
+        var registered = new StubEnvironment("Staging");
+        var passed = new StubEnvironment("Development");
+        var module = new ProbeModule();
+
+        var collection = new ServiceCollection();
+        collection.AddSingleton<IModuleEnvironment>(registered);
+        collection.AddModules(passed, module);
+
+        Assert.Same(passed, module.Seen);
+
+        // Replaced rather than joined, so what resolves is what decided the registrations.
+        var descriptor = Assert.Single(collection, d => d.ServiceType == typeof(IModuleEnvironment));
+        Assert.Same(passed, descriptor.ImplementationInstance);
+    }
+
+    /// <summary>
+    /// Registered by type it cannot be constructed — there is no provider yet — so it is refused
+    /// rather than ignored in favour of the process default.
+    /// </summary>
+    [Fact]
+    public void AnEnvironmentRegisteredByTypeIsRefused() {
+        var collection = new ServiceCollection();
+        collection.AddSingleton<IModuleEnvironment, StubByType>();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => collection.AddModules(new ProbeModule()));
+
+        Assert.Contains("singleton instance", exception.Message);
+    }
+
+    [Fact]
+    public void AnEnvironmentRegisteredByFactoryIsRefused() {
+        var collection = new ServiceCollection();
+        collection.AddSingleton<IModuleEnvironment>(_ => new StubEnvironment("Development"));
+
+        Assert.Throws<InvalidOperationException>(() => collection.AddModules(new ProbeModule()));
+    }
+
+    private class StubByType : IModuleEnvironment {
+        public string EnvironmentName => "Development";
+        public string? Value(string valueName) => null;
+    }
+}
+
+public class EnvironmentConditionsTests {
+
+    private static IModuleEnvironment Env(string name, params (string Key, string? Value)[] values) =>
+        new ModuleEnvironment(name, values.ToDictionary(v => v.Key, v => v.Value));
+
+    [Theory]
+    [InlineData("Development", true)]
+    [InlineData("development", true)]
+    [InlineData("DEVELOPMENT", true)]
+    [InlineData("Production", false)]
+    public void NameIsIgnoresCase(string environmentName, bool expected) =>
+        Assert.Equal(expected, EnvironmentConditions.NameIs(Env(environmentName), "Development"));
+
+    [Fact]
+    public void NameIsAcceptsAnyOfSeveral() {
+        Assert.True(EnvironmentConditions.NameIs(Env("Staging"), "Development", "Staging"));
+        Assert.False(EnvironmentConditions.NameIs(Env("Production"), "Development", "Staging"));
+    }
+
+    [Fact]
+    public void NameIsWithNoNamesMatchesNothing() =>
+        Assert.False(EnvironmentConditions.NameIs(Env("Development")));
+
+    [Fact]
+    public void HasValueIsPresenceNotTruthiness() {
+        Assert.True(EnvironmentConditions.HasValue(Env("Any", ("K", "v")), "K"));
+        Assert.True(EnvironmentConditions.HasValue(Env("Any", ("K", "")), "K"));
+        Assert.False(EnvironmentConditions.HasValue(Env("Any"), "K"));
+    }
+
+    [Fact]
+    public void ValueIsComparesOrdinally() {
+        Assert.True(EnvironmentConditions.ValueIs(Env("Any", ("K", "on")), "K", "on"));
+        Assert.False(EnvironmentConditions.ValueIs(Env("Any", ("K", "On")), "K", "on"));
+        Assert.False(EnvironmentConditions.ValueIs(Env("Any"), "K", "on"));
+    }
+
+    /// <summary>
+    /// Generated code is handed a non-null environment, but these are public and a hand-written
+    /// module can reach them. Refusing to match beats throwing out of a registration.
+    /// </summary>
+    [Fact]
+    public void ANullEnvironmentMatchesNothing() {
+        Assert.False(EnvironmentConditions.NameIs(null!, "Development"));
+        Assert.False(EnvironmentConditions.HasValue(null!, "K"));
+        Assert.False(EnvironmentConditions.ValueIs(null!, "K", "v"));
+    }
+}

--- a/tests/DependencyModules.Tests/RuntimeTests/ModuleLoadingTests.cs
+++ b/tests/DependencyModules.Tests/RuntimeTests/ModuleLoadingTests.cs
@@ -166,16 +166,34 @@ public class ModuleLoadingTests {
         Assert.Same(environment, module.ObservedEnvironment);
     }
 
+    /// <summary>
+    /// No environment supplied means the process default, not null.
+    /// </summary>
+    /// <remarks>
+    /// The same environment the [IfEnvironment] attributes are evaluated against. A module that got
+    /// null here while its own conditional registrations evaluated against Production would be
+    /// looking at two different answers to the same question.
+    /// </remarks>
     [Fact]
-    public void AddModules_WithoutEnvironment_PassesNullToConfiguration() {
+    public void AddModules_WithoutEnvironment_PassesTheProcessDefaultToConfiguration() {
         var module = new EnvironmentModule();
 
         var collection = new ServiceCollection();
         // Cast is required: without it the call is ambiguous with AddModules(params IDependencyModule[]).
         collection.AddModules((IModuleEnvironment?)null, module);
 
-        Assert.Null(module.ObservedEnvironment);
+        Assert.Same(ModuleEnvironment.Default, module.ObservedEnvironment);
         Assert.True(module.ConfigureCalled);
+    }
+
+    [Fact]
+    public void AddModules_WithModuleEnvironmentNone_PassesNoneRatherThanTheDefault() {
+        var module = new EnvironmentModule();
+
+        var collection = new ServiceCollection();
+        collection.AddModules(ModuleEnvironment.None, module);
+
+        Assert.Same(ModuleEnvironment.None, module.ObservedEnvironment);
     }
 
     [Fact]
@@ -300,7 +318,7 @@ public class ModuleLoadingTests {
 
         public void PopulateServiceCollection(IServiceCollection serviceCollection) { }
 
-        public void ConfigureServices(IServiceCollection services, IModuleEnvironment? environment) {
+        public void ConfigureServices(IServiceCollection services, IModuleEnvironment environment) {
             ConfigureCalled = true;
             ObservedEnvironment = environment;
         }

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.GenericServiceRegistrations.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.GenericServiceRegistrations.verified.txt
@@ -57,6 +57,15 @@ namespace TestNamespace
         }
 
         [Browsable(false)]
+        void global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalApplyServices(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services, global::DependencyModules.Runtime.Interfaces.IModuleEnvironment environment)
+        {
+            global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.ApplyServices(
+                services,
+                environment
+            );
+        }
+
+        [Browsable(false)]
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithAllServiceLifetimes.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithAllServiceLifetimes.verified.txt
@@ -61,6 +61,15 @@ namespace TestNamespace
         }
 
         [Browsable(false)]
+        void global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalApplyServices(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services, global::DependencyModules.Runtime.Interfaces.IModuleEnvironment environment)
+        {
+            global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.ApplyServices(
+                services,
+                environment
+            );
+        }
+
+        [Browsable(false)]
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithConstructorParametersAndProperties.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithConstructorParametersAndProperties.verified.txt
@@ -54,6 +54,15 @@ namespace TestNamespace
         }
 
         [Browsable(false)]
+        void global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalApplyServices(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services, global::DependencyModules.Runtime.Interfaces.IModuleEnvironment environment)
+        {
+            global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.ApplyServices(
+                services,
+                environment
+            );
+        }
+
+        [Browsable(false)]
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithCoverageExclusionDisabled.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithCoverageExclusionDisabled.verified.txt
@@ -52,6 +52,15 @@ namespace TestNamespace
         }
 
         [Browsable(false)]
+        void global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalApplyServices(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services, global::DependencyModules.Runtime.Interfaces.IModuleEnvironment environment)
+        {
+            global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.ApplyServices(
+                services,
+                environment
+            );
+        }
+
+        [Browsable(false)]
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithEnvironmentConditions.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.ModuleWithEnvironmentConditions.verified.txt
@@ -1,4 +1,5 @@
 // ---- TestModule.Dependencies.g.cs ----
+using DependencyModules.Runtime.Interfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System.Diagnostics.CodeAnalysis;
@@ -11,17 +12,30 @@ namespace TestNamespace
         [DynamicDependency(nameof(ModuleDependencies))]
         private static int moduleField = global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.Add(ModuleDependencies);
 
-        private static void ModuleDependencies(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services)
+        private static void ModuleDependencies(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services, global::DependencyModules.Runtime.Interfaces.IModuleEnvironment environment)
         {
             services.AddSingleton(
-                typeof(global::TestNamespace.IOther),
-                typeof(global::TestNamespace.AsThing)
+                typeof(global::TestNamespace.IAlways),
+                typeof(global::TestNamespace.Always)
             );
-            services.AddKeyedSingleton(
-                typeof(global::TestNamespace.IThing),
-                "the-key",
-                typeof(global::TestNamespace.KeyedThing)
+            services.AddSingleton(
+                typeof(global::TestNamespace.IEmailSender),
+                typeof(global::TestNamespace.SmtpEmailSender)
             );
+            if (!global::DependencyModules.Runtime.Helpers.EnvironmentConditions.NameIs(environment, "Production") && global::DependencyModules.Runtime.Helpers.EnvironmentConditions.ValueIs(environment, "FEATURE_BILLING", "on"))
+            {
+                services.AddSingleton(
+                    typeof(global::TestNamespace.IBilling),
+                    typeof(global::TestNamespace.Billing)
+                );
+            }
+            if (global::DependencyModules.Runtime.Helpers.EnvironmentConditions.NameIs(environment, "Development", "Staging"))
+            {
+                services.AddSingleton(
+                    typeof(global::TestNamespace.IEmailSender),
+                    typeof(global::TestNamespace.FakeEmailSender)
+                );
+            }
         }
     }
 }

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.RecordModule.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.RecordModule.verified.txt
@@ -53,6 +53,15 @@ namespace TestNamespace
         }
 
         [Browsable(false)]
+        void global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalApplyServices(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services, global::DependencyModules.Runtime.Interfaces.IModuleEnvironment environment)
+        {
+            global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.ApplyServices(
+                services,
+                environment
+            );
+        }
+
+        [Browsable(false)]
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.RegistrationTypeVariants.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.RegistrationTypeVariants.verified.txt
@@ -63,6 +63,15 @@ namespace TestNamespace
         }
 
         [Browsable(false)]
+        void global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalApplyServices(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services, global::DependencyModules.Runtime.Interfaces.IModuleEnvironment environment)
+        {
+            global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.ApplyServices(
+                services,
+                environment
+            );
+        }
+
+        [Browsable(false)]
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();

--- a/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.SimpleModule.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/ModuleGenerationSnapshotTests.SimpleModule.verified.txt
@@ -53,6 +53,15 @@ namespace TestNamespace
         }
 
         [Browsable(false)]
+        void global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalApplyServices(global::Microsoft.Extensions.DependencyInjection.IServiceCollection services, global::DependencyModules.Runtime.Interfaces.IModuleEnvironment environment)
+        {
+            global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.ApplyServices(
+                services,
+                environment
+            );
+        }
+
+        [Browsable(false)]
         global::System.Collections.Generic.IEnumerable<object> global::DependencyModules.Runtime.Interfaces.IDependencyModule.InternalGetModules()
         {
             return global::DependencyModules.Runtime.Helpers.DependencyRegistry<global::TestNamespace.TestModule>.GetModules();

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
@@ -52,6 +52,34 @@ namespace DependencyModules.Runtime.Attributes
         Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime { get; set; }
         DependencyModules.Runtime.Attributes.RegistrationType Using { get; set; }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public class IfEnvironmentAttribute : System.Attribute
+    {
+        public IfEnvironmentAttribute(params string[] environmentNames) { }
+        public string[] EnvironmentNames { get; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public class IfEnvironmentValueAttribute : System.Attribute
+    {
+        public IfEnvironmentValueAttribute(string key) { }
+        public IfEnvironmentValueAttribute(string key, string value) { }
+        public string Key { get; }
+        public string? Value { get; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=false, Inherited=false)]
+    public class IfNotEnvironmentAttribute : System.Attribute
+    {
+        public IfNotEnvironmentAttribute(params string[] environmentNames) { }
+        public string[] EnvironmentNames { get; }
+    }
+    [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
+    public class IfNotEnvironmentValueAttribute : System.Attribute
+    {
+        public IfNotEnvironmentValueAttribute(string key) { }
+        public IfNotEnvironmentValueAttribute(string key, string value) { }
+        public string Key { get; }
+        public string? Value { get; }
+    }
     [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple=true, Inherited=false)]
     public class InterceptAttribute : System.Attribute
     {
@@ -125,6 +153,7 @@ namespace DependencyModules.Runtime.Helpers
     public class DependencyRegistry<T>
     {
         public DependencyRegistry() { }
+        public static int Add(DependencyModules.Runtime.Helpers.EnvironmentRegistryFunc registryFunc) { }
         public static int Add(DependencyModules.Runtime.Helpers.RegistryFunc registryFunc) { }
         public static int Add<TInstance>(System.Func<System.IServiceProvider, TInstance> provider, Microsoft.Extensions.DependencyInjection.ServiceLifetime lifetime = 2)
             where TInstance :  class { }
@@ -134,10 +163,18 @@ namespace DependencyModules.Runtime.Helpers
         public static int AddModule(params DependencyModules.Runtime.Interfaces.IDependencyModule[] modules) { }
         public static void ApplyDecorators(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
         public static void ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
+        public static void ApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection, DependencyModules.Runtime.Interfaces.IModuleEnvironment environment) { }
         public static System.Collections.Generic.IReadOnlyList<DependencyModules.Runtime.Helpers.DecoratorRegistration> GetDecorators() { }
         public static System.Collections.Generic.IEnumerable<object> GetModules(params object[] modules) { }
         public static void LoadModules(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection, params DependencyModules.Runtime.Interfaces.IDependencyModule[] dependencyModules) { }
     }
+    public static class EnvironmentConditions
+    {
+        public static bool HasValue(DependencyModules.Runtime.Interfaces.IModuleEnvironment environment, string key) { }
+        public static bool NameIs(DependencyModules.Runtime.Interfaces.IModuleEnvironment environment, params string[] names) { }
+        public static bool ValueIs(DependencyModules.Runtime.Interfaces.IModuleEnvironment environment, string key, string value) { }
+    }
+    public delegate void EnvironmentRegistryFunc(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection, DependencyModules.Runtime.Interfaces.IModuleEnvironment environment);
     public delegate void RegistryFunc(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection);
 }
 namespace DependencyModules.Runtime.Interception
@@ -227,6 +264,8 @@ namespace DependencyModules.Runtime.Interfaces
         [System.ComponentModel.Browsable(false)]
         void InternalApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection);
         [System.ComponentModel.Browsable(false)]
+        void InternalApplyServices(Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection, DependencyModules.Runtime.Interfaces.IModuleEnvironment environment);
+        [System.ComponentModel.Browsable(false)]
         System.Collections.Generic.IEnumerable<DependencyModules.Runtime.Helpers.DecoratorRegistration> InternalGetDecorators();
         [System.ComponentModel.Browsable(false)]
         System.Collections.Generic.IEnumerable<object> InternalGetModules();
@@ -238,7 +277,7 @@ namespace DependencyModules.Runtime.Interfaces
     }
     public interface IEnvironmentServiceCollectionConfiguration
     {
-        void ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services, DependencyModules.Runtime.Interfaces.IModuleEnvironment? environment);
+        void ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection services, DependencyModules.Runtime.Interfaces.IModuleEnvironment environment);
     }
     public interface IModuleEnvironment
     {
@@ -253,6 +292,14 @@ namespace DependencyModules.Runtime.Interfaces
 }
 namespace DependencyModules.Runtime
 {
+    public class ModuleEnvironment : DependencyModules.Runtime.Interfaces.IModuleEnvironment
+    {
+        public ModuleEnvironment(string environmentName, System.Collections.Generic.IReadOnlyDictionary<string, string?>? values = null) { }
+        public string EnvironmentName { get; }
+        public static DependencyModules.Runtime.Interfaces.IModuleEnvironment Default { get; }
+        public static DependencyModules.Runtime.Interfaces.IModuleEnvironment None { get; }
+        public string? Value(string name) { }
+    }
     public static class ServiceCollectionExtensions
     {
         public static Microsoft.Extensions.DependencyInjection.IServiceCollection AddModule(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, DependencyModules.Runtime.Interfaces.IDependencyModule module) { }

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -901,9 +901,11 @@ namespace DependencyModules.SourceGenerator.Impl
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ConventionCannotBeRead;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ConventionMatchNotConstructable;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ConventionMatchedNothing;
+        public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor EmptyEnvironmentCondition;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ExposedByConvention;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor GeneratorFailure;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ModuleMustBePartial;
+        public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor RegisteredConditionally;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ServiceCannotBeConstructed;
     }
     public class DependencyModuleWriter
@@ -957,6 +959,7 @@ namespace DependencyModules.SourceGenerator.Impl
                 public const string Namespace = "DependencyModules.Runtime.Helpers";
                 public static readonly CSharpAuthor.ITypeDefinition DecoratorHelper;
                 public static readonly CSharpAuthor.ITypeDefinition DecoratorRegistration;
+                public static readonly CSharpAuthor.ITypeDefinition EnvironmentConditions;
             }
             public static class Interception
             {
@@ -975,6 +978,7 @@ namespace DependencyModules.SourceGenerator.Impl
                 public const string Namespace = "DependencyModules.Runtime.Interfaces";
                 public static readonly CSharpAuthor.ITypeDefinition IDependencyModule;
                 public static readonly CSharpAuthor.ITypeDefinition IDependencyModuleProvider;
+                public static readonly CSharpAuthor.ITypeDefinition IModuleEnvironment;
             }
         }
         public static class Microsoft
@@ -1101,6 +1105,21 @@ namespace DependencyModules.SourceGenerator.Impl.Models
         public DependencyModuleConfigurationModelComparer() { }
         public bool Equals(DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel? x, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel? y) { }
         public int GetHashCode(DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel obj) { }
+    }
+    public enum EnvironmentConditionKind
+    {
+        Name = 0,
+        Value = 1,
+    }
+    public class EnvironmentConditionModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.EnvironmentConditionModel>
+    {
+        public EnvironmentConditionModel(DependencyModules.SourceGenerator.Impl.Models.EnvironmentConditionKind Kind, bool Negate, string? Key, System.Collections.Generic.IReadOnlyList<string> Values) { }
+        public string? Key { get; init; }
+        public DependencyModules.SourceGenerator.Impl.Models.EnvironmentConditionKind Kind { get; init; }
+        public bool Negate { get; init; }
+        public System.Collections.Generic.IReadOnlyList<string> Values { get; init; }
+        public virtual bool Equals(DependencyModules.SourceGenerator.Impl.Models.EnvironmentConditionModel? other) { }
+        public override int GetHashCode() { }
     }
     public delegate CSharpAuthor.IOutputComponent? FactoryOutputDelegate(DependencyModules.SourceGenerator.Impl.Models.ServiceModel serviceModel, DependencyModules.SourceGenerator.Impl.Models.ServiceRegistrationModel registrationModel);
     public interface IClassModel
@@ -1307,7 +1326,8 @@ namespace DependencyModules.SourceGenerator.Impl.Models
     public class ServiceModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>
     {
         public static DependencyModules.SourceGenerator.Impl.Models.ServiceModel Ignore;
-        public ServiceModel(CSharpAuthor.ITypeDefinition ImplementationType, DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? Constructor, DependencyModules.SourceGenerator.Impl.Models.ServiceFactoryModel? Factory, DependencyModules.SourceGenerator.Impl.Models.FactoryOutputDelegate? FactoryOutput, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ServiceRegistrationModel> Registrations, DependencyModules.SourceGenerator.Impl.Models.RegistrationFeature Features) { }
+        public ServiceModel(CSharpAuthor.ITypeDefinition ImplementationType, DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? Constructor, DependencyModules.SourceGenerator.Impl.Models.ServiceFactoryModel? Factory, DependencyModules.SourceGenerator.Impl.Models.FactoryOutputDelegate? FactoryOutput, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ServiceRegistrationModel> Registrations, DependencyModules.SourceGenerator.Impl.Models.RegistrationFeature Features, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.EnvironmentConditionModel>? Conditions = null) { }
+        public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.EnvironmentConditionModel>? Conditions { get; init; }
         public DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? Constructor { get; init; }
         public DependencyModules.SourceGenerator.Impl.Models.ServiceFactoryModel? Factory { get; init; }
         public DependencyModules.SourceGenerator.Impl.Models.FactoryOutputDelegate? FactoryOutput { get; init; }
@@ -1380,6 +1400,12 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities
                 "Right"})] System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>> entryPointList) { }
         public static DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel EnsureNamespace(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel) { }
         public static string GenerateFileName(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, string uniquePortion) { }
+    }
+    public static class EnvironmentConditionUtility
+    {
+        public static string Describe(DependencyModules.SourceGenerator.Impl.Models.EnvironmentConditionModel condition) { }
+        public static System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.EnvironmentConditionModel>? GetConditions(DependencyModules.SourceGenerator.Impl.Utilities.SyntaxTransformContext context, Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) { }
+        public static bool IsEmpty(DependencyModules.SourceGenerator.Impl.Models.EnvironmentConditionModel condition) { }
     }
     public class FileLogger : System.IDisposable
     {


### PR DESCRIPTION
Registers services conditionally on the environment, decided at composition time.

```csharp
[SingletonService] [IfEnvironment("Development", "Staging")]  public class FakeEmailSender : IEmailSender;
[SingletonService] [IfNotEnvironment("Production")]           public class RequestProfiler : IProfiler;
[SingletonService] [IfEnvironmentValue("FEATURE_BILLING")]    public class Billing : IBilling;
[SingletonService] [IfEnvironmentValue("MODE", "on")]         public class Thing : IThing;
```

Conditions of different kinds combine with **and**; alternatives go inside one attribute via `params`, so two attributes that could never both hold cannot be written. Environment names compare case-insensitively, matching `IHostEnvironment`; values compare ordinally, because a value is data rather than a well-known label.

## Nothing breaks

The environment is threaded through additively. `EnvironmentRegistryFunc` joins `RegistryFunc`, both in one list so declaration order is preserved — that ordering is load-bearing, because the container resolves a single service from the last matching descriptor. `IDependencyModule` gains an `InternalApplyServices` overload with a default implementation forwarding to the existing one.

Generated modules emit **both** overloads. The generator package declares no dependency on the runtime package, so a new generator paired with an older runtime would otherwise land on the interface default and register nothing at all.

The one removal is `IEnvironmentServiceCollectionConfiguration.ConfigureServices`, whose parameter is no longer nullable. Existing implementations still compile — a parameter declared `IModuleEnvironment?` accepts more than the interface promises — but one branching on `null` now takes the other branch.

## Ordering

Conditional registrations are emitted **after** unconditional ones within a module, so a conditional can override a default. Ordering by name alone made that depend on the class names — `FakeEmailSender` sorts ahead of `SmtpEmailSender`, so the default landed last and won in Development too. Proven before fixing.

Across modules, module order decides. A referenced module's conditional cannot override the module that references it, because modules expand dependencies-first. That is why conditionals do **not** get a global phase like decorators: a decorator wraps and discards nothing, a conditional registration replaces, and replacement across an ownership boundary should not be implicit.

## One environment, never null

Nothing supplied means `ModuleEnvironment.Default` — `ASPNETCORE_ENVIRONMENT` → `DOTNET_ENVIRONMENT` → `"Production"`, read live — and it is **registered** rather than merely used, so what resolves is what decided the registrations. An environment passed to `AddModules` **replaces** one already in the collection rather than joining it: the environment answers a single question, and several would need a rule for which one the conditions read, which would come out of module ordering rather than out of anything written down. `ModuleEnvironment.None` says an application has no environment. To layer, read the existing one and combine before calling `AddModules` — the collection is right there.

`IEnvironmentServiceCollectionConfiguration` receives the same non-null environment the attributes are evaluated against, so a module cannot see one answer there and a different one in its own conditional registrations.

## Bugs found on the way

- An `IModuleEnvironment` registered **by type or factory** was silently ignored in favour of the process default, then shadowed by it — a service gated on `"Development"` quietly took its production branch. It cannot be constructed while the collection is still being populated, so it is now refused with a message naming the fix.
- Conditions were silently dropped on **convention-matched** types. A class carrying a service attribute is never a convention candidate, so those conditions had no other route.
- A static initialization order bug in `ModuleEnvironment.None`, caught by a runtime test.

## Diagnostics

| ID | Severity | Condition |
|---|---|---|
| DM0011 | Info | What a conditional registration depends on — whether it holds is a run-time question, so no build error is available |
| DM0012 | Warning | A condition that names nothing to test (`[IfEnvironment()]`, `[IfEnvironmentValue("")]`) |

## The honest cost

Environment conditions decide **behaviour, not size**. The test runs at run time, so both branches are emitted and every conditionally registered type stays referenced. Trimming a service out of a build is a compile-time decision and belongs to `#if`.

## Verification

- `dotnet build -c Release --no-incremental` — **0 warnings**
- `./scripts/coverage.sh 85` — **549 tests pass, 87.4% coverage**
- `./scripts/verify-packages.sh` — clean

Behaviour is asserted by compiling and executing generated assemblies under different environments, not by matching generated text. A mutation dropping the `!` from negation failed exactly the two negation tests.

## Not in this PR

Decorators, module-level conditions, conditions on factory methods (the attributes are `AttributeTargets.Class`, so putting one on a method is a compile error rather than a silent no-op), fluent `.IfEnvironment(...)` on convention chains, and `ModuleTestCase` taking an environment. DM0011 is not reported on the convention path — the behaviour is right there, only the info diagnostic is missing.

The second commit is a design-doc revision recording what convention registration shipped and the remaining Scrutor parity gap; it is unrelated to the environment work and kept separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C56x6Vv6HJ6ArfqwKsuSb9