### PR TITLE
Convention selection and shape gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,7 @@ $RECYCLE.BIN/
 
 # Local build artifacts (coverage reports, packed output)
 artifacts/
+
+# Session working notes. Scratch for picking work up in a fresh session, not
+# project documentation — what is worth keeping belongs in docs/design.
+docs/HANDOFF.md

--- a/DependencyModules.sln
+++ b/DependencyModules.sln
@@ -35,6 +35,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependencyModules.Tests", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependencyModules.Conventions", "src\DependencyModules.Conventions\DependencyModules.Conventions.csproj", "{B39ACDFB-85D2-4764-B06E-74744E683268}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{2E4BAA8C-195F-490B-B9F9-57194B08CD12}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DependencyModules.Benchmarks", "benchmarks\DependencyModules.Benchmarks\DependencyModules.Benchmarks.csproj", "{F72AFF5C-C9FB-406E-B65A-192933E697D2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,6 +97,10 @@ Global
 		{B39ACDFB-85D2-4764-B06E-74744E683268}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B39ACDFB-85D2-4764-B06E-74744E683268}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B39ACDFB-85D2-4764-B06E-74744E683268}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F72AFF5C-C9FB-406E-B65A-192933E697D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F72AFF5C-C9FB-406E-B65A-192933E697D2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F72AFF5C-C9FB-406E-B65A-192933E697D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F72AFF5C-C9FB-406E-B65A-192933E697D2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{1E7E9023-435E-499B-9A6F-6C3E20A9A4F1} = {FB161494-E422-4D4E-BA04-3473C2EB13B0}
@@ -109,5 +117,6 @@ Global
 		{DA2D8D38-FA99-4483-B375-449E0EF86549} = {D6D764B2-B906-4386-BC37-7EE29D7821DF}
 		{1AFFBCCF-FD6E-4232-9DC7-40FE2784ECD1} = {F4DC9AA2-7F61-4DEE-A7D1-2BCDBEEFD1C5}
 		{B39ACDFB-85D2-4764-B06E-74744E683268} = {FB161494-E422-4D4E-BA04-3473C2EB13B0}
+		{F72AFF5C-C9FB-406E-B65A-192933E697D2} = {2E4BAA8C-195F-490B-B9F9-57194B08CD12}
 	EndGlobalSection
 EndGlobal

--- a/benchmarks/DependencyModules.Benchmarks/DependencyModules.Benchmarks.csproj
+++ b/benchmarks/DependencyModules.Benchmarks/DependencyModules.Benchmarks.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>disable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <!-- Not a test project; nothing here should be collected for coverage. -->
+        <IsTestProject>false</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\DependencyModules.Conventions\DependencyModules.Conventions.csproj"/>
+        <ProjectReference Include="..\..\src\DependencyModules.Runtime\DependencyModules.Runtime.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/benchmarks/DependencyModules.Benchmarks/Program.cs
+++ b/benchmarks/DependencyModules.Benchmarks/Program.cs
@@ -1,0 +1,184 @@
+using System.Diagnostics;
+using System.Text;
+using DependencyModules.Conventions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DependencyModules.Benchmarks;
+
+/// <summary>
+/// Times the convention generator over synthetic compilations.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Run it with tiered compilation off, or the numbers drift as the JIT warms up across the sweep:
+/// </para>
+/// <code>
+/// DOTNET_TieredCompilation=0 dotnet run -c Release --project benchmarks/DependencyModules.Benchmarks
+/// </code>
+/// <para>
+/// Four things here are load-bearing, each because getting it wrong produced a believable but wrong
+/// number while this was being written:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <b>Time only RunGeneratorsAndUpdateCompilation.</b> The test harness also calls GetDiagnostics on
+/// the output compilation, which is a full semantic analysis and buries everything else.
+/// </item>
+/// <item>
+/// <b>One syntax tree per class.</b> Roslyn re-runs the predicate and transform for every node in a
+/// tree that changed and serves the rest from cache, so a single-file compilation makes every
+/// keystroke look like a cold build.
+/// </item>
+/// <item>
+/// <b>Real class bodies.</b> The transform's cost tracks how much code a class contains, not how
+/// many classes there are. One-line classes understated it by roughly five times.
+/// </item>
+/// <item>
+/// <b>The incremental row is the one that matters.</b> A cold build pays once; an IDE re-runs the
+/// generator on every keystroke.
+/// </item>
+/// </list>
+/// </remarks>
+public static class Program {
+
+    private const int Runs = 15;
+
+    public static void Main() {
+        Console.WriteLine(
+            $"TieredCompilation={Environment.GetEnvironmentVariable("DOTNET_TieredCompilation") ?? "(default, results will drift)"}");
+
+        for (var i = 0; i < 20; i++) {
+            ColdRun(BuildSources(400, 100));
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("classes  implementing   cold ms   after one edit ms");
+        Console.WriteLine("---------------------------------------------------");
+
+        foreach (var total in new[] { 500, 2000 }) {
+            foreach (var implementing in new[] { 0, total / 4, total }) {
+                var cold = Median(() => ColdRun(BuildSources(total, implementing)));
+                var incremental = Median(() => IncrementalRun(total, implementing));
+
+                Console.WriteLine($"{total,7}  {implementing,12}  {cold,8:F1}  {incremental,18:F1}");
+            }
+        }
+    }
+
+    private static double Median(Func<double> measure) {
+        var timings = new List<double>(Runs);
+
+        for (var run = 0; run < Runs; run++) {
+            timings.Add(measure());
+        }
+
+        timings.Sort();
+
+        return timings[timings.Count / 2];
+    }
+
+    private static double ColdRun(string[] sources) {
+        var compilation = Compile(sources);
+
+        // A fresh driver each run: reusing one would measure the incremental cache instead.
+        var driver = CSharpGeneratorDriver.Create(
+            new ConventionSourceGenerator().AsSourceGenerator());
+
+        return Time(() => driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _));
+    }
+
+    /// <summary>
+    /// The second run of one driver, after editing a method body in a single file.
+    /// </summary>
+    private static double IncrementalRun(int total, int implementing) {
+        var sources = BuildSources(total, implementing);
+        var options = new CSharpParseOptions(LanguageVersion.Latest);
+        var compilation = Compile(sources);
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            new ConventionSourceGenerator().AsSourceGenerator());
+
+        driver = driver.RunGeneratorsAndUpdateCompilation(compilation, out _, out _);
+
+        // Only the edited tree is replaced; the other N-1 keep their identity and should stay cached.
+        var edited = compilation.ReplaceSyntaxTree(
+            compilation.SyntaxTrees.ElementAt(1),
+            CSharpSyntaxTree.ParseText(sources[1].Replace("_seed = 0", "_seed = 42"), options));
+
+        return Time(() => driver.RunGeneratorsAndUpdateCompilation(edited, out _, out _));
+    }
+
+    private static double Time(Action action) {
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+
+        var start = Stopwatch.GetTimestamp();
+
+        action();
+
+        return (Stopwatch.GetTimestamp() - start) * 1000.0 / Stopwatch.Frequency;
+    }
+
+    private static CSharpCompilation Compile(string[] sources) {
+        var options = new CSharpParseOptions(LanguageVersion.Latest);
+
+        return CSharpCompilation.Create(
+            "BenchAssembly",
+            sources.Select(source => CSharpSyntaxTree.ParseText(source, options)),
+            References,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+    }
+
+    private static string[] BuildSources(int total, int implementing) {
+        var trees = new string[total + 2];
+
+        trees[0] = "namespace BenchNamespace; public interface IMarker { }";
+
+        for (var i = 0; i < total; i++) {
+            trees[i + 1] = i < implementing
+                ? $"namespace BenchNamespace; public class Implementing{i} : IMarker {{{Body(i)}}}"
+                : $"namespace BenchNamespace; public class Plain{i} {{{Body(i)}}}";
+        }
+
+        var builder = new StringBuilder();
+
+        builder.AppendLine("using DependencyModules.Runtime.Attributes;");
+        builder.AppendLine("using DependencyModules.Conventions;");
+        builder.AppendLine("namespace BenchNamespace;");
+        builder.AppendLine("[DependencyModule]");
+        builder.AppendLine("public partial class BenchModule : IConventionModule {");
+        builder.AppendLine("    void IConventionModule.Conventions(IConventionDefinitions conventions) {");
+        builder.AppendLine("        conventions.RegisterAll<IMarker>().AsScoped();");
+        builder.AppendLine("    }");
+        builder.AppendLine("}");
+
+        trees[total + 1] = builder.ToString();
+
+        return trees;
+    }
+
+    private static string Body(int i) => $$"""
+
+        private readonly int _seed = {{i}};
+        public int Value => _seed;
+        public int Add(int a, int b) { var t = a + b; if (t > 10) { t -= 1; } return t + _seed; }
+        public string Describe() { var parts = new[] { "a", "b", "c" }; return string.Join(",", parts) + _seed; }
+        public bool Check(int x) { for (var j = 0; j < x; j++) { if (j == _seed) { return true; } } return false; }
+        public int Sum(int[] values) { var total = 0; foreach (var v in values) { total += v; } return total; }
+""";
+
+    private static readonly MetadataReference[] References = BuildReferences();
+
+    private static MetadataReference[] BuildReferences() {
+        // Touched so the runtime and DI assemblies are loaded before the sweep below.
+        _ = typeof(IServiceCollection);
+        _ = typeof(Runtime.ModuleEnvironment);
+
+        return AppDomain.CurrentDomain.GetAssemblies()
+            .Where(assembly => !assembly.IsDynamic && !string.IsNullOrEmpty(assembly.Location))
+            .Select(assembly => (MetadataReference)MetadataReference.CreateFromFile(assembly.Location))
+            .ToArray();
+    }
+}

--- a/docs/design/convention-self-registration.md
+++ b/docs/design/convention-self-registration.md
@@ -1,0 +1,145 @@
+# Convention self-registration: the missing shape, and what `AsSelfWithInterfaces` should exclude
+
+Status: designed, not implemented. Two independent changes, both in
+`ConventionMatcher.BuildRegistrations`. Written as a work order.
+
+Both come out of measuring convention registration against FluentValidation, which is the one library
+of its kind that conventions can replace outright. (MediatR cannot be replaced and does not need to
+be — `AddMediatR` registers its own handlers, so if you call it conventions add nothing, and if you
+do not call it you do not have MediatR. There is no work item there.)
+
+---
+
+## 1. A shape between `Interfaces` and `SelfAndInterfaces`
+
+FluentValidation registers every validator **twice** — as `IValidator<T>` and as the concrete type:
+
+> Each found validator is registered both by its interface type and as itself.
+> — `FluentValidation.DependencyInjectionExtensions/ServiceCollectionExtensions.cs`
+
+Neither current shape produces that pair. Given the ordinary validator, and
+`AbstractValidator<T> : IValidator<T>, IEnumerable<IValidationRule>` (verified against the
+FluentValidation source):
+
+```csharp
+public class FooValidator : AbstractValidator<Foo> { }
+
+conventions.RegisterAll(typeof(IValidator<>)).AsScoped().IncludeBaseClasses();
+```
+
+| shape | registers |
+|---|---|
+| default (`Interfaces`) | `IValidator<Foo>` — missing the concrete type |
+| `AsSelf()` | `FooValidator` — missing the interface |
+| `AsSelfWithInterfaces()` | `IValidator<Foo>`, `IValidator`, `IEnumerable<IValidationRule>`, `IEnumerable` — see item 2 |
+
+The missing shape is **self plus the interfaces the convention matched**, rather than self plus every
+interface the type can reach.
+
+### The verb
+
+`AlsoAsSelf()`, additive to the default rather than a replacement for it. It reads as what it does,
+and it keeps `AsSelf` meaning "instead of" while `AlsoAsSelf` means "as well as".
+
+```csharp
+conventions.RegisterAll(typeof(IValidator<>)).AsScoped().IncludeBaseClasses().AlsoAsSelf();
+```
+
+Add it to `IConventionRegistration` in `ConventionContractSource`, a fourth member to
+`ConventionRegisterAs` (`Models/ConventionModel.cs:47`), and an entry to
+`ConventionModelUtility.RegisterAsCalls` (line 40). Note the existing conflict check at line 264
+refuses two *different* `As*` calls in one chain, which is the right behaviour here too — `AsSelf()`
+and `AlsoAsSelf()` together is a contradiction.
+
+### Cross-wire it
+
+Emit as `SelfAndInterfaces` already does: one registration per matched interface carrying
+`CrossWire: true`, plus one of the implementation type. FluentValidation registers the pair
+independently, which hands you **two instances per scope**; cross-wiring gives one. That is a
+deliberate difference and the better behaviour — worth a line in the docs rather than matching FV
+exactly.
+
+### Watch `RegistrationKey`
+
+`ConventionMatcher.cs:387` keys `(implementation, implementation)` for anything that is not
+`Interfaces`. Under the new shape one match produces both interface registrations and a self
+registration, so the key has to be computed per emitted registration, not per match, or two
+conventions matching one type through different interfaces would collide on the self key.
+
+The collision itself is correct when it happens — two conventions each registering `FooValidator` as
+itself *is* a duplicate declaration and should be DM0004. Just make sure the interface registrations
+are not dragged down with it.
+
+### Tests
+
+Behavioural, `GeneratedAssembly` style:
+
+- a validator resolves as both `IValidator<Foo>` and `FooValidator`
+- both resolve to the **same instance** within a scope, which is what distinguishes this from FV
+- `AlsoAsSelf()` does not pull in interfaces the convention did not name
+- `AsSelf()` and `AlsoAsSelf()` in one chain is refused
+
+---
+
+## 2. `AsSelfWithInterfaces` should exclude `System.*`
+
+`BuildRegistrations` (`ConventionMatcher.cs:512-528`) loops `InterfacesInReach` and cross-wires
+everything it finds. For the validator above that includes `IEnumerable<IValidationRule>` and
+non-generic `IEnumerable`. Resolving `IEnumerable<IValidationRule>` and getting a validator is wrong,
+and bare `IEnumerable` is meaningless as a service type.
+
+This is not a validator problem. Any type whose base implements `IDisposable` gets `IDisposable`
+cross-wired to it, which is the sharper version of the same bug.
+
+### Prior art — both filter, both reactively, and they filter different things
+
+| | excluded | not excluded |
+|---|---|---|
+| Autofac | `IDisposable` — `.Where(i => i != typeof(IDisposable))` in `GetImplementedInterfaces` | `IEnumerable` |
+| Scrutor | `IEnumerable<T>`, `IEnumerable` — `ShouldRegister` | `IDisposable` |
+
+Autofac filters the one that bites; Scrutor filters the exact pair that bites FluentValidation.
+Neither filters both. These are patches applied after users hit them, and the list they imply keeps
+growing: `IEquatable<T>`, `IComparable`, `ICloneable`, `ISerializable`.
+
+### The rule
+
+**Skip interfaces declared in `System` or a namespace beginning `System.`.** One rule instead of a
+list that accretes, and it is defensible in a sentence: cross-wiring a BCL interface is never what
+"register this as its interfaces" means.
+
+It covers `IDisposable`, `IAsyncDisposable`, `IEnumerable`, `IEnumerable<T>`, `IEquatable<T>` and the
+rest of that family at once. It keeps `IValidator<T>`, which is third-party and wanted.
+
+**Do not extend it to `Microsoft.Extensions.*`.** `class Worker : BackgroundService` reaching
+`IHostedService` is something a developer could legitimately want cross-wired, so that line is not
+defensible the way the `System.*` one is.
+
+### Scope of the filter
+
+Only the *expansion* — the `SelfAndInterfaces` loop. It must **not** apply to the default shape,
+where the registered interface is the one the convention named: `RegisterAll<IDisposable>()` is a
+strange thing to write but the developer wrote it, and refusing to honour a named service type is a
+different kind of wrong.
+
+By the same reasoning it does not apply to item 1, whose interfaces are the matched ones.
+
+### Two behaviours that already work and should stay working
+
+- The `crossWired.Count == 0` fallback at line 523 registers the implementation type when nothing
+  else survives. Filtering to zero therefore degrades to `AsSelf()`, which is the right outcome.
+- DM0010 reports every convention registration at the class, so whatever survives the filter stays
+  visible in the IDE. That is worth more than a longer blocklist — Scrutor and Autofac leak silently;
+  here a leak is at least legible.
+
+No diagnostic for a skipped interface. It would fire on ordinary code and say nothing actionable.
+
+### Tests
+
+- a type whose base implements `IDisposable` does not resolve as `IDisposable` under
+  `AsSelfWithInterfaces()`
+- a validator under `AsSelfWithInterfaces()` does not resolve as `IEnumerable<IValidationRule>`
+- a third-party interface in a non-`System` namespace still registers
+- `RegisterAll<IDisposable>()` with the default shape still registers `IDisposable`, proving the
+  filter is scoped to the expansion
+- a type reaching only `System.*` interfaces falls back to registering itself

--- a/docs/design/convention-self-registration.md
+++ b/docs/design/convention-self-registration.md
@@ -1,7 +1,20 @@
 # Convention self-registration: the missing shape, and what `AsSelfWithInterfaces` should exclude
 
-Status: designed, not implemented. Two independent changes, both in
-`ConventionMatcher.BuildRegistrations`. Written as a work order.
+Status: **implemented**, both items. Kept for the reasoning and the FluentValidation measurement,
+which the code cannot carry.
+
+Two notes where the plan and the outcome differ:
+
+- **`AlsoAsSelf` emits only the cross-wired matched interface, not a self registration as well.**
+  The writer already adds the implementation registration once per service model whenever anything
+  is cross-wired, so emitting one here produced the type twice. Caught by the test for a handler
+  closing two messages. What separates `AlsoAsSelf` from `AsSelfWithInterfaces` is therefore which
+  interfaces are expanded, not what "self" costs.
+- The *Watch `RegistrationKey`* warning was right, and the fix is the one it describes: the
+  ambiguity check now runs over emitted registrations rather than over matches, so a duplicated
+  registration cannot drag an unrelated one from the same match down with it. That restructuring
+  stands on its own — it also makes two conventions using `AsSelfWithInterfaces` on one type collide
+  per interface rather than once.
 
 Both come out of measuring convention registration against FluentValidation, which is the one library
 of its kind that conventions can replace outright. (MediatR cannot be replaced and does not need to

--- a/docs/design/dm0004-multi-role-types.md
+++ b/docs/design/dm0004-multi-role-types.md
@@ -1,0 +1,180 @@
+# DM0004: stop refusing types that fill more than one role
+
+Status: **implemented**. Kept for the reasoning, which the code cannot carry — why a type filling two
+roles is not an ambiguity, and why the diagnostic still fires when two conventions name one service
+type. Written as a work order; what follows describes the change as it was planned, and all four
+changes plus the test inversion landed as described.
+
+Two notes for anyone reading it as a plan rather than as history:
+
+- *Also in this file, and blocking the zero-warning gate* is resolved. All four CS8602s are cleared,
+  including the one it deferred: a convention with no service type never reaches assignability
+  matching.
+- *Out of scope* — one convention matching a type through several closings of one open generic —
+  was implemented immediately afterwards, as it predicted. `FirstMatchingInterface` is now
+  `AllMatchingInterfaces`. Its prerequisite, change 2, is what made that a small change.
+
+One thing the plan did not anticipate: keying the ambiguity check on `ConventionTypeKey` does not
+work. That key is deliberately equal for every closing of one generic, so `IHandler<A>` and
+`IHandler<B>` looked like one service type and a two-message handler was reported as a duplicate
+declaration. The key is the type definitions themselves.
+
+DM0004 currently refuses a type that two conventions in one module both match, and drops every
+registration it would have produced. That is right when the conventions collide on one service type
+and wrong when they reach the type through different interfaces — which is the ordinary shape of a
+MediatR handler and the reason convention registration cannot cover MediatR today.
+
+---
+
+## The defect
+
+`ConventionMatcher.RemoveAmbiguous` (`src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs:277`)
+groups matches by `match.Candidate.ImplementationType` alone (line 283). Any candidate appearing in
+more than one group entry is reported and **dropped entirely** — nothing is added to `usable`
+(lines 296-317).
+
+So this registers nothing, and fails the build:
+
+```csharp
+public class OrderEvents : INotificationHandler<OrderPlaced>, IRequestPreProcessor<ShipOrder> { }
+
+conventions.RegisterAll(typeof(INotificationHandler<>)).AsTransient();
+conventions.RegisterAll(typeof(IRequestPreProcessor<>)).AsTransient();
+```
+
+Nothing about it is ambiguous. The two registrations name different service types, and MediatR's own
+`ServiceRegistrar` registers exactly this shape against every handler interface the type closes.
+
+## The rule
+
+Group by **`(ImplementationType, Interface.InterfaceType)`**, not by `ImplementationType`.
+
+- **Different interfaces → both register.** A type filling two roles is not an ambiguity; the two
+  registrations are independently predictable from reading the module.
+- **Same interface → still DM0004.** This is the case the diagnostic exists for: one service type
+  claimed by two conventions, so one lifetime has to win and no one can tell which from the source.
+
+  ```csharp
+  conventions.RegisterAll<IRepository>().AsScoped();
+  conventions.RegisterAll<IRepository>().AsSingleton();   // DM0004
+  ```
+
+Equal lifetimes on the same interface stay an error too. The outcome is predictable, but the
+declaration is redundant, and silently collapsing a duplicate is the failure mode this codebase
+avoids.
+
+---
+
+## Changes
+
+### 1. Regroup `RemoveAmbiguous` — `ConventionMatcher.cs:277`
+
+Key the dictionary on the pair. Everything else in the method stands: one match per key is usable,
+more than one is reported and dropped. Keep insertion order — the emitted registration order feeds
+the module snapshot tests.
+
+### 2. One `ServiceModel` per implementation — `ConventionMatcher.cs:342`
+
+`BuildServiceModels` emits one `ServiceModel` per match (line 354), so a type matched through two
+interfaces now produces two models with the same `ImplementationType`. The attribute path does not
+do that: `ServiceModelUtility` builds **one** `ServiceModel` per class carrying a list of
+`ServiceRegistrationModel`s (`src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs:140`).
+
+Group the usable matches by `ImplementationType` and emit one model with N registrations. That
+preserves the "indistinguishable from the attribute path" property `DependencyFileWriter` relies on,
+and it is what keeps per-implementation state — constructor, conditions, cross-wire — from being
+duplicated across models.
+
+The constructor and conditions come from the candidate, which is shared across the matches, so
+merging is a straight regroup with no reconciliation.
+
+### 3. Rewrite the DM0004 message — `DependencyModuleDiagnostics.cs:63`
+
+Current format names the two conventions' service types:
+
+```
+"'{0}' is matched by more than one convention in '{1}' — as '{2}' and as '{3}'."
+```
+
+Under the new key those are always the same string, so it would print `as 'IRepository' and as
+'IRepository'` — the same confusing output the partial-class defect used to produce. Name the service
+type once and put the difference in a trailing clause built by the caller:
+
+```
+"'{0}' is matched by two conventions in '{1}' that both register it as '{2}'. {3}"
+```
+
+with `{3}` either `They declare different lifetimes (Scoped and Singleton).` or `The declaration is
+duplicated.` One descriptor, and neither wording repeats itself.
+
+### 4. Update the release line — `AnalyzerReleases.Unshipped.md:11`
+
+Reads `Two conventions in one module match the same type.` Should say they register it as the same
+service type. DM0004 is unshipped, so the line is free to change.
+
+---
+
+## The test that has to be inverted
+
+**`TwoConventionsMatchingOnePartialClassIsStillAmbiguous`** in
+`tests/DependencyModules.Tests/GeneratorTests/ConventionRegistrationTests.cs` (uncommitted at the
+time of writing) asserts DM0004 fires for:
+
+```csharp
+public partial class Thing : IFoo { }
+public partial class Thing : IBar { }
+
+conventions.RegisterAll<IFoo>().AsSingleton();
+conventions.RegisterAll<IBar>().AsSingleton();
+```
+
+That is exactly the case this change legalises. The test was written to prove the partial-class merge
+did not disable the ambiguity check, which is a real thing to hold onto — so replace the assertion
+rather than deleting the test: `Thing` should register twice, once as `IFoo` and once as `IBar`, with
+no DM0004. Then add a separate test that keeps the check honest by colliding on one interface.
+
+New behavioural tests, in the `GeneratedAssembly` style the rest of the file uses — compile, load,
+resolve, do not assert on generated text:
+
+- a type matched by two conventions through different interfaces resolves as both
+- both registrations point at the same implementation type
+- two conventions naming the same service type still report DM0004 and register nothing
+- same as above with equal lifetimes — still DM0004
+- a type matched through different interfaces with different lifetimes registers both, each with its
+  own lifetime (two instances is correct here, and is what Scrutor and MediatR both produce)
+
+---
+
+## Also in this file, and blocking the zero-warning gate
+
+`ConventionMatcher` carries four CS8602s introduced by the nullable `ConventionModel.ServiceType` in
+the current working tree:
+
+| line | expression |
+|---|---|
+| 70 | `convention.ServiceType.Name` — use `convention.DisplayName` |
+| 147 | `convention.ServiceType.Equals(candidateInterface.InterfaceType)` in `FirstMatchingInterface` |
+| 308 | `first.Convention.ServiceType.Name`, `second.Convention.ServiceType.Name` |
+
+Line 308 disappears with change 1. Lines 70 and 147 are on the path this work touches and the build
+gate is 0 warnings, so clear them here. Line 147 needs a decision that belongs to the in-flight
+`RegisterAll()` work rather than to this one: a convention with no service type selects by filter, so
+it should not reach assignability matching at all.
+
+---
+
+## Out of scope, and why it is worth knowing
+
+**This does not fix one convention matching a type through several closings of one open generic.**
+
+```csharp
+public class OrderEvents : INotificationHandler<OrderPlaced>, INotificationHandler<OrderShipped> { }
+```
+
+`FirstMatchingInterface` (`ConventionMatcher.cs:138`) returns the first match per candidate per
+convention, so this registers `INotificationHandler<OrderPlaced>` only, silently. That is parity step
+4 and a separate change — `FirstMatchingInterface` becomes `AllMatchingInterfaces` and returns a list.
+
+It is worth doing next, and change 2 is its prerequisite: once one `ServiceModel` carries N
+registrations, returning several interfaces per convention needs no further plumbing. Both changes
+are needed before conventions can honestly claim to cover MediatR; neither alone is enough.

--- a/src/DependencyModules.Conventions/ConventionContractSource.cs
+++ b/src/DependencyModules.Conventions/ConventionContractSource.cs
@@ -128,6 +128,29 @@ public static class ConventionContractSource {
                 /// </remarks>
                 /// <param name="serviceType">The service type to scan for, open or closed.</param>
                 IConventionRegistration RegisterAll(global::System.Type serviceType);
+
+                /// <summary>
+                /// Registers types selected by something other than the service they implement.
+                /// </summary>
+                /// <remarks>
+                /// <para>
+                /// With no service type there is nothing to register the matches <i>as</i>, so this
+                /// form requires <see cref="IConventionRegistration.AsSelf"/> or
+                /// <see cref="IConventionRegistration.AsSelfWithInterfaces"/>. It is how a concrete
+                /// class that implements no interface gets registered by convention.
+                /// </para>
+                /// <para>
+                /// It also requires at least one filter. Without one it would match every class in
+                /// the compilation, which is never what anybody means and is reported rather than
+                /// obeyed.
+                /// </para>
+                /// <example>
+                /// <code>
+                /// conventions.RegisterAll().InNamespaceOf&lt;OrderMarker&gt;().AsSelf().AsScoped();
+                /// </code>
+                /// </example>
+                /// </remarks>
+                IConventionRegistration RegisterAll();
             }
 
             /// <summary>
@@ -159,6 +182,90 @@ public static class ConventionContractSource {
                 /// of that base joining the convention without anyone revisiting it.
                 /// </remarks>
                 IConventionRegistration IncludeBaseClasses();
+
+                /// <summary>
+                /// Registers each match as its own concrete type rather than as the service type.
+                /// </summary>
+                /// <remarks>
+                /// <c>RegisterAll&lt;IHandler&gt;().AsSelf()</c> puts <c>CreateOrderHandler</c> in
+                /// the container under <c>CreateOrderHandler</c>, not under <c>IHandler</c>.
+                /// </remarks>
+                IConventionRegistration AsSelf();
+
+                /// <summary>
+                /// Registers each match as its own type <i>and</i> as every interface it implements,
+                /// sharing one instance between them.
+                /// </summary>
+                /// <remarks>
+                /// The same contract as <c>[CrossWireService]</c>: resolving the concrete type and
+                /// resolving any of its interfaces gives the same instance, rather than one instance
+                /// per service type as two independent registrations would.
+                /// </remarks>
+                IConventionRegistration AsSelfWithInterfaces();
+
+                /// <summary>
+                /// Limits matches to the namespace of <typeparamref name="TMarker"/> and the
+                /// namespaces beneath it.
+                /// </summary>
+                /// <remarks>
+                /// A type argument rather than a string, so a namespace that does not exist cannot
+                /// be named. Several namespace filters combine with <b>or</b>.
+                /// </remarks>
+                /// <typeparam name="TMarker">Any type in the namespace to scan.</typeparam>
+                IConventionRegistration InNamespaceOf<TMarker>();
+
+                /// <summary>
+                /// Limits matches to the given namespaces and the namespaces beneath them.
+                /// </summary>
+                /// <param name="namespaces">Namespaces to include.</param>
+                IConventionRegistration InNamespaces(params string[] namespaces);
+
+                /// <summary>
+                /// Limits matches to exactly the given namespaces, excluding those beneath them.
+                /// </summary>
+                /// <param name="namespaces">Namespaces to include.</param>
+                IConventionRegistration InExactNamespaces(params string[] namespaces);
+
+                /// <summary>
+                /// Excludes the namespace of <typeparamref name="TMarker"/> and those beneath it.
+                /// </summary>
+                /// <remarks>
+                /// Exclusions are applied after inclusions, and a match excluded by any of them is
+                /// out however many inclusions it satisfied.
+                /// </remarks>
+                /// <typeparam name="TMarker">Any type in the namespace to exclude.</typeparam>
+                IConventionRegistration NotInNamespaceOf<TMarker>();
+
+                /// <summary>
+                /// Excludes the given namespaces and those beneath them.
+                /// </summary>
+                /// <param name="namespaces">Namespaces to exclude.</param>
+                IConventionRegistration NotInNamespaces(params string[] namespaces);
+
+                /// <summary>
+                /// Chooses how each match is added to the service collection.
+                /// </summary>
+                /// <remarks>
+                /// The same choice <c>[SingletonService(Using = ...)]</c> makes, and the answer to
+                /// Scrutor's <c>RegistrationStrategy</c>: <c>Try</c> skips a service type already
+                /// registered, <c>TryEnumerable</c> allows several implementations of one service,
+                /// and <c>Replace</c> takes over an existing registration. Defaults to <c>Add</c>.
+                /// </remarks>
+                /// <param name="registrationType">How to add the registration.</param>
+                IConventionRegistration Using(
+                    global::DependencyModules.Runtime.Attributes.RegistrationType registrationType);
+
+                /// <summary>
+                /// Registers every match under a service key.
+                /// </summary>
+                /// <remarks>
+                /// The key is written into the registration as you wrote it, so a string literal, a
+                /// <c>const</c> or an enum member all work. Every match of this convention shares
+                /// the key — there is no way to vary it per type, because that would take a lambda
+                /// over types the generator is only describing.
+                /// </remarks>
+                /// <param name="key">The service key.</param>
+                IConventionRegistration WithKey(object key);
             }
         }
         """;

--- a/src/DependencyModules.Conventions/ConventionContractSource.cs
+++ b/src/DependencyModules.Conventions/ConventionContractSource.cs
@@ -193,6 +193,34 @@ public static class ConventionContractSource {
                 IConventionRegistration AsSelf();
 
                 /// <summary>
+                /// Registers each match as the service type the convention matched <i>and</i> as its
+                /// own concrete type, sharing one instance between them.
+                /// </summary>
+                /// <remarks>
+                /// <para>
+                /// Additive, where <c>AsSelf</c> replaces: <c>AsSelf</c> means "instead of the
+                /// interface", this means "as well as it". Only the interfaces the convention
+                /// matched are registered, not every interface the type can reach — that is
+                /// <see cref="AsSelfWithInterfaces"/>.
+                /// </para>
+                /// <para>
+                /// The shape FluentValidation wants. It registers each validator as
+                /// <c>IValidator&lt;T&gt;</c> and as the concrete type, independently, which hands
+                /// you two instances per scope; cross-wiring them gives one, which is the better
+                /// behaviour and a deliberate difference.
+                /// </para>
+                /// <example>
+                /// <code>
+                /// conventions.RegisterAll(typeof(IValidator&lt;&gt;))
+                ///     .IncludeBaseClasses()
+                ///     .AlsoAsSelf()
+                ///     .AsScoped();
+                /// </code>
+                /// </example>
+                /// </remarks>
+                IConventionRegistration AlsoAsSelf();
+
+                /// <summary>
                 /// Registers each match as its own type <i>and</i> as every interface it implements,
                 /// sharing one instance between them.
                 /// </summary>

--- a/src/DependencyModules.Conventions/ConventionContractSource.cs
+++ b/src/DependencyModules.Conventions/ConventionContractSource.cs
@@ -319,6 +319,40 @@ public static class ConventionContractSource {
                 IConventionRegistration As<TService>();
 
                 /// <summary>
+                /// Scans the assembly <typeparamref name="TMarker"/> lives in, instead of the
+                /// project being built.
+                /// </summary>
+                /// <remarks>
+                /// <para>
+                /// For registering types out of a package you do not own. A project you <i>do</i>
+                /// own is better served by giving it its own module with its own conventions and
+                /// composing through module attributes — explicit, ordered, and cross-assembly by
+                /// construction.
+                /// </para>
+                /// <para>
+                /// The assembly is always named, and named by a type rather than a string, so an
+                /// assembly that is not referenced cannot be asked for. There is deliberately no
+                /// "scan everything I depend on": measured, walking every reference visits 5,350
+                /// types where one named assembly visits 10, on every keystroke.
+                /// </para>
+                /// <para>
+                /// Only <c>public</c> types are visible across an assembly boundary, where a scan of
+                /// the project being built also sees <c>internal</c> ones. Nothing can report the
+                /// <c>internal</c> type it cannot see, so this is a difference to know rather than
+                /// one that can be diagnosed.
+                /// </para>
+                /// <example>
+                /// <code>
+                /// conventions.RegisterAll(typeof(IHandler&lt;,&gt;))
+                ///     .InAssemblyOf&lt;SomeTypeInThatPackage&gt;()
+                ///     .AsScoped();
+                /// </code>
+                /// </example>
+                /// </remarks>
+                /// <typeparam name="TMarker">Any type in the assembly to scan.</typeparam>
+                IConventionRegistration InAssemblyOf<TMarker>();
+
+                /// <summary>
                 /// Registers each match as the interface named after it — <c>Foo</c> as
                 /// <c>IFoo</c>.
                 /// </summary>

--- a/src/DependencyModules.Conventions/ConventionContractSource.cs
+++ b/src/DependencyModules.Conventions/ConventionContractSource.cs
@@ -266,6 +266,67 @@ public static class ConventionContractSource {
                 /// </remarks>
                 /// <param name="key">The service key.</param>
                 IConventionRegistration WithKey(object key);
+
+                /// <summary>
+                /// Limits matches to types carrying <typeparamref name="TAttribute"/>.
+                /// </summary>
+                /// <remarks>
+                /// The attribute is resolved, not matched on how it was written, so a
+                /// namespace-qualified usage and an alias both count. Several attribute filters
+                /// combine with <b>and</b>.
+                /// </remarks>
+                /// <typeparam name="TAttribute">The attribute to require.</typeparam>
+                IConventionRegistration WithAttribute<TAttribute>()
+                    where TAttribute : global::System.Attribute;
+
+                /// <summary>
+                /// Excludes types carrying <typeparamref name="TAttribute"/>.
+                /// </summary>
+                /// <typeparam name="TAttribute">The attribute to exclude on.</typeparam>
+                IConventionRegistration WithoutAttribute<TAttribute>()
+                    where TAttribute : global::System.Attribute;
+
+                /// <summary>
+                /// Limits matches to types whose name fits one of the given patterns.
+                /// </summary>
+                /// <remarks>
+                /// <para>
+                /// Two wildcards and no regex: <c>*</c> matches zero or more characters, <c>?</c>
+                /// matches exactly one. A pattern containing a dot is matched against the full
+                /// <c>Namespace.TypeName</c>; otherwise against the bare type name. Matching is
+                /// ordinal and case-sensitive, like C# identifiers.
+                /// </para>
+                /// <para>
+                /// The weakest selector here, and deliberately last. It is the one most likely to
+                /// match something nobody intended when a class is added years later — prefer
+                /// <c>RegisterAll&lt;T&gt;</c>, an attribute, or a namespace.
+                /// </para>
+                /// </remarks>
+                /// <param name="patterns">Name patterns to include; several combine with or.</param>
+                IConventionRegistration WithName(params string[] patterns);
+
+                /// <summary>
+                /// Excludes types whose name fits one of the given patterns.
+                /// </summary>
+                /// <param name="patterns">Name patterns to exclude.</param>
+                IConventionRegistration WithoutName(params string[] patterns);
+
+                /// <summary>
+                /// Registers every match as <typeparamref name="TService"/>, whatever it matched
+                /// through.
+                /// </summary>
+                /// <typeparam name="TService">The service type to register as.</typeparam>
+                IConventionRegistration As<TService>();
+
+                /// <summary>
+                /// Registers each match as the interface named after it — <c>Foo</c> as
+                /// <c>IFoo</c>.
+                /// </summary>
+                /// <remarks>
+                /// A match that implements no such interface is skipped rather than registered some
+                /// other way, since the convention asked for one specific shape.
+                /// </remarks>
+                IConventionRegistration AsMatchingInterface();
             }
         }
         """;

--- a/src/DependencyModules.Conventions/ConventionSourceGenerator.cs
+++ b/src/DependencyModules.Conventions/ConventionSourceGenerator.cs
@@ -70,20 +70,41 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
             .Where(model => !model.IsIgnored)
             .Collect();
 
+        // Candidates from assemblies a convention names with InAssemblyOf<T>. Combined with the
+        // compilation, so this Select re-runs whenever the compilation changes — which is every
+        // keystroke — but its result is compared by value, so the emission downstream stays cached
+        // unless the scanned assembly's public surface actually differs. When no convention names an
+        // assembly it returns an empty list after one pass over the conventions, which is the common
+        // case and costs nothing.
+        var metadataCandidates = conventionModules
+            .Combine(context.CompilationProvider)
+            .Select((pair, cancellation) =>
+                new EquatableList<ConventionCandidateModel>(
+                    MetadataCandidateUtility.Collect(pair.Left, pair.Right, cancellation)));
+
         context.RegisterSourceOutput(
-            incrementalValueProvider.Collect().Combine(conventionModules).Combine(candidates),
+            incrementalValueProvider.Collect()
+                .Combine(conventionModules)
+                .Combine(candidates)
+                .Combine(metadataCandidates),
             GenerateSourceOutput);
     }
 
     private void GenerateSourceOutput(
         SourceProductionContext context,
-        ((ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Left,
+        (((ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Left,
             ImmutableArray<ConventionModuleModel> Right) Left,
-            ImmutableArray<ConventionCandidateModel> Right) data) {
+            ImmutableArray<ConventionCandidateModel> Right) Left,
+            EquatableList<ConventionCandidateModel> Right) data) {
 
-        var entryPoints = data.Left.Left;
-        var conventionModules = data.Left.Right;
-        var candidates = data.Right;
+        var entryPoints = data.Left.Left.Left;
+        var conventionModules = data.Left.Left.Right;
+
+        // In-compilation candidates and metadata candidates travel together; a convention sees one
+        // source or the other, decided by whether it named an assembly.
+        var candidates = data.Left.Right.Length == 0
+            ? (IReadOnlyList<ConventionCandidateModel>)data.Right
+            : data.Left.Right.Concat(data.Right).ToArray();
 
         if (entryPoints.Length == 0 || conventionModules.Length == 0) {
             return;
@@ -108,14 +129,14 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
         SourceProductionContext context,
         ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> entryPoints,
         ImmutableArray<ConventionModuleModel> conventionModules,
-        ImmutableArray<ConventionCandidateModel> candidates,
+        IReadOnlyList<ConventionCandidateModel> candidates,
         FileLogger logger) {
 
         var (entryPointList, configurationModel) = EntryModelUtil.ConsolidateEntryPointModels(entryPoints);
 
         logger.Info(
             $"Discovered {conventionModules.Length} convention module(s) and " +
-            $"{candidates.Length} candidate type(s).");
+            $"{candidates.Count} candidate type(s).");
 
         var claimed = new HashSet<ConventionModuleModel>();
 
@@ -143,7 +164,7 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
         ModuleEntryPointModel entryPointModel,
         DependencyModuleConfigurationModel configurationModel,
         ConventionModuleModel conventionModule,
-        ImmutableArray<ConventionCandidateModel> candidates,
+        IReadOnlyList<ConventionCandidateModel> candidates,
         FileLogger logger) {
 
         var withNamespace = EntryModelUtil.EnsureNamespace(entryPointModel, configurationModel);

--- a/src/DependencyModules.Conventions/Models/ConventionCandidateModel.cs
+++ b/src/DependencyModules.Conventions/Models/ConventionCandidateModel.cs
@@ -61,7 +61,17 @@ public record ConventionCandidateModel(
     /// and an alias. Only collected for declarations that carry attributes at all, which is what
     /// keeps it off the cost of the wider candidate population.
     /// </remarks>
-    IReadOnlyList<string>? AttributeTypeKeys = null) {
+    IReadOnlyList<string>? AttributeTypeKeys = null,
+    /// <summary>
+    /// The referenced assembly this candidate was read from, or null when it comes from the
+    /// compilation being built.
+    /// </summary>
+    /// <remarks>
+    /// A convention sees one source or the other, never both: a scan of the project being built
+    /// should not silently pick up a type from a package, and a scan of a package should not pick up
+    /// a local one.
+    /// </remarks>
+    string? AssemblyName = null) {
 
     public static readonly ConventionCandidateModel Ignore = new(
         TypeDefinition.Get("", "Ignore"),
@@ -92,7 +102,8 @@ public record ConventionCandidateModel(
         ((Conditions?.Count ?? 0) == 0 && (other.Conditions?.Count ?? 0) == 0 ||
          ModelEquality.ListEquals(Conditions, other.Conditions)) &&
         ((AttributeTypeKeys?.Count ?? 0) == 0 && (other.AttributeTypeKeys?.Count ?? 0) == 0 ||
-         ModelEquality.ListEquals(AttributeTypeKeys, other.AttributeTypeKeys));
+         ModelEquality.ListEquals(AttributeTypeKeys, other.AttributeTypeKeys)) &&
+        AssemblyName == other.AssemblyName;
 
     private static bool CompareConstructor(ConstructorInfoModel? x, ConstructorInfoModel? y) {
         if (x is null && y is null) return true;

--- a/src/DependencyModules.Conventions/Models/ConventionCandidateModel.cs
+++ b/src/DependencyModules.Conventions/Models/ConventionCandidateModel.cs
@@ -52,7 +52,16 @@ public record ConventionCandidateModel(
     /// on a class whose conditions have no other way to be honoured. Dropping them would register a
     /// development-only service in production with nothing anywhere saying why.
     /// </remarks>
-    IReadOnlyList<EnvironmentConditionModel>? Conditions = null) {
+    IReadOnlyList<EnvironmentConditionModel>? Conditions = null,
+    /// <summary>
+    /// The attribute types the candidate carries, as ConventionTypeKey renders them.
+    /// </summary>
+    /// <remarks>
+    /// Resolved rather than taken as written, so WithAttribute matches a namespace-qualified usage
+    /// and an alias. Only collected for declarations that carry attributes at all, which is what
+    /// keeps it off the cost of the wider candidate population.
+    /// </remarks>
+    IReadOnlyList<string>? AttributeTypeKeys = null) {
 
     public static readonly ConventionCandidateModel Ignore = new(
         TypeDefinition.Get("", "Ignore"),
@@ -81,7 +90,9 @@ public record ConventionCandidateModel(
         // Null and empty both mean unconditional and have to compare equal, or an edit elsewhere
         // in the file would miss the incremental cache.
         ((Conditions?.Count ?? 0) == 0 && (other.Conditions?.Count ?? 0) == 0 ||
-         ModelEquality.ListEquals(Conditions, other.Conditions));
+         ModelEquality.ListEquals(Conditions, other.Conditions)) &&
+        ((AttributeTypeKeys?.Count ?? 0) == 0 && (other.AttributeTypeKeys?.Count ?? 0) == 0 ||
+         ModelEquality.ListEquals(AttributeTypeKeys, other.AttributeTypeKeys));
 
     private static bool CompareConstructor(ConstructorInfoModel? x, ConstructorInfoModel? y) {
         if (x is null && y is null) return true;

--- a/src/DependencyModules.Conventions/Models/ConventionModel.cs
+++ b/src/DependencyModules.Conventions/Models/ConventionModel.cs
@@ -149,6 +149,10 @@ public record AttributeFilterModel(string TypeKey, bool Exclude);
 /// <param name="AttributeFilters">
 /// Set by <c>WithAttribute</c> and <c>WithoutAttribute</c>. All of them have to hold.
 /// </param>
+/// <param name="AssemblyName">
+/// Set by <c>InAssemblyOf&lt;T&gt;()</c>. Null scans the compilation being built, which is the
+/// default and the common case. A convention only ever sees candidates from one source.
+/// </param>
 public record ConventionModel(
     ITypeDefinition? ServiceType,
     string? DefinitionKey,
@@ -163,7 +167,8 @@ public record ConventionModel(
     IReadOnlyList<string>? KeyNamespaces = null,
     IReadOnlyList<AttributeFilterModel>? AttributeFilters = null,
     IReadOnlyList<NameFilterModel>? NameFilters = null,
-    ITypeDefinition? ExplicitServiceType = null) {
+    ITypeDefinition? ExplicitServiceType = null,
+    string? AssemblyName = null) {
 
     /// <summary>
     /// Whether the attributes a candidate carries pass the filters.
@@ -237,7 +242,8 @@ public record ConventionModel(
         ModelEquality.ListEquals(KeyNamespaces, other.KeyNamespaces) &&
         ModelEquality.ListEquals(AttributeFilters, other.AttributeFilters) &&
         ModelEquality.ListEquals(NameFilters, other.NameFilters) &&
-        Equals(ExplicitServiceType, other.ExplicitServiceType);
+        Equals(ExplicitServiceType, other.ExplicitServiceType) &&
+        AssemblyName == other.AssemblyName;
 
     public override int GetHashCode() {
         unchecked {
@@ -254,6 +260,7 @@ public record ConventionModel(
             hash = hash * 31 + ModelEquality.ListHashCode(AttributeFilters);
             hash = hash * 31 + ModelEquality.ListHashCode(NameFilters);
             hash = hash * 31 + (ExplicitServiceType?.GetHashCode() ?? 0);
+            hash = hash * 31 + (AssemblyName?.GetHashCode() ?? 0);
             return hash;
         }
     }

--- a/src/DependencyModules.Conventions/Models/ConventionModel.cs
+++ b/src/DependencyModules.Conventions/Models/ConventionModel.cs
@@ -45,6 +45,12 @@ public enum ConventionRegisterAs {
     SelfAndInterfaces,
 
     /// <summary>
+    /// As the service types the convention matched, and also as the concrete type, sharing one
+    /// instance. Additive where <see cref="Self"/> replaces.
+    /// </summary>
+    AlsoSelf,
+
+    /// <summary>
     /// As one service type named by <c>As&lt;T&gt;()</c>, whatever the match matched through.
     /// </summary>
     Explicit,

--- a/src/DependencyModules.Conventions/Models/ConventionModel.cs
+++ b/src/DependencyModules.Conventions/Models/ConventionModel.cs
@@ -24,24 +24,6 @@ public static class ConventionTypeKey {
 }
 
 /// <summary>
-/// One <c>RegisterAll</c> declaration read out of a module's <c>Conventions</c> method.
-/// </summary>
-/// <param name="ServiceType">The service type as written.</param>
-/// <param name="DefinitionKey">Namespace, name and arity, for matching. See <see cref="ConventionTypeKey"/>.</param>
-/// <param name="IsOpenGeneric">
-/// True for <c>RegisterAll(typeof(IHandler&lt;,&gt;))</c>. An open convention matches any closing
-/// and registers each candidate against the construction it actually implements; a closed one has
-/// to match that exact construction, or <c>RegisterAll&lt;IHandler&lt;A, B&gt;&gt;()</c> would pick
-/// up every other closing too.
-/// </param>
-/// <param name="Lifestyle">
-/// Null when no <c>AsSingleton</c>/<c>AsScoped</c>/<c>AsTransient</c> was called. Deliberately not
-/// defaulted — a lifetime nobody wrote down is the most expensive thing to get wrong, so this is
-/// reported as DM0009 rather than guessed.
-/// </param>
-/// <param name="IncludeBaseClasses">Set by <c>IncludeBaseClasses()</c>.</param>
-/// <param name="Location">Where the chain was written, for diagnostics.</param>
-/// <summary>
 /// What a convention registers each match as.
 /// </summary>
 public enum ConventionRegisterAs {
@@ -61,6 +43,33 @@ public enum ConventionRegisterAs {
     /// <see cref="ServiceRegistrationModel.CrossWire"/>.
     /// </summary>
     SelfAndInterfaces,
+
+    /// <summary>
+    /// As one service type named by <c>As&lt;T&gt;()</c>, whatever the match matched through.
+    /// </summary>
+    Explicit,
+
+    /// <summary>
+    /// As the interface named after the type: <c>Foo</c> as <c>IFoo</c>.
+    /// </summary>
+    MatchingInterface,
+}
+
+/// <summary>
+/// One <c>WithName</c> or <c>WithoutName</c> filter.
+/// </summary>
+/// <param name="Pattern">
+/// The glob as written. Kept as a string rather than a compiled <c>Regex</c>, which is not equatable
+/// and would break the incremental cache; the matcher compiles one per convention, which is still
+/// once per pattern rather than once per candidate.
+/// </param>
+/// <param name="Exclude">True for the <c>Without</c> form.</param>
+public record NameFilterModel(string Pattern, bool Exclude) {
+
+    /// <summary>
+    /// True when the pattern is matched against the full name rather than the bare type name.
+    /// </summary>
+    public bool IsQualified => Pattern.IndexOf('.') >= 0;
 }
 
 /// <summary>
@@ -94,15 +103,51 @@ public record NamespaceFilterModel(string Namespace, bool Exact, bool Exclude) {
     }
 }
 
+/// <summary>
+/// One <c>WithAttribute</c> or <c>WithoutAttribute</c> filter.
+/// </summary>
+/// <param name="TypeKey">
+/// The attribute type's namespace, name and arity, as <see cref="ConventionTypeKey"/> renders it.
+/// Compared against the same rendering of what the candidate carries, so both sides are resolved
+/// and a namespace-qualified usage matches a plain one.
+/// </param>
+/// <param name="Exclude">True for the <c>Without</c> form.</param>
+public record AttributeFilterModel(string TypeKey, bool Exclude);
+
+/// <summary>
+/// One <c>RegisterAll</c> declaration read out of a module's <c>Conventions</c> method.
+/// </summary>
 /// <param name="ServiceType">
 /// The service type as written, or null for <c>RegisterAll()</c> — a convention selected by filters
 /// rather than by assignability, which registers its matches as themselves.
 /// </param>
-/// <param name="DefinitionKey">Namespace, name and arity, for matching. Null with no service type.</param>
+/// <param name="DefinitionKey">
+/// Namespace, name and arity, for matching. See <see cref="ConventionTypeKey"/>. Null with no
+/// service type.
+/// </param>
+/// <param name="IsOpenGeneric">
+/// True for <c>RegisterAll(typeof(IHandler&lt;,&gt;))</c>. An open convention matches any closing
+/// and registers each candidate against the construction it actually implements; a closed one has
+/// to match that exact construction, or <c>RegisterAll&lt;IHandler&lt;A, B&gt;&gt;()</c> would pick
+/// up every other closing too.
+/// </param>
+/// <param name="Lifestyle">
+/// Null when no <c>AsSingleton</c>/<c>AsScoped</c>/<c>AsTransient</c> was called. Deliberately not
+/// defaulted — a lifetime nobody wrote down is the most expensive thing to get wrong, so this is
+/// reported as DM0009 rather than guessed.
+/// </param>
+/// <param name="IncludeBaseClasses">Set by <c>IncludeBaseClasses()</c>.</param>
+/// <param name="Location">Where the chain was written, for diagnostics.</param>
 /// <param name="RegisterAs">Set by <c>AsSelf()</c> or <c>AsSelfWithInterfaces()</c>.</param>
 /// <param name="NamespaceFilters">
 /// Inclusions combine with <b>or</b>; exclusions are applied afterwards and any one of them removes
 /// a match. Null when the convention did not filter by namespace.
+/// </param>
+/// <param name="RegistrationType">Set by <c>Using(...)</c>; null means <c>Add</c>.</param>
+/// <param name="Key">Set by <c>WithKey(...)</c>, kept as it was written.</param>
+/// <param name="KeyNamespaces">Namespaces the key expression needs, for an enum member.</param>
+/// <param name="AttributeFilters">
+/// Set by <c>WithAttribute</c> and <c>WithoutAttribute</c>. All of them have to hold.
 /// </param>
 public record ConventionModel(
     ITypeDefinition? ServiceType,
@@ -115,7 +160,33 @@ public record ConventionModel(
     IReadOnlyList<NamespaceFilterModel>? NamespaceFilters = null,
     RegistrationType? RegistrationType = null,
     object? Key = null,
-    IReadOnlyList<string>? KeyNamespaces = null) {
+    IReadOnlyList<string>? KeyNamespaces = null,
+    IReadOnlyList<AttributeFilterModel>? AttributeFilters = null,
+    IReadOnlyList<NameFilterModel>? NameFilters = null,
+    ITypeDefinition? ExplicitServiceType = null) {
+
+    /// <summary>
+    /// Whether the attributes a candidate carries pass the filters.
+    /// </summary>
+    /// <remarks>
+    /// Requirements combine with <b>and</b>: a type has to carry every attribute asked for and none
+    /// of the excluded ones. Alternatives would need an or, which no Scrutor overload offers either.
+    /// </remarks>
+    public bool AttributesMatch(IReadOnlyList<string>? candidateAttributes) {
+        if (AttributeFilters == null) {
+            return true;
+        }
+
+        foreach (var filter in AttributeFilters) {
+            var carried = candidateAttributes != null && candidateAttributes.Contains(filter.TypeKey);
+
+            if (carried == filter.Exclude) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     /// <summary>
     /// The name to use in a diagnostic, whether or not a service type was named.
@@ -163,7 +234,10 @@ public record ConventionModel(
         RegistrationType == other.RegistrationType &&
         Equals(Key, other.Key) &&
         ModelEquality.ListEquals(NamespaceFilters, other.NamespaceFilters) &&
-        ModelEquality.ListEquals(KeyNamespaces, other.KeyNamespaces);
+        ModelEquality.ListEquals(KeyNamespaces, other.KeyNamespaces) &&
+        ModelEquality.ListEquals(AttributeFilters, other.AttributeFilters) &&
+        ModelEquality.ListEquals(NameFilters, other.NameFilters) &&
+        Equals(ExplicitServiceType, other.ExplicitServiceType);
 
     public override int GetHashCode() {
         unchecked {
@@ -177,6 +251,9 @@ public record ConventionModel(
             hash = hash * 31 + (Key?.GetHashCode() ?? 0);
             hash = hash * 31 + ModelEquality.ListHashCode(NamespaceFilters);
             hash = hash * 31 + ModelEquality.ListHashCode(KeyNamespaces);
+            hash = hash * 31 + ModelEquality.ListHashCode(AttributeFilters);
+            hash = hash * 31 + ModelEquality.ListHashCode(NameFilters);
+            hash = hash * 31 + (ExplicitServiceType?.GetHashCode() ?? 0);
             return hash;
         }
     }

--- a/src/DependencyModules.Conventions/Models/ConventionModel.cs
+++ b/src/DependencyModules.Conventions/Models/ConventionModel.cs
@@ -41,13 +41,146 @@ public static class ConventionTypeKey {
 /// </param>
 /// <param name="IncludeBaseClasses">Set by <c>IncludeBaseClasses()</c>.</param>
 /// <param name="Location">Where the chain was written, for diagnostics.</param>
+/// <summary>
+/// What a convention registers each match as.
+/// </summary>
+public enum ConventionRegisterAs {
+    /// <summary>
+    /// As the service type the convention matched through. The default.
+    /// </summary>
+    Interfaces,
+
+    /// <summary>
+    /// As the match's own concrete type.
+    /// </summary>
+    Self,
+
+    /// <summary>
+    /// As the concrete type and every interface it implements, sharing one instance — the contract
+    /// <c>[CrossWireService]</c> already provides, reached through
+    /// <see cref="ServiceRegistrationModel.CrossWire"/>.
+    /// </summary>
+    SelfAndInterfaces,
+}
+
+/// <summary>
+/// One namespace filter on a convention.
+/// </summary>
+/// <param name="Namespace">The namespace as written, or the namespace of the marker type.</param>
+/// <param name="Exact">
+/// True to match only this namespace. False also matches the namespaces beneath it, which is what
+/// <c>InNamespaceOf</c> means and what people expect of a namespace filter.
+/// </param>
+/// <param name="Exclude">True for the <c>NotIn</c> forms.</param>
+public record NamespaceFilterModel(string Namespace, bool Exact, bool Exclude) {
+
+    /// <summary>
+    /// Whether a type's namespace falls inside this filter, ignoring whether it includes or
+    /// excludes.
+    /// </summary>
+    public bool Covers(string? candidateNamespace) {
+        var value = candidateNamespace ?? "";
+
+        if (Exact) {
+            return string.Equals(value, Namespace, StringComparison.Ordinal);
+        }
+
+        // A prefix match has to stop at a namespace separator, or "MyApp.Order" would swallow
+        // "MyApp.Ordering".
+        return value.Equals(Namespace, StringComparison.Ordinal) ||
+               (value.Length > Namespace.Length &&
+                value[Namespace.Length] == '.' &&
+                value.StartsWith(Namespace, StringComparison.Ordinal));
+    }
+}
+
+/// <param name="ServiceType">
+/// The service type as written, or null for <c>RegisterAll()</c> — a convention selected by filters
+/// rather than by assignability, which registers its matches as themselves.
+/// </param>
+/// <param name="DefinitionKey">Namespace, name and arity, for matching. Null with no service type.</param>
+/// <param name="RegisterAs">Set by <c>AsSelf()</c> or <c>AsSelfWithInterfaces()</c>.</param>
+/// <param name="NamespaceFilters">
+/// Inclusions combine with <b>or</b>; exclusions are applied afterwards and any one of them removes
+/// a match. Null when the convention did not filter by namespace.
+/// </param>
 public record ConventionModel(
-    ITypeDefinition ServiceType,
-    string DefinitionKey,
+    ITypeDefinition? ServiceType,
+    string? DefinitionKey,
     bool IsOpenGeneric,
     ServiceLifestyle? Lifestyle,
     bool IncludeBaseClasses,
-    LocationModel Location);
+    LocationModel Location,
+    ConventionRegisterAs RegisterAs = ConventionRegisterAs.Interfaces,
+    IReadOnlyList<NamespaceFilterModel>? NamespaceFilters = null,
+    RegistrationType? RegistrationType = null,
+    object? Key = null,
+    IReadOnlyList<string>? KeyNamespaces = null) {
+
+    /// <summary>
+    /// The name to use in a diagnostic, whether or not a service type was named.
+    /// </summary>
+    public string DisplayName => ServiceType?.Name ?? "RegisterAll()";
+
+    /// <summary>
+    /// Whether a candidate's namespace passes the filters.
+    /// </summary>
+    public bool NamespaceMatches(string? candidateNamespace) {
+        if (NamespaceFilters == null) {
+            return true;
+        }
+
+        var included = false;
+        var anyInclusion = false;
+
+        foreach (var filter in NamespaceFilters) {
+            if (filter.Exclude) {
+                if (filter.Covers(candidateNamespace)) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            anyInclusion = true;
+            included |= filter.Covers(candidateNamespace);
+        }
+
+        return !anyInclusion || included;
+    }
+
+    // Structural equality over the filter list; a positional record would compare it by reference
+    // and never hit the incremental cache. See ModelEquality.
+    public virtual bool Equals(ConventionModel? other) =>
+        other is not null &&
+        Equals(ServiceType, other.ServiceType) &&
+        DefinitionKey == other.DefinitionKey &&
+        IsOpenGeneric == other.IsOpenGeneric &&
+        Lifestyle == other.Lifestyle &&
+        IncludeBaseClasses == other.IncludeBaseClasses &&
+        Location == other.Location &&
+        RegisterAs == other.RegisterAs &&
+        RegistrationType == other.RegistrationType &&
+        Equals(Key, other.Key) &&
+        ModelEquality.ListEquals(NamespaceFilters, other.NamespaceFilters) &&
+        ModelEquality.ListEquals(KeyNamespaces, other.KeyNamespaces);
+
+    public override int GetHashCode() {
+        unchecked {
+            var hash = ServiceType?.GetHashCode() ?? 0;
+            hash = hash * 31 + (DefinitionKey?.GetHashCode() ?? 0);
+            hash = hash * 31 + IsOpenGeneric.GetHashCode();
+            hash = hash * 31 + Lifestyle.GetHashCode();
+            hash = hash * 31 + IncludeBaseClasses.GetHashCode();
+            hash = hash * 31 + (int)RegisterAs;
+            hash = hash * 31 + (RegistrationType?.GetHashCode() ?? 0);
+            hash = hash * 31 + (Key?.GetHashCode() ?? 0);
+            hash = hash * 31 + ModelEquality.ListHashCode(NamespaceFilters);
+            hash = hash * 31 + ModelEquality.ListHashCode(KeyNamespaces);
+            return hash;
+        }
+    }
+}
 
 /// <summary>
 /// A statement in a <c>Conventions</c> body the generator could not read.

--- a/src/DependencyModules.Conventions/Models/EquatableList.cs
+++ b/src/DependencyModules.Conventions/Models/EquatableList.cs
@@ -1,0 +1,34 @@
+using DependencyModules.SourceGenerator.Impl.Models;
+
+namespace DependencyModules.Conventions.Models;
+
+/// <summary>
+/// A list that compares by its contents, for use as an incremental provider's output.
+/// </summary>
+/// <remarks>
+/// A plain list — and <c>ImmutableArray</c> — compares by reference of the underlying array, so an
+/// unchanged walk still looks different on every run and everything downstream is recomputed. That
+/// is measurable rather than theoretical: the metadata scan re-runs on every keystroke by
+/// construction, so without this the emission would too.
+/// </remarks>
+public sealed class EquatableList<T> : IReadOnlyList<T> {
+    private readonly IReadOnlyList<T> _items;
+
+    public EquatableList(IReadOnlyList<T> items) {
+        _items = items;
+    }
+
+    public int Count => _items.Count;
+
+    public T this[int index] => _items[index];
+
+    public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();
+
+    System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() =>
+        ((System.Collections.IEnumerable)_items).GetEnumerator();
+
+    public override bool Equals(object? obj) =>
+        obj is EquatableList<T> other && ModelEquality.ListEquals(_items, other._items);
+
+    public override int GetHashCode() => ModelEquality.ListHashCode(_items);
+}

--- a/src/DependencyModules.Conventions/Utilities/ConventionCandidateUtility.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionCandidateUtility.cs
@@ -121,7 +121,8 @@ public static class ConventionCandidateUtility {
                 ServiceModelUtility.GetConstructorInfo(context, typeDeclaration, cancellationToken),
                 DeclaresAccessibleConstructor(typeDeclaration),
                 LocationModel.From(typeDeclaration),
-                EnvironmentConditionUtility.GetConditions(context, typeDeclaration, cancellationToken));
+                EnvironmentConditionUtility.GetConditions(context, typeDeclaration, cancellationToken),
+                CollectAttributeKeys(context, typeDeclaration, cancellationToken));
         }
 
         if (context.SemanticModel.GetDeclaredSymbol(typeDeclaration) is not INamedTypeSymbol symbol) {
@@ -140,7 +141,39 @@ public static class ConventionCandidateUtility {
             ServiceModelUtility.GetConstructorInfo(context, typeDeclaration, cancellationToken),
             HasAccessibleConstructor(symbol),
             LocationModel.From(typeDeclaration),
-            EnvironmentConditionUtility.GetConditions(context, typeDeclaration, cancellationToken));
+            EnvironmentConditionUtility.GetConditions(context, typeDeclaration, cancellationToken),
+            CollectAttributeKeys(context, typeDeclaration, cancellationToken));
+    }
+
+    /// <summary>
+    /// The attribute types a declaration carries, resolved.
+    /// </summary>
+    /// <remarks>
+    /// Resolved rather than taken as written, because matching attributes on their written name is
+    /// how a namespace-qualified usage came to be silently ignored once already in this generator.
+    /// Costs nothing for a type with no attributes, which is most of them, so it stays off the price
+    /// of admitting every class as a candidate.
+    /// </remarks>
+    private static IReadOnlyList<string>? CollectAttributeKeys(
+        SyntaxTransformContext context, TypeDeclarationSyntax typeDeclaration,
+        CancellationToken cancellationToken) {
+
+        List<string>? keys = null;
+
+        foreach (var attributeList in typeDeclaration.AttributeLists) {
+            foreach (var attribute in attributeList.Attributes) {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (ModelExtensions.GetTypeInfo(context.SemanticModel, attribute).Type is not { } type) {
+                    continue;
+                }
+
+                keys ??= new List<string>();
+                keys.Add(ConventionTypeKey.For(type.GetTypeDefinition()));
+            }
+        }
+
+        return keys;
     }
 
     /// <summary>

--- a/src/DependencyModules.Conventions/Utilities/ConventionCandidateUtility.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionCandidateUtility.cs
@@ -40,11 +40,21 @@ public static class ConventionCandidateUtility {
     /// The provider predicate. Syntax only — it runs on a great many nodes.
     /// </summary>
     /// <remarks>
-    /// Rejecting a declaration with no base list is free and removes most of the population: a type
-    /// implementing nothing can never be assignable to a service type. Abstract and static types are
-    /// dropped silently rather than reported, because an abstract base implementing the convention's
-    /// interface is the normal shape rather than a mistake. A type carrying an explicit service
-    /// attribute is never a candidate; the attribute always wins.
+    /// <para>
+    /// Abstract and static types are dropped silently rather than reported, because an abstract base
+    /// implementing the convention's interface is the normal shape rather than a mistake. A type
+    /// carrying an explicit service attribute is never a candidate; the attribute always wins.
+    /// </para>
+    /// <para>
+    /// A declaration with no base list <b>is</b> a candidate. It used to be rejected here, which was
+    /// free and removed most of the population — but it also meant a concrete class implementing no
+    /// interface could not be registered by convention at all, and that is the whole point of
+    /// <c>RegisterAll().InNamespaceOf&lt;T&gt;().AsSelf()</c>. The predicate cannot know whether any
+    /// convention in the compilation selects by filter rather than by assignability, because
+    /// providers cannot see each other, so the cost is paid whenever the convention package is
+    /// referenced. What keeps it small is that the transform does almost nothing for these: with no
+    /// base list there is no interface walk.
+    /// </para>
     /// </remarks>
     public static bool IsCandidate(SyntaxNode node, CancellationToken cancellationToken) {
         cancellationToken.ThrowIfCancellationRequested();
@@ -54,10 +64,6 @@ public static class ConventionCandidateUtility {
         }
 
         var typeDeclaration = (TypeDeclarationSyntax)node;
-
-        if (typeDeclaration.BaseList == null || typeDeclaration.BaseList.Types.Count == 0) {
-            return false;
-        }
 
         foreach (var modifier in typeDeclaration.Modifiers) {
             if (modifier.IsKind(SyntaxKind.StaticKeyword) ||
@@ -103,6 +109,21 @@ public static class ConventionCandidateUtility {
             return ConventionCandidateModel.Ignore;
         }
 
+        // No base list means no assignability to resolve, and nothing else this model needs is a
+        // semantic question. Binding a symbol for every such type — which is most types in most
+        // projects — was the largest remaining cost of admitting them: measured on 2,000 classes,
+        // the second run after an edit took 40 ms with the symbol and 12 ms without.
+        if (typeDeclaration.BaseList is not { Types.Count: > 0 }) {
+            return new ConventionCandidateModel(
+                typeDeclaration.GetTypeDefinition(),
+                Array.Empty<ImplementedInterfaceModel>(),
+                Array.Empty<ImplementedInterfaceModel>(),
+                ServiceModelUtility.GetConstructorInfo(context, typeDeclaration, cancellationToken),
+                DeclaresAccessibleConstructor(typeDeclaration),
+                LocationModel.From(typeDeclaration),
+                EnvironmentConditionUtility.GetConditions(context, typeDeclaration, cancellationToken));
+        }
+
         if (context.SemanticModel.GetDeclaredSymbol(typeDeclaration) is not INamedTypeSymbol symbol) {
             return ConventionCandidateModel.Ignore;
         }
@@ -111,10 +132,6 @@ public static class ConventionCandidateUtility {
         var viaBaseClass = new List<ImplementedInterfaceModel>();
 
         CollectInterfaces(symbol, typeDeclaration, context, declared, viaBaseClass, cancellationToken);
-
-        if (declared.Count == 0 && viaBaseClass.Count == 0) {
-            return ConventionCandidateModel.Ignore;
-        }
 
         return new ConventionCandidateModel(
             ImplementationTypeOf(symbol),
@@ -269,6 +286,39 @@ public static class ConventionCandidateUtility {
     /// surprising in a way an abstract base is not, which is why abstract types are dropped by the
     /// predicate and this is reported.
     /// </remarks>
+    /// <summary>
+    /// The syntactic counterpart of <see cref="HasAccessibleConstructor"/>, for the path that has no
+    /// symbol.
+    /// </summary>
+    /// <remarks>
+    /// A type declaring no constructor has the implicit public parameterless one; a primary
+    /// constructor is public; otherwise any constructor not marked private or protected will do.
+    /// </remarks>
+    private static bool DeclaresAccessibleConstructor(TypeDeclarationSyntax typeDeclaration) {
+        if (typeDeclaration.ParameterList is { Parameters.Count: >= 0 }) {
+            return true;
+        }
+
+        var declaredAny = false;
+
+        foreach (var constructor in typeDeclaration.Members.OfType<ConstructorDeclarationSyntax>()) {
+            if (constructor.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword))) {
+                continue;
+            }
+
+            declaredAny = true;
+
+            var hidden = constructor.Modifiers.Any(
+                m => m.IsKind(SyntaxKind.PrivateKeyword) || m.IsKind(SyntaxKind.ProtectedKeyword));
+
+            if (!hidden) {
+                return true;
+            }
+        }
+
+        return !declaredAny;
+    }
+
     private static bool HasAccessibleConstructor(INamedTypeSymbol symbol) {
         if (symbol.InstanceConstructors.Length == 0) {
             return true;

--- a/src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs
@@ -97,6 +97,12 @@ public static class ConventionMatcher {
                 continue;
             }
 
+            // One source or the other. A scan of the project being built must not pick up a type
+            // from a package, and a scan of a package must not pick up a local one.
+            if (candidate.AssemblyName != convention.AssemblyName) {
+                continue;
+            }
+
             if (!convention.NamespaceMatches(candidate.ImplementationType.Namespace) ||
                 !convention.AttributesMatch(candidate.AttributeTypeKeys) ||
                 !NameMatches(nameFilters, candidate.ImplementationType)) {
@@ -135,7 +141,9 @@ public static class ConventionMatcher {
 
                 report(Diagnostic.Create(
                     DependencyModuleDiagnostics.ConventionMatchNotConstructable,
-                    candidate.Location.ToLocationOrNone(),
+                    candidate.Location == LocationModel.None
+                        ? convention.Location.ToLocationOrNone()
+                        : candidate.Location.ToLocation(),
                     candidate.ImplementationType.Name,
                     serviceName,
                     moduleName));
@@ -441,7 +449,7 @@ public static class ConventionMatcher {
 
             report(Diagnostic.Create(
                 DependencyModuleDiagnostics.AmbiguousConventionMatch,
-                first.Candidate.Location.ToLocationOrNone(),
+                LocationOf(first),
                 first.Candidate.ImplementationType.Name,
                 moduleName,
                 serviceName,
@@ -482,6 +490,20 @@ public static class ConventionMatcher {
             _ => (implementation, implementation),
         };
     }
+
+    /// <summary>
+    /// Where to report a diagnostic about a match.
+    /// </summary>
+    /// <remarks>
+    /// The class itself when it is in this compilation, which is the affordance that makes DM0010
+    /// worth having — "this type is in the container as IFoo" answered in the IDE, at the type. A
+    /// match read out of a referenced assembly has no class to squiggle, so it reports at the
+    /// convention that asked for it, which is the only place the developer can act on it.
+    /// </remarks>
+    private static Location LocationOf(ConventionRegistrationMatch match) =>
+        match.Candidate.Location == LocationModel.None
+            ? match.Convention.Location.ToLocationOrNone()
+            : match.Candidate.Location.ToLocation();
 
     /// <summary>
     /// Whether an interface is one the BCL declares, and so not something to expand a service into.
@@ -541,12 +563,14 @@ public static class ConventionMatcher {
         IReadOnlyList<ConventionRegistrationMatch> matches, string moduleName, Action<Diagnostic> report) {
 
         foreach (var match in matches) {
+            var location = LocationOf(match);
+
             // A filter-selected convention reached the type directly, so there is no interface to
             // name and the type is exposed as itself.
             if (match.Interface == null) {
                 report(Diagnostic.Create(
                     DependencyModuleDiagnostics.ExposedByConvention,
-                    match.Candidate.Location.ToLocationOrNone(),
+                    location,
                     $"{match.Candidate.ImplementationType.Name} in {moduleName}"));
 
                 continue;
@@ -556,7 +580,7 @@ public static class ConventionMatcher {
 
             report(Diagnostic.Create(
                 DependencyModuleDiagnostics.ExposedByConvention,
-                match.Candidate.Location.ToLocationOrNone(),
+                location,
                 $"{match.Interface.InterfaceType.Name} in {moduleName}{via}"));
         }
     }

--- a/src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs
@@ -21,6 +21,19 @@ public record ConventionRegistrationMatch(
     ImplementedInterfaceModel? Interface);
 
 /// <summary>
+/// One registration a match produces, before the ambiguity check has run.
+/// </summary>
+/// <remarks>
+/// A match and a registration are not one to one: <c>AsSelfWithInterfaces</c> produces several, and
+/// <c>AlsoAsSelf</c> produces an interface registration and a self one. The ambiguity check works on
+/// these rather than on matches, so a duplicated self registration does not take an interface
+/// registration down with it.
+/// </remarks>
+internal record PendingRegistration(
+    ConventionRegistrationMatch Match,
+    ServiceRegistrationModel Registration);
+
+/// <summary>
 /// Matches a module's conventions against the candidates in the compilation.
 /// </summary>
 /// <remarks>
@@ -57,11 +70,23 @@ public static class ConventionMatcher {
             CollectMatches(convention, merged, moduleName, matches, report, logger);
         }
 
-        var usable = RemoveAmbiguous(matches, moduleName, report, logger);
+        // Registrations are built before the ambiguity check, not after. A shape like AlsoAsSelf
+        // produces both an interface registration and a self registration from one match, and the
+        // two collide with other conventions on entirely different terms — checking per match would
+        // drag a perfectly good interface registration down with a duplicated self one.
+        var pending = new List<PendingRegistration>();
+
+        foreach (var match in matches) {
+            foreach (var registration in BuildRegistrations(match, entryPointModel)) {
+                pending.Add(new PendingRegistration(match, registration));
+            }
+        }
+
+        var usable = RemoveAmbiguous(pending, moduleName, report, logger);
 
         ReportExposure(usable, moduleName, report);
 
-        return BuildServiceModels(usable, entryPointModel, logger);
+        return BuildServiceModels(usable, logger);
     }
 
     private static void CollectMatches(
@@ -124,8 +149,10 @@ public static class ConventionMatcher {
                 }
 
                 // AsSelf and AsSelfWithInterfaces name the implementation, so several matching
-                // closings still produce one registration rather than one per closing.
-                matched = convention.RegisterAs == ConventionRegisterAs.Interfaces
+                // closings still produce one registration rather than one per closing. The default
+                // and AlsoAsSelf register each matched closing.
+                matched = convention.RegisterAs is ConventionRegisterAs.Interfaces
+                    or ConventionRegisterAs.AlsoSelf
                     ? reachable.Cast<ImplementedInterfaceModel?>().ToList()
                     : new List<ImplementedInterfaceModel?> { reachable[0] };
             }
@@ -395,33 +422,34 @@ public static class ConventionMatcher {
     /// Reported rather than resolved. Picking one silently produces a registration nobody can
     /// predict from reading the module, which is the outcome DM0004 exists to prevent.
     /// </remarks>
-    private static List<ConventionRegistrationMatch> RemoveAmbiguous(
-        List<ConventionRegistrationMatch> matches,
+    private static List<PendingRegistration> RemoveAmbiguous(
+        List<PendingRegistration> pending,
         string moduleName,
         Action<Diagnostic> report,
         FileLogger logger) {
 
-        // Keyed on what the match will actually register as, not on the implementation alone. A type
-        // filling two roles registers twice; one service type claimed twice is the ambiguity.
+        // Keyed on what actually reaches the container: this implementation, under this service
+        // type. A type filling two roles registers twice; one service type claimed twice is the
+        // ambiguity.
         var byRegistration =
             new Dictionary<(ITypeDefinition Implementation, ITypeDefinition Service),
-                List<ConventionRegistrationMatch>>();
+                List<PendingRegistration>>();
 
         var order = new List<(ITypeDefinition Implementation, ITypeDefinition Service)>();
 
-        foreach (var match in matches) {
-            var key = RegistrationKey(match);
+        foreach (var entry in pending) {
+            var key = (entry.Match.Candidate.ImplementationType, entry.Registration.ServiceType);
 
             if (!byRegistration.TryGetValue(key, out var list)) {
-                list = new List<ConventionRegistrationMatch>();
+                list = new List<PendingRegistration>();
                 byRegistration[key] = list;
                 order.Add(key);
             }
 
-            list.Add(match);
+            list.Add(entry);
         }
 
-        var usable = new List<ConventionRegistrationMatch>();
+        var usable = new List<PendingRegistration>();
 
         // Insertion order rather than dictionary order: the emitted registration order feeds the
         // module snapshots, and a hash order would move them for unrelated reasons.
@@ -436,21 +464,21 @@ public static class ConventionMatcher {
 
             var first = group[0];
             var second = group[1];
-            var serviceName = ServiceTypeNameOf(first);
+            var serviceName = key.Service.Name;
 
-            var difference = first.Convention.Lifestyle == second.Convention.Lifestyle
+            var difference = first.Match.Convention.Lifestyle == second.Match.Convention.Lifestyle
                 ? "The declaration is duplicated."
-                : $"They declare different lifetimes ({first.Convention.Lifestyle} and " +
-                  $"{second.Convention.Lifestyle}).";
+                : $"They declare different lifetimes ({first.Match.Convention.Lifestyle} and " +
+                  $"{second.Match.Convention.Lifestyle}).";
 
             logger.Error(
-                $"{moduleName}: '{first.Candidate.ImplementationType.Name}' is registered as " +
+                $"{moduleName}: '{key.Implementation.Name}' is registered as " +
                 $"'{serviceName}' by two conventions. {difference}");
 
             report(Diagnostic.Create(
                 DependencyModuleDiagnostics.AmbiguousConventionMatch,
-                LocationOf(first),
-                first.Candidate.ImplementationType.Name,
+                LocationOf(first.Match),
+                key.Implementation.Name,
                 moduleName,
                 serviceName,
                 difference));
@@ -560,28 +588,23 @@ public static class ConventionMatcher {
     /// match was not direct.
     /// </summary>
     private static void ReportExposure(
-        IReadOnlyList<ConventionRegistrationMatch> matches, string moduleName, Action<Diagnostic> report) {
+        IReadOnlyList<PendingRegistration> usable, string moduleName, Action<Diagnostic> report) {
 
-        foreach (var match in matches) {
-            var location = LocationOf(match);
+        foreach (var entry in usable) {
+            var serviceType = entry.Registration.ServiceType;
 
-            // A filter-selected convention reached the type directly, so there is no interface to
-            // name and the type is exposed as itself.
-            if (match.Interface == null) {
-                report(Diagnostic.Create(
-                    DependencyModuleDiagnostics.ExposedByConvention,
-                    location,
-                    $"{match.Candidate.ImplementationType.Name} in {moduleName}"));
-
-                continue;
-            }
-
-            var via = match.Interface.ViaTypeName == null ? "" : $" (via {match.Interface.ViaTypeName})";
+            // The interface a convention matched through explains a match that was not direct, and
+            // only applies when this registration is that interface.
+            var via = entry.Match.Interface != null &&
+                      entry.Match.Interface.InterfaceType.Equals(serviceType) &&
+                      entry.Match.Interface.ViaTypeName != null
+                ? $" (via {entry.Match.Interface.ViaTypeName})"
+                : "";
 
             report(Diagnostic.Create(
                 DependencyModuleDiagnostics.ExposedByConvention,
-                location,
-                $"{match.Interface.InterfaceType.Name} in {moduleName}{via}"));
+                LocationOf(entry.Match),
+                $"{serviceType.Name} in {moduleName}{via}"));
         }
     }
 
@@ -589,31 +612,25 @@ public static class ConventionMatcher {
     /// Produces the same models the attribute path produces, so emission needs no special case.
     /// </summary>
     private static IReadOnlyList<ServiceModel> BuildServiceModels(
-        IReadOnlyList<ConventionRegistrationMatch> matches,
-        ModuleEntryPointModel entryPointModel,
-        FileLogger logger) {
+        IReadOnlyList<PendingRegistration> usable, FileLogger logger) {
 
         // One model per implementation, carrying every registration it produces — the shape
-        // ServiceModelUtility builds for the attribute path. Emitting one model per match would put
-        // two models with the same ImplementationType in front of DependencyFileWriter, which
-        // duplicates the per-implementation state it reads: constructor, conditions, cross-wire.
+        // ServiceModelUtility builds for the attribute path. Two models with the same
+        // ImplementationType would duplicate the per-implementation state the writer reads:
+        // constructor, conditions, cross-wire.
         var byImplementation = new Dictionary<ITypeDefinition, List<ServiceRegistrationModel>>();
         var order = new List<ConventionRegistrationMatch>();
 
-        foreach (var match in matches) {
-            var registrations = BuildRegistrations(match, entryPointModel);
+        foreach (var entry in usable) {
+            var implementation = entry.Match.Candidate.ImplementationType;
 
-            if (registrations.Count == 0) {
-                continue;
-            }
-
-            if (!byImplementation.TryGetValue(match.Candidate.ImplementationType, out var list)) {
+            if (!byImplementation.TryGetValue(implementation, out var list)) {
                 list = new List<ServiceRegistrationModel>();
-                byImplementation[match.Candidate.ImplementationType] = list;
-                order.Add(match);
+                byImplementation[implementation] = list;
+                order.Add(entry.Match);
             }
 
-            list.AddRange(registrations);
+            list.Add(entry.Registration);
         }
 
         var models = new List<ServiceModel>(order.Count);
@@ -673,6 +690,15 @@ public static class ConventionMatcher {
         switch (convention.RegisterAs) {
             case ConventionRegisterAs.Self:
                 return new[] { Registration(match.Candidate.ImplementationType) };
+
+            case ConventionRegisterAs.AlsoSelf:
+                // Only the matched interface, cross-wired. The writer adds the implementation
+                // registration itself once per service model whenever anything is cross-wired, so
+                // emitting one here too produced the type twice. The difference from
+                // SelfAndInterfaces is which interfaces are expanded, not what self costs.
+                return match.Interface == null
+                    ? new[] { Registration(match.Candidate.ImplementationType) }
+                    : new[] { Registration(match.Interface.InterfaceType, crossWire: true) };
 
             case ConventionRegisterAs.Explicit:
                 return new[] { Registration(convention.ExplicitServiceType!) };

--- a/src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs
@@ -3,6 +3,7 @@ using DependencyModules.Conventions.Models;
 using DependencyModules.SourceGenerator.Impl;
 using DependencyModules.SourceGenerator.Impl.Models;
 using DependencyModules.SourceGenerator.Impl.Utilities;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 
 namespace DependencyModules.Conventions.Utilities;
@@ -87,12 +88,18 @@ public static class ConventionMatcher {
 
         var found = 0;
 
+        // Compiled once per convention rather than once per candidate, which is the whole reason
+        // the model keeps patterns as strings.
+        var nameFilters = CompileNameFilters(convention);
+
         foreach (var candidate in candidates) {
             if (candidate.IsIgnored) {
                 continue;
             }
 
-            if (!convention.NamespaceMatches(candidate.ImplementationType.Namespace)) {
+            if (!convention.NamespaceMatches(candidate.ImplementationType.Namespace) ||
+                !convention.AttributesMatch(candidate.AttributeTypeKeys) ||
+                !NameMatches(nameFilters, candidate.ImplementationType)) {
                 continue;
             }
 
@@ -150,6 +157,69 @@ public static class ConventionMatcher {
                 serviceName,
                 moduleName));
         }
+    }
+
+    /// <summary>
+    /// Translates each name glob to an anchored regular expression, once per convention.
+    /// </summary>
+    /// <remarks>
+    /// Two wildcards and nothing else: <c>*</c> for zero or more characters, <c>?</c> for exactly
+    /// one. Everything else is escaped, so a pattern cannot smuggle in a regex.
+    /// </remarks>
+    private static List<(Regex Pattern, bool Qualified, bool Exclude)>? CompileNameFilters(
+        ConventionModel convention) {
+
+        if (convention.NameFilters == null) {
+            return null;
+        }
+
+        var compiled = new List<(Regex, bool, bool)>(convention.NameFilters.Count);
+
+        foreach (var filter in convention.NameFilters) {
+            var expression = "^" +
+                             Regex.Escape(filter.Pattern).Replace("\\*", ".*").Replace("\\?", ".") +
+                             "$";
+
+            // Ordinal and case-sensitive, consistent with C# identifiers.
+            compiled.Add((new Regex(expression, RegexOptions.CultureInvariant), filter.IsQualified,
+                filter.Exclude));
+        }
+
+        return compiled;
+    }
+
+    private static bool NameMatches(
+        List<(Regex Pattern, bool Qualified, bool Exclude)>? filters, ITypeDefinition implementation) {
+
+        if (filters == null) {
+            return true;
+        }
+
+        var bareName = implementation.Name;
+
+        var qualifiedName = string.IsNullOrEmpty(implementation.Namespace)
+            ? bareName
+            : implementation.Namespace + "." + bareName;
+
+        var included = false;
+        var anyInclusion = false;
+
+        foreach (var (pattern, qualified, exclude) in filters) {
+            var subject = qualified ? qualifiedName : bareName;
+
+            if (exclude) {
+                if (pattern.IsMatch(subject)) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            anyInclusion = true;
+            included |= pattern.IsMatch(subject);
+        }
+
+        return !anyInclusion || included;
     }
 
     /// <summary>
@@ -269,7 +339,21 @@ public static class ConventionMatcher {
             }
         }
 
+        var attributeKeys = new List<string>();
+
+        // Attributes on partial parts combine, so the keys do too.
+        foreach (var part in parts) {
+            if (part.AttributeTypeKeys != null) {
+                foreach (var key in part.AttributeTypeKeys) {
+                    if (!attributeKeys.Contains(key)) {
+                        attributeKeys.Add(key);
+                    }
+                }
+            }
+        }
+
         return parts[0] with {
+            AttributeTypeKeys = attributeKeys.Count > 0 ? attributeKeys : null,
             DeclaredInterfaces = declared,
             BaseClassInterfaces = viaBaseClass,
             // The greediest constructor, matching what GetConstructorInfo does within one
@@ -389,15 +473,34 @@ public static class ConventionMatcher {
 
         var implementation = match.Candidate.ImplementationType;
 
-        return match.Convention.RegisterAs == ConventionRegisterAs.Interfaces && match.Interface != null
-            ? (implementation, match.Interface.InterfaceType)
-            : (implementation, implementation);
+        return match.Convention.RegisterAs switch {
+            ConventionRegisterAs.Explicit => (implementation, match.Convention.ExplicitServiceType!),
+            ConventionRegisterAs.MatchingInterface =>
+                (implementation, MatchingInterfaceOf(match) ?? implementation),
+            ConventionRegisterAs.Interfaces when match.Interface != null =>
+                (implementation, match.Interface.InterfaceType),
+            _ => (implementation, implementation),
+        };
+    }
+
+    /// <summary>
+    /// The interface named after the implementation — Foo as IFoo.
+    /// </summary>
+    private static ITypeDefinition? MatchingInterfaceOf(ConventionRegistrationMatch match) {
+        var wanted = "I" + match.Candidate.ImplementationType.Name;
+
+        foreach (var candidateInterface in
+                 match.Candidate.InterfacesInReach(match.Convention.IncludeBaseClasses)) {
+            if (string.Equals(candidateInterface.InterfaceType.Name, wanted, StringComparison.Ordinal)) {
+                return candidateInterface.InterfaceType;
+            }
+        }
+
+        return null;
     }
 
     private static string ServiceTypeNameOf(ConventionRegistrationMatch match) =>
-        match.Convention.RegisterAs == ConventionRegisterAs.Interfaces && match.Interface != null
-            ? match.Interface.InterfaceType.Name
-            : match.Candidate.ImplementationType.Name;
+        RegistrationKey(match).Service.Name;
 
     /// <summary>
     /// Reports DM0010 on each registered class, naming the interface it was reached through when the
@@ -515,6 +618,18 @@ public static class ConventionMatcher {
         switch (convention.RegisterAs) {
             case ConventionRegisterAs.Self:
                 return new[] { Registration(match.Candidate.ImplementationType) };
+
+            case ConventionRegisterAs.Explicit:
+                return new[] { Registration(convention.ExplicitServiceType!) };
+
+            case ConventionRegisterAs.MatchingInterface:
+                var matching = MatchingInterfaceOf(match);
+
+                // Skipped rather than registered some other way: the convention asked for one shape
+                // and this type does not have it.
+                return matching == null
+                    ? Array.Empty<ServiceRegistrationModel>()
+                    : new[] { Registration(matching) };
 
             case ConventionRegisterAs.SelfAndInterfaces:
                 var crossWired = new List<ServiceRegistrationModel>();

--- a/src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs
@@ -484,6 +484,37 @@ public static class ConventionMatcher {
     }
 
     /// <summary>
+    /// Whether an interface is one the BCL declares, and so not something to expand a service into.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Applies only to the <c>AsSelfWithInterfaces</c> expansion, where the interfaces are whatever
+    /// the type happens to reach rather than anything the developer named. Without it, any type whose
+    /// base implements <see cref="IDisposable"/> becomes resolvable as <c>IDisposable</c>, and a
+    /// FluentValidation validator becomes resolvable as <c>IEnumerable&lt;IValidationRule&gt;</c> —
+    /// neither of which is what "register this as its interfaces" means.
+    /// </para>
+    /// <para>
+    /// One rule rather than a list. Autofac excludes <c>IDisposable</c> and not <c>IEnumerable</c>;
+    /// Scrutor excludes <c>IEnumerable</c> and not <c>IDisposable</c>. Both are patches added after
+    /// users hit them, and the list they imply keeps growing — <c>IEquatable&lt;T&gt;</c>,
+    /// <c>IComparable</c>, <c>ICloneable</c>. Excluding the <c>System</c> namespace covers the family
+    /// at once and is defensible in a sentence.
+    /// </para>
+    /// <para>
+    /// Deliberately not extended to <c>Microsoft.Extensions.*</c>: a <c>BackgroundService</c>
+    /// reaching <c>IHostedService</c> is something a developer could legitimately want cross-wired,
+    /// so that line does not hold the way this one does.
+    /// </para>
+    /// </remarks>
+    private static bool IsFrameworkInterface(ITypeDefinition interfaceType) {
+        var namespaceName = interfaceType.Namespace;
+
+        return namespaceName == "System" ||
+               (namespaceName != null && namespaceName.StartsWith("System.", StringComparison.Ordinal));
+    }
+
+    /// <summary>
     /// The interface named after the implementation — Foo as IFoo.
     /// </summary>
     private static ITypeDefinition? MatchingInterfaceOf(ConventionRegistrationMatch match) {
@@ -636,11 +667,15 @@ public static class ConventionMatcher {
 
                 foreach (var reachable in
                          match.Candidate.InterfacesInReach(convention.IncludeBaseClasses)) {
+                    if (IsFrameworkInterface(reachable.InterfaceType)) {
+                        continue;
+                    }
+
                     crossWired.Add(Registration(reachable.InterfaceType, crossWire: true));
                 }
 
-                // No interfaces at all still registers the type itself, which is what the developer
-                // asked for by naming a shape that includes "self".
+                // Nothing left to expand to still registers the type itself, so filtering everything
+                // away degrades to AsSelf() rather than to nothing.
                 if (crossWired.Count == 0) {
                     crossWired.Add(Registration(match.Candidate.ImplementationType));
                 }

--- a/src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionMatcher.cs
@@ -10,10 +10,14 @@ namespace DependencyModules.Conventions.Utilities;
 /// <summary>
 /// One candidate matched by one convention, through one interface.
 /// </summary>
+/// <param name="Interface">
+/// Null when the convention named no service type. A filter-selected convention matches the type
+/// itself rather than through anything it implements.
+/// </param>
 public record ConventionRegistrationMatch(
     ConventionModel Convention,
     ConventionCandidateModel Candidate,
-    ImplementedInterfaceModel Interface);
+    ImplementedInterfaceModel? Interface);
 
 /// <summary>
 /// Matches a module's conventions against the candidates in the compilation.
@@ -44,10 +48,12 @@ public static class ConventionMatcher {
                 unreadable.Text));
         }
 
+        var merged = MergePartialDeclarations(candidates);
+
         var matches = new List<ConventionRegistrationMatch>();
 
         foreach (var convention in conventionModule.Conventions) {
-            CollectMatches(convention, candidates, moduleName, matches, report, logger);
+            CollectMatches(convention, merged, moduleName, matches, report, logger);
         }
 
         var usable = RemoveAmbiguous(matches, moduleName, report, logger);
@@ -65,7 +71,7 @@ public static class ConventionMatcher {
         Action<Diagnostic> report,
         FileLogger logger) {
 
-        var serviceName = convention.ServiceType.Name;
+        var serviceName = convention.DisplayName;
 
         if (convention.Lifestyle == null) {
             logger.Error($"{moduleName}: the convention registering '{serviceName}' declared no lifetime.");
@@ -86,10 +92,29 @@ public static class ConventionMatcher {
                 continue;
             }
 
-            var matched = FirstMatchingInterface(convention, candidate);
-
-            if (matched == null) {
+            if (!convention.NamespaceMatches(candidate.ImplementationType.Namespace)) {
                 continue;
+            }
+
+            // With no service type the filters are the whole selection, and the candidate matches
+            // as itself — one match, no interface.
+            List<ImplementedInterfaceModel?> matched;
+
+            if (convention.ServiceType == null) {
+                matched = new List<ImplementedInterfaceModel?> { null };
+            }
+            else {
+                var reachable = AllMatchingInterfaces(convention, candidate);
+
+                if (reachable.Count == 0) {
+                    continue;
+                }
+
+                // AsSelf and AsSelfWithInterfaces name the implementation, so several matching
+                // closings still produce one registration rather than one per closing.
+                matched = convention.RegisterAs == ConventionRegisterAs.Interfaces
+                    ? reachable.Cast<ImplementedInterfaceModel?>().ToList()
+                    : new List<ImplementedInterfaceModel?> { reachable[0] };
             }
 
             found++;
@@ -111,7 +136,9 @@ public static class ConventionMatcher {
                 continue;
             }
 
-            matches.Add(new ConventionRegistrationMatch(convention, candidate, matched));
+            foreach (var candidateInterface in matched) {
+                matches.Add(new ConventionRegistrationMatch(convention, candidate, candidateInterface));
+            }
         }
 
         if (found == 0) {
@@ -126,15 +153,19 @@ public static class ConventionMatcher {
     }
 
     /// <summary>
-    /// The construction of the convention's service type that this candidate implements, if any.
+    /// Every construction of the convention's service type this candidate implements.
     /// </summary>
     /// <remarks>
-    /// One interface per candidate per convention. A candidate implementing two closings of the same
-    /// open generic is registered against the first; registering it against both would mean the same
-    /// implementation appearing twice for one declaration.
+    /// All of them, not the first. A notification handler covering two events implements
+    /// <c>INotificationHandler&lt;OrderPlaced&gt;</c> and <c>INotificationHandler&lt;OrderShipped&gt;</c>,
+    /// and registering only the first left the second silently unregistered — a green build and an
+    /// event that never fires. They are different service types, so registering both is not the same
+    /// implementation appearing twice.
     /// </remarks>
-    private static ImplementedInterfaceModel? FirstMatchingInterface(
+    private static List<ImplementedInterfaceModel> AllMatchingInterfaces(
         ConventionModel convention, ConventionCandidateModel candidate) {
+
+        var matched = new List<ImplementedInterfaceModel>();
 
         foreach (var candidateInterface in candidate.InterfacesInReach(convention.IncludeBaseClasses)) {
             // An open convention matches any closing, and the candidate is registered against the
@@ -142,14 +173,127 @@ public static class ConventionMatcher {
             // RegisterAll<IHandler<A,B>>() would pick up every other closing as well.
             var isMatch = convention.IsOpenGeneric
                 ? convention.DefinitionKey == candidateInterface.DefinitionKey
-                : convention.ServiceType.Equals(candidateInterface.InterfaceType);
+                : convention.ServiceType!.Equals(candidateInterface.InterfaceType);
 
             if (isMatch) {
-                return candidateInterface;
+                matched.Add(candidateInterface);
             }
         }
 
-        return null;
+        return matched;
+    }
+
+    /// <summary>
+    /// Collapses the declarations of one partial type into a single candidate.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The candidate provider runs per declaration, and <c>CollectInterfaces</c> reads the base list
+    /// of the declaration in front of it rather than the interfaces of the merged symbol. So
+    /// <c>partial class Foo : IFoo</c> in one part and <c>partial class Foo : FooBase</c> in another
+    /// produce two candidates that each see half of the picture, and the ambiguity check — which
+    /// groups by implementation type — read the second one as a competing match and refused both.
+    /// </para>
+    /// <para>
+    /// Merging rather than deduping the matches, because the halves are genuinely different: the
+    /// interface a convention matches through decides whether the match is by declaration or through
+    /// a base class, and which of the two parts happened to be visited first should not decide that.
+    /// A type that declares the interface in any part declares it.
+    /// </para>
+    /// </remarks>
+    private static IReadOnlyList<ConventionCandidateModel> MergePartialDeclarations(
+        IReadOnlyList<ConventionCandidateModel> candidates) {
+
+        var byType = new Dictionary<ITypeDefinition, List<ConventionCandidateModel>>();
+        var order = new List<ITypeDefinition>();
+        var anyPartial = false;
+
+        foreach (var candidate in candidates) {
+            if (!byType.TryGetValue(candidate.ImplementationType, out var parts)) {
+                parts = new List<ConventionCandidateModel>();
+                byType[candidate.ImplementationType] = parts;
+                order.Add(candidate.ImplementationType);
+            }
+            else {
+                anyPartial = true;
+            }
+
+            parts.Add(candidate);
+        }
+
+        if (!anyPartial) {
+            return candidates;
+        }
+
+        var merged = new List<ConventionCandidateModel>(order.Count);
+
+        foreach (var implementationType in order) {
+            var parts = byType[implementationType];
+
+            merged.Add(parts.Count == 1 ? parts[0] : MergeParts(parts));
+        }
+
+        return merged;
+    }
+
+    private static ConventionCandidateModel MergeParts(List<ConventionCandidateModel> parts) {
+        var declared = new List<ImplementedInterfaceModel>();
+        var viaBaseClass = new List<ImplementedInterfaceModel>();
+        var seen = new HashSet<ITypeDefinition>();
+
+        // Declared first across every part, so an interface written on one declaration is a declared
+        // match even when another part only reaches it through a base class. That is what makes
+        // IncludeBaseClasses() unnecessary for a type that names the interface anywhere.
+        foreach (var part in parts) {
+            foreach (var declaredInterface in part.DeclaredInterfaces) {
+                if (seen.Add(declaredInterface.InterfaceType)) {
+                    declared.Add(declaredInterface);
+                }
+            }
+        }
+
+        foreach (var part in parts) {
+            foreach (var baseClassInterface in part.BaseClassInterfaces) {
+                if (seen.Add(baseClassInterface.InterfaceType)) {
+                    viaBaseClass.Add(baseClassInterface);
+                }
+            }
+        }
+
+        var conditions = new List<EnvironmentConditionModel>();
+
+        // Attributes on partial parts combine, so the conditions do too.
+        foreach (var part in parts) {
+            if (part.Conditions != null) {
+                conditions.AddRange(part.Conditions);
+            }
+        }
+
+        return parts[0] with {
+            DeclaredInterfaces = declared,
+            BaseClassInterfaces = viaBaseClass,
+            // The greediest constructor, matching what GetConstructorInfo does within one
+            // declaration. A part that declares none reports an empty parameter list, so taking the
+            // first part's would emit a call to a constructor the type does not have.
+            Constructor = GreediestConstructor(parts),
+            Conditions = conditions.Count > 0 ? conditions : null,
+        };
+    }
+
+    private static ConstructorInfoModel? GreediestConstructor(List<ConventionCandidateModel> parts) {
+        ConstructorInfoModel? greediest = null;
+
+        foreach (var part in parts) {
+            if (part.Constructor == null) {
+                continue;
+            }
+
+            if (greediest == null || part.Constructor.Parameters.Count > greediest.Parameters.Count) {
+                greediest = part.Constructor;
+            }
+        }
+
+        return greediest;
     }
 
     /// <summary>
@@ -165,12 +309,21 @@ public static class ConventionMatcher {
         Action<Diagnostic> report,
         FileLogger logger) {
 
-        var byCandidate = new Dictionary<ITypeDefinition, List<ConventionRegistrationMatch>>();
+        // Keyed on what the match will actually register as, not on the implementation alone. A type
+        // filling two roles registers twice; one service type claimed twice is the ambiguity.
+        var byRegistration =
+            new Dictionary<(ITypeDefinition Implementation, ITypeDefinition Service),
+                List<ConventionRegistrationMatch>>();
+
+        var order = new List<(ITypeDefinition Implementation, ITypeDefinition Service)>();
 
         foreach (var match in matches) {
-            if (!byCandidate.TryGetValue(match.Candidate.ImplementationType, out var list)) {
+            var key = RegistrationKey(match);
+
+            if (!byRegistration.TryGetValue(key, out var list)) {
                 list = new List<ConventionRegistrationMatch>();
-                byCandidate[match.Candidate.ImplementationType] = list;
+                byRegistration[key] = list;
+                order.Add(key);
             }
 
             list.Add(match);
@@ -178,31 +331,73 @@ public static class ConventionMatcher {
 
         var usable = new List<ConventionRegistrationMatch>();
 
-        foreach (var pair in byCandidate) {
-            if (pair.Value.Count == 1) {
-                usable.Add(pair.Value[0]);
+        // Insertion order rather than dictionary order: the emitted registration order feeds the
+        // module snapshots, and a hash order would move them for unrelated reasons.
+        foreach (var key in order) {
+            var group = byRegistration[key];
+
+            if (group.Count == 1) {
+                usable.Add(group[0]);
 
                 continue;
             }
 
-            var first = pair.Value[0];
-            var second = pair.Value[1];
+            var first = group[0];
+            var second = group[1];
+            var serviceName = ServiceTypeNameOf(first);
+
+            var difference = first.Convention.Lifestyle == second.Convention.Lifestyle
+                ? "The declaration is duplicated."
+                : $"They declare different lifetimes ({first.Convention.Lifestyle} and " +
+                  $"{second.Convention.Lifestyle}).";
 
             logger.Error(
-                $"{moduleName}: '{pair.Key.Name}' is matched by conventions for " +
-                $"'{first.Convention.ServiceType.Name}' and '{second.Convention.ServiceType.Name}'.");
+                $"{moduleName}: '{first.Candidate.ImplementationType.Name}' is registered as " +
+                $"'{serviceName}' by two conventions. {difference}");
 
             report(Diagnostic.Create(
                 DependencyModuleDiagnostics.AmbiguousConventionMatch,
                 first.Candidate.Location.ToLocationOrNone(),
-                pair.Key.Name,
+                first.Candidate.ImplementationType.Name,
                 moduleName,
-                first.Convention.ServiceType.Name,
-                second.Convention.ServiceType.Name));
+                serviceName,
+                difference));
         }
 
         return usable;
     }
+
+    /// <summary>
+    /// Identifies the registration a match produces, so two matches collide only when they would
+    /// put the same implementation in the container under the same service type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Keyed on the type definitions rather than on <see cref="ConventionTypeKey"/>, which is
+    /// deliberately equal for every closing of one generic so an open convention can match them all.
+    /// Using it here made <c>IHandler&lt;A&gt;</c> and <c>IHandler&lt;B&gt;</c> look like one service
+    /// type and reported a handler covering two messages as a duplicate declaration.
+    /// </para>
+    /// <para>
+    /// The shapes that name the implementation itself — <c>AsSelf</c> and
+    /// <c>AsSelfWithInterfaces</c> — key on it, since two such conventions on one type would collide
+    /// however their interface sets differ.
+    /// </para>
+    /// </remarks>
+    private static (ITypeDefinition Implementation, ITypeDefinition Service) RegistrationKey(
+        ConventionRegistrationMatch match) {
+
+        var implementation = match.Candidate.ImplementationType;
+
+        return match.Convention.RegisterAs == ConventionRegisterAs.Interfaces && match.Interface != null
+            ? (implementation, match.Interface.InterfaceType)
+            : (implementation, implementation);
+    }
+
+    private static string ServiceTypeNameOf(ConventionRegistrationMatch match) =>
+        match.Convention.RegisterAs == ConventionRegisterAs.Interfaces && match.Interface != null
+            ? match.Interface.InterfaceType.Name
+            : match.Candidate.ImplementationType.Name;
 
     /// <summary>
     /// Reports DM0010 on each registered class, naming the interface it was reached through when the
@@ -212,6 +407,17 @@ public static class ConventionMatcher {
         IReadOnlyList<ConventionRegistrationMatch> matches, string moduleName, Action<Diagnostic> report) {
 
         foreach (var match in matches) {
+            // A filter-selected convention reached the type directly, so there is no interface to
+            // name and the type is exposed as itself.
+            if (match.Interface == null) {
+                report(Diagnostic.Create(
+                    DependencyModuleDiagnostics.ExposedByConvention,
+                    match.Candidate.Location.ToLocationOrNone(),
+                    $"{match.Candidate.ImplementationType.Name} in {moduleName}"));
+
+                continue;
+            }
+
             var via = match.Interface.ViaTypeName == null ? "" : $" (via {match.Interface.ViaTypeName})";
 
             report(Diagnostic.Create(
@@ -229,31 +435,105 @@ public static class ConventionMatcher {
         ModuleEntryPointModel entryPointModel,
         FileLogger logger) {
 
-        var models = new List<ServiceModel>(matches.Count);
+        // One model per implementation, carrying every registration it produces — the shape
+        // ServiceModelUtility builds for the attribute path. Emitting one model per match would put
+        // two models with the same ImplementationType in front of DependencyFileWriter, which
+        // duplicates the per-implementation state it reads: constructor, conditions, cross-wire.
+        var byImplementation = new Dictionary<ITypeDefinition, List<ServiceRegistrationModel>>();
+        var order = new List<ConventionRegistrationMatch>();
 
         foreach (var match in matches) {
+            var registrations = BuildRegistrations(match, entryPointModel);
+
+            if (registrations.Count == 0) {
+                continue;
+            }
+
+            if (!byImplementation.TryGetValue(match.Candidate.ImplementationType, out var list)) {
+                list = new List<ServiceRegistrationModel>();
+                byImplementation[match.Candidate.ImplementationType] = list;
+                order.Add(match);
+            }
+
+            list.AddRange(registrations);
+        }
+
+        var models = new List<ServiceModel>(order.Count);
+
+        foreach (var match in order) {
+            var registrations = byImplementation[match.Candidate.ImplementationType];
+
             logger.Info(
-                $"  {match.Candidate.ImplementationType.Name} -> {match.Interface.InterfaceType.Name} " +
-                $"({match.Convention.Lifestyle}, by convention)");
+                $"  {match.Candidate.ImplementationType.Name} -> " +
+                $"{string.Join(", ", registrations.Select(r => r.ServiceType.Name))} " +
+                "(by convention)");
 
             models.Add(new ServiceModel(
                 match.Candidate.ImplementationType,
                 match.Candidate.Constructor,
                 null,
                 null,
-                new[] {
-                    new ServiceRegistrationModel(
-                        match.Interface.InterfaceType,
-                        match.Convention.Lifestyle!.Value,
-                        // Scoped to the declaring module. Without this an OnlyRealm module would
-                        // drop its own convention registrations, because the writer skips a
-                        // registration with no realm when the module declares one.
-                        Realm: entryPointModel.EntryPointType)
-                },
+                registrations,
                 RegistrationFeature.None,
+                // Shared across every match for this type, so the first one carries them all.
                 match.Candidate.Conditions));
         }
 
         return models;
+    }
+
+    /// <summary>
+    /// The registrations one match produces, according to what the convention registers matches as.
+    /// </summary>
+    /// <remarks>
+    /// <c>AsSelfWithInterfaces</c> is the existing cross-wire emission rather than a second
+    /// mechanism: one registration per interface carrying <see cref="ServiceRegistrationModel.CrossWire"/>,
+    /// which the writer turns into a factory resolving the implementation type, plus a single
+    /// registration of that type. Two plain registrations of the same implementation would give one
+    /// instance per service type instead of the shared instance the contract promises.
+    /// </remarks>
+    private static IReadOnlyList<ServiceRegistrationModel> BuildRegistrations(
+        ConventionRegistrationMatch match, ModuleEntryPointModel entryPointModel) {
+
+        var convention = match.Convention;
+        var lifestyle = convention.Lifestyle!.Value;
+
+        // Scoped to the declaring module. Without this an OnlyRealm module would drop its own
+        // convention registrations, because the writer skips a registration with no realm when the
+        // module declares one.
+        var realm = entryPointModel.EntryPointType;
+
+        ServiceRegistrationModel Registration(ITypeDefinition serviceType, bool crossWire = false) =>
+            new(serviceType,
+                lifestyle,
+                convention.RegistrationType,
+                realm,
+                convention.Key,
+                crossWire,
+                convention.KeyNamespaces);
+
+        switch (convention.RegisterAs) {
+            case ConventionRegisterAs.Self:
+                return new[] { Registration(match.Candidate.ImplementationType) };
+
+            case ConventionRegisterAs.SelfAndInterfaces:
+                var crossWired = new List<ServiceRegistrationModel>();
+
+                foreach (var reachable in
+                         match.Candidate.InterfacesInReach(convention.IncludeBaseClasses)) {
+                    crossWired.Add(Registration(reachable.InterfaceType, crossWire: true));
+                }
+
+                // No interfaces at all still registers the type itself, which is what the developer
+                // asked for by naming a shape that includes "self".
+                if (crossWired.Count == 0) {
+                    crossWired.Add(Registration(match.Candidate.ImplementationType));
+                }
+
+                return crossWired;
+
+            default:
+                return new[] { Registration(match.Interface!.InterfaceType) };
+        }
     }
 }

--- a/src/DependencyModules.Conventions/Utilities/ConventionModelUtility.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionModelUtility.cs
@@ -30,11 +30,29 @@ public static class ConventionModelUtility {
 
     private const string RegisterAll = "RegisterAll";
     private const string IncludeBaseClasses = "IncludeBaseClasses";
+    private const string UsingCall = "Using";
+    private const string WithKeyCall = "WithKey";
 
     private static readonly Dictionary<string, ServiceLifestyle> LifetimeCalls = new() {
         ["AsSingleton"] = ServiceLifestyle.Singleton,
         ["AsScoped"] = ServiceLifestyle.Scoped,
         ["AsTransient"] = ServiceLifestyle.Transient,
+    };
+
+    private static readonly Dictionary<string, ConventionRegisterAs> RegisterAsCalls = new() {
+        ["AsSelf"] = ConventionRegisterAs.Self,
+        ["AsSelfWithInterfaces"] = ConventionRegisterAs.SelfAndInterfaces,
+    };
+
+    /// <summary>
+    /// The namespace filter calls, and the shape of filter each produces.
+    /// </summary>
+    private static readonly Dictionary<string, (bool Exact, bool Exclude)> NamespaceCalls = new() {
+        ["InNamespaceOf"] = (false, false),
+        ["InNamespaces"] = (false, false),
+        ["InExactNamespaces"] = (true, false),
+        ["NotInNamespaceOf"] = (false, true),
+        ["NotInNamespaces"] = (false, true),
     };
 
     /// <summary>
@@ -197,21 +215,38 @@ public static class ConventionModelUtility {
             return null;
         }
 
-        var serviceType = ReadServiceType(context, head, out var isOpenGeneric);
+        // No type argument and no argument at all is the filter-selected form, which is valid and
+        // has no service type. Anything else that fails to resolve is a mistake.
+        var selectsByFilter =
+            head.Expression is MemberAccessExpressionSyntax { Name: not GenericNameSyntax } &&
+            head.ArgumentList.Arguments.Count == 0;
 
-        if (serviceType == null) {
-            reason =
-                $"could not resolve the service type; write {RegisterAll}<IService>() or " +
-                $"{RegisterAll}(typeof(IService<>))";
+        ITypeDefinition? serviceType = null;
+        var isOpenGeneric = false;
 
-            return null;
+        if (!selectsByFilter) {
+            serviceType = ReadServiceType(context, head, out isOpenGeneric);
+
+            if (serviceType == null) {
+                reason =
+                    $"could not resolve the service type; write {RegisterAll}<IService>(), " +
+                    $"{RegisterAll}(typeof(IService<>)) or {RegisterAll}() with a filter";
+
+                return null;
+            }
         }
 
         ServiceLifestyle? lifestyle = null;
         var includeBaseClasses = false;
+        var registerAs = ConventionRegisterAs.Interfaces;
+        List<NamespaceFilterModel>? namespaceFilters = null;
+        RegistrationType? registrationType = null;
+        object? key = null;
+        IReadOnlyList<string>? keyNamespaces = null;
 
         for (var i = 1; i < chain.Count; i++) {
-            var name = MethodNameOf(chain[i]);
+            var call = chain[i];
+            var name = MethodNameOf(call);
 
             if (LifetimeCalls.TryGetValue(name, out var candidateLifestyle)) {
                 if (lifestyle != null) {
@@ -231,20 +266,140 @@ public static class ConventionModelUtility {
                 continue;
             }
 
+            if (RegisterAsCalls.TryGetValue(name, out var candidateRegisterAs)) {
+                if (registerAs != ConventionRegisterAs.Interfaces && registerAs != candidateRegisterAs) {
+                    reason = "a convention registers matches one way, and this one says more than one";
+
+                    return null;
+                }
+
+                registerAs = candidateRegisterAs;
+
+                continue;
+            }
+
+            if (name == UsingCall) {
+                var argument = call.ArgumentList.Arguments.FirstOrDefault()?.Expression;
+
+                registrationType = argument == null
+                    ? null
+                    : SourceGenerator.Impl.BaseSourceGenerator.GetRegistrationType(argument.ToString());
+
+                if (registrationType == null) {
+                    reason = $"'{name}' needs a RegistrationType it can read at compile time";
+
+                    return null;
+                }
+
+                continue;
+            }
+
+            if (name == WithKeyCall) {
+                var argument = call.ArgumentList.Arguments.FirstOrDefault()?.Expression;
+
+                if (argument == null) {
+                    reason = $"'{name}' needs a key";
+
+                    return null;
+                }
+
+                // Kept as it was written, the way the attribute path keeps it, so a literal, a const
+                // and an enum member all reach the emitted registration unchanged.
+                key = argument.ToString();
+
+                if (argument is MemberAccessExpressionSyntax memberAccess) {
+                    keyNamespaces = memberAccess.GetTypeDefinition(context)?.KnownNamespaces.ToArray();
+                }
+
+                continue;
+            }
+
+            if (NamespaceCalls.TryGetValue(name, out var namespaceCall)) {
+                var read = ReadNamespaceFilters(context, call, namespaceCall);
+
+                if (read == null) {
+                    reason = $"'{name}' needs a namespace it can read at compile time";
+
+                    return null;
+                }
+
+                namespaceFilters ??= new List<NamespaceFilterModel>();
+                namespaceFilters.AddRange(read);
+
+                continue;
+            }
+
             reason = $"'{name}' is not a convention call";
 
             return null;
         }
 
-        // Left null on purpose. A lifetime nobody wrote down is the most expensive thing for a
-        // registration to get wrong, so it is reported at output rather than defaulted here.
+        if (selectsByFilter) {
+            if (registerAs == ConventionRegisterAs.Interfaces) {
+                reason =
+                    $"{RegisterAll}() names no service type, so there is nothing to register the " +
+                    "matches as; call AsSelf() or AsSelfWithInterfaces()";
+
+                return null;
+            }
+
+            if (namespaceFilters == null || namespaceFilters.All(filter => filter.Exclude)) {
+                reason =
+                    $"{RegisterAll}() with no filter matches every class in the compilation; " +
+                    "narrow it with InNamespaceOf<T>() or InNamespaces(...)";
+
+                return null;
+            }
+        }
+
+        // Lifestyle left null on purpose. A lifetime nobody wrote down is the most expensive thing
+        // for a registration to get wrong, so it is reported at output rather than defaulted here.
         return new ConventionModel(
             serviceType,
-            ConventionTypeKey.For(serviceType),
+            serviceType == null ? null : ConventionTypeKey.For(serviceType),
             isOpenGeneric,
             lifestyle,
             includeBaseClasses,
-            LocationModel.From(statement));
+            LocationModel.From(statement),
+            registerAs,
+            namespaceFilters,
+            registrationType,
+            key,
+            keyNamespaces);
+    }
+
+    /// <summary>
+    /// Reads the namespaces one filter call names, from a marker type argument or from string
+    /// literals.
+    /// </summary>
+    private static List<NamespaceFilterModel>? ReadNamespaceFilters(
+        SyntaxTransformContext context, InvocationExpressionSyntax call, (bool Exact, bool Exclude) form) {
+
+        var filters = new List<NamespaceFilterModel>();
+
+        // InNamespaceOf<TMarker>() — the namespace is wherever the marker type lives.
+        if (call.Expression is MemberAccessExpressionSyntax { Name: GenericNameSyntax generic } &&
+            generic.TypeArgumentList.Arguments.Count == 1) {
+            var marker = generic.TypeArgumentList.Arguments[0].GetTypeDefinition(context);
+
+            if (marker == null) {
+                return null;
+            }
+
+            filters.Add(new NamespaceFilterModel(marker.Namespace ?? "", form.Exact, form.Exclude));
+
+            return filters;
+        }
+
+        foreach (var argument in call.ArgumentList.Arguments) {
+            if (context.SemanticModel.GetConstantValue(argument.Expression).Value is not string value) {
+                return null;
+            }
+
+            filters.Add(new NamespaceFilterModel(value, form.Exact, form.Exclude));
+        }
+
+        return filters.Count > 0 ? filters : null;
     }
 
     /// <summary>

--- a/src/DependencyModules.Conventions/Utilities/ConventionModelUtility.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionModelUtility.cs
@@ -37,6 +37,7 @@ public static class ConventionModelUtility {
     private const string WithoutNameCall = "WithoutName";
     private const string AsCall = "As";
     private const string AsMatchingInterfaceCall = "AsMatchingInterface";
+    private const string InAssemblyOfCall = "InAssemblyOf";
     private const string WithKeyCall = "WithKey";
 
     private static readonly Dictionary<string, ServiceLifestyle> LifetimeCalls = new() {
@@ -252,6 +253,7 @@ public static class ConventionModelUtility {
         List<AttributeFilterModel>? attributeFilters = null;
         List<NameFilterModel>? nameFilters = null;
         ITypeDefinition? explicitServiceType = null;
+        string? assemblyName = null;
 
         for (var i = 1; i < chain.Count; i++) {
             var call = chain[i];
@@ -318,6 +320,18 @@ public static class ConventionModelUtility {
 
                 if (argument is MemberAccessExpressionSyntax memberAccess) {
                     keyNamespaces = memberAccess.GetTypeDefinition(context)?.KnownNamespaces.ToArray();
+                }
+
+                continue;
+            }
+
+            if (name == InAssemblyOfCall) {
+                assemblyName = MarkerAssemblyNameOf(context, call);
+
+                if (assemblyName == null) {
+                    reason = $"'{name}' needs a type argument from the assembly to scan";
+
+                    return null;
                 }
 
                 continue;
@@ -436,7 +450,8 @@ public static class ConventionModelUtility {
             keyNamespaces,
             attributeFilters,
             nameFilters,
-            explicitServiceType);
+            explicitServiceType,
+            assemblyName);
     }
 
     /// <summary>
@@ -458,6 +473,27 @@ public static class ConventionModelUtility {
         }
 
         return values;
+    }
+
+    /// <summary>
+    /// The name of the assembly the call's marker type lives in.
+    /// </summary>
+    /// <remarks>
+    /// A name rather than a symbol, because this lands in an incremental model and symbols are not
+    /// equatable. It is also what lets a reference be rejected before any symbol work happens, which
+    /// is what keeps a metadata scan affordable.
+    /// </remarks>
+    private static string? MarkerAssemblyNameOf(
+        SyntaxTransformContext context, InvocationExpressionSyntax call) {
+
+        if (call.Expression is not MemberAccessExpressionSyntax { Name: GenericNameSyntax generic } ||
+            generic.TypeArgumentList.Arguments.Count != 1) {
+            return null;
+        }
+
+        var symbol = context.SemanticModel.GetSymbolInfo(generic.TypeArgumentList.Arguments[0]).Symbol;
+
+        return symbol?.ContainingAssembly?.Name;
     }
 
     /// <summary>

--- a/src/DependencyModules.Conventions/Utilities/ConventionModelUtility.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionModelUtility.cs
@@ -31,6 +31,12 @@ public static class ConventionModelUtility {
     private const string RegisterAll = "RegisterAll";
     private const string IncludeBaseClasses = "IncludeBaseClasses";
     private const string UsingCall = "Using";
+    private const string WithAttributeCall = "WithAttribute";
+    private const string WithoutAttributeCall = "WithoutAttribute";
+    private const string WithNameCall = "WithName";
+    private const string WithoutNameCall = "WithoutName";
+    private const string AsCall = "As";
+    private const string AsMatchingInterfaceCall = "AsMatchingInterface";
     private const string WithKeyCall = "WithKey";
 
     private static readonly Dictionary<string, ServiceLifestyle> LifetimeCalls = new() {
@@ -243,6 +249,9 @@ public static class ConventionModelUtility {
         RegistrationType? registrationType = null;
         object? key = null;
         IReadOnlyList<string>? keyNamespaces = null;
+        List<AttributeFilterModel>? attributeFilters = null;
+        List<NameFilterModel>? nameFilters = null;
+        ITypeDefinition? explicitServiceType = null;
 
         for (var i = 1; i < chain.Count; i++) {
             var call = chain[i];
@@ -314,6 +323,60 @@ public static class ConventionModelUtility {
                 continue;
             }
 
+            if (name == AsMatchingInterfaceCall) {
+                registerAs = ConventionRegisterAs.MatchingInterface;
+
+                continue;
+            }
+
+            if (name == AsCall) {
+                explicitServiceType = SingleTypeArgumentOf(context, call);
+
+                if (explicitServiceType == null) {
+                    reason = $"'{name}' needs a service type argument";
+
+                    return null;
+                }
+
+                registerAs = ConventionRegisterAs.Explicit;
+
+                continue;
+            }
+
+            if (name is WithNameCall or WithoutNameCall) {
+                var patterns = ReadPatterns(context, call);
+
+                if (patterns.Count == 0) {
+                    reason = $"'{name}' needs at least one pattern it can read at compile time";
+
+                    return null;
+                }
+
+                nameFilters ??= new List<NameFilterModel>();
+
+                foreach (var pattern in patterns) {
+                    nameFilters.Add(new NameFilterModel(pattern, name == WithoutNameCall));
+                }
+
+                continue;
+            }
+
+            if (name is WithAttributeCall or WithoutAttributeCall) {
+                var attributeType = SingleTypeArgumentOf(context, call);
+
+                if (attributeType == null) {
+                    reason = $"'{name}' needs an attribute type argument";
+
+                    return null;
+                }
+
+                attributeFilters ??= new List<AttributeFilterModel>();
+                attributeFilters.Add(new AttributeFilterModel(
+                    ConventionTypeKey.For(attributeType), name == WithoutAttributeCall));
+
+                continue;
+            }
+
             if (NamespaceCalls.TryGetValue(name, out var namespaceCall)) {
                 var read = ReadNamespaceFilters(context, call, namespaceCall);
 
@@ -343,7 +406,12 @@ public static class ConventionModelUtility {
                 return null;
             }
 
-            if (namespaceFilters == null || namespaceFilters.All(filter => filter.Exclude)) {
+            var hasInclusion =
+                namespaceFilters?.Any(filter => !filter.Exclude) == true ||
+                nameFilters?.Any(filter => !filter.Exclude) == true ||
+                attributeFilters?.Any(filter => !filter.Exclude) == true;
+
+            if (!hasInclusion) {
                 reason =
                     $"{RegisterAll}() with no filter matches every class in the compilation; " +
                     "narrow it with InNamespaceOf<T>() or InNamespaces(...)";
@@ -365,8 +433,42 @@ public static class ConventionModelUtility {
             namespaceFilters,
             registrationType,
             key,
-            keyNamespaces);
+            keyNamespaces,
+            attributeFilters,
+            nameFilters,
+            explicitServiceType);
     }
+
+    /// <summary>
+    /// The constant string arguments of a filter call.
+    /// </summary>
+    /// <remarks>
+    /// <c>GetConstantValue</c> rather than the literal text, so a <c>const</c> declared elsewhere
+    /// reads as the string it evaluates to.
+    /// </remarks>
+    private static IReadOnlyList<string> ReadPatterns(
+        SyntaxTransformContext context, InvocationExpressionSyntax call) {
+
+        var values = new List<string>();
+
+        foreach (var argument in call.ArgumentList.Arguments) {
+            if (context.SemanticModel.GetConstantValue(argument.Expression).Value is string value) {
+                values.Add(value);
+            }
+        }
+
+        return values;
+    }
+
+    /// <summary>
+    /// The single type argument of a generic filter call, resolved.
+    /// </summary>
+    private static ITypeDefinition? SingleTypeArgumentOf(
+        SyntaxTransformContext context, InvocationExpressionSyntax call) =>
+        call.Expression is MemberAccessExpressionSyntax { Name: GenericNameSyntax generic } &&
+        generic.TypeArgumentList.Arguments.Count == 1
+            ? generic.TypeArgumentList.Arguments[0].GetTypeDefinition(context)
+            : null;
 
     /// <summary>
     /// Reads the namespaces one filter call names, from a marker type argument or from string

--- a/src/DependencyModules.Conventions/Utilities/ConventionModelUtility.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionModelUtility.cs
@@ -49,6 +49,7 @@ public static class ConventionModelUtility {
     private static readonly Dictionary<string, ConventionRegisterAs> RegisterAsCalls = new() {
         ["AsSelf"] = ConventionRegisterAs.Self,
         ["AsSelfWithInterfaces"] = ConventionRegisterAs.SelfAndInterfaces,
+        ["AlsoAsSelf"] = ConventionRegisterAs.AlsoSelf,
     };
 
     /// <summary>

--- a/src/DependencyModules.Conventions/Utilities/MetadataCandidateUtility.cs
+++ b/src/DependencyModules.Conventions/Utilities/MetadataCandidateUtility.cs
@@ -1,0 +1,208 @@
+using CSharpAuthor;
+using DependencyModules.Conventions.Models;
+using DependencyModules.SourceGenerator.Impl.Models;
+using DependencyModules.SourceGenerator.Impl.Utilities;
+using Microsoft.CodeAnalysis;
+
+namespace DependencyModules.Conventions.Utilities;
+
+/// <summary>
+/// Reads convention candidates out of a referenced assembly's metadata.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The counterpart to <see cref="ConventionCandidateUtility"/>, which reads the compilation being
+/// built. Everything here comes from symbols rather than syntax, because a referenced assembly has
+/// no syntax to read — that is the whole difference, and it is why the constructor path is separate
+/// rather than shared.
+/// </para>
+/// <para>
+/// <b>What bounds the cost is the convention naming the assembly.</b> Walking every reference visits
+/// thousands of types on every keystroke; walking one named assembly visits its own. A reference is
+/// therefore rejected on <see cref="IAssemblySymbol.Name"/> before any type is touched. There is no
+/// way to ask for all of them, and there should not be one.
+/// </para>
+/// <para>
+/// Only <c>public</c> types are visible here. A scan of the compilation being built also sees
+/// <c>internal</c> ones, and nothing can report the type it cannot see, so that difference is
+/// documented rather than diagnosed.
+/// </para>
+/// </remarks>
+public static class MetadataCandidateUtility {
+
+    /// <summary>
+    /// Candidates from every assembly the given conventions name.
+    /// </summary>
+    /// <remarks>
+    /// Returns an empty list when nothing names an assembly, which is the common case and costs one
+    /// pass over the convention list.
+    /// </remarks>
+    public static IReadOnlyList<ConventionCandidateModel> Collect(
+        IReadOnlyList<ConventionModuleModel> conventionModules,
+        Compilation compilation,
+        CancellationToken cancellationToken) {
+
+        var wanted = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var module in conventionModules) {
+            foreach (var convention in module.Conventions) {
+                if (convention.AssemblyName != null) {
+                    wanted.Add(convention.AssemblyName);
+                }
+            }
+        }
+
+        if (wanted.Count == 0) {
+            return Array.Empty<ConventionCandidateModel>();
+        }
+
+        var candidates = new List<ConventionCandidateModel>();
+
+        foreach (var reference in compilation.References) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (compilation.GetAssemblyOrModuleSymbol(reference) is not IAssemblySymbol assembly ||
+                !wanted.Contains(assembly.Name)) {
+                continue;
+            }
+
+            CollectFromNamespace(assembly.GlobalNamespace, assembly.Name, candidates, cancellationToken);
+        }
+
+        return candidates;
+    }
+
+    private static void CollectFromNamespace(
+        INamespaceSymbol namespaceSymbol,
+        string assemblyName,
+        List<ConventionCandidateModel> candidates,
+        CancellationToken cancellationToken) {
+
+        foreach (var member in namespaceSymbol.GetMembers()) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            switch (member) {
+                case INamespaceSymbol nested:
+                    CollectFromNamespace(nested, assemblyName, candidates, cancellationToken);
+                    break;
+
+                case INamedTypeSymbol type when IsCandidate(type):
+                    candidates.Add(BuildCandidate(type, assemblyName));
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The metadata counterpart of the syntactic predicate: a constructible public class.
+    /// </summary>
+    private static bool IsCandidate(INamedTypeSymbol type) =>
+        type.TypeKind == TypeKind.Class &&
+        !type.IsAbstract &&
+        !type.IsStatic &&
+        type.DeclaredAccessibility == Accessibility.Public;
+
+    private static ConventionCandidateModel BuildCandidate(INamedTypeSymbol type, string assemblyName) {
+        var declared = new List<ImplementedInterfaceModel>();
+        var viaBaseClass = new List<ImplementedInterfaceModel>();
+        var seen = new HashSet<ITypeDefinition>();
+
+        // Directly implemented interfaces, and what those extend, are the metadata equivalent of
+        // "written on the declaration". Anything else in AllInterfaces arrived through a base class,
+        // which is the distinction IncludeBaseClasses turns on.
+        foreach (var interfaceSymbol in type.Interfaces) {
+            Add(declared, seen, interfaceSymbol, null);
+
+            foreach (var inherited in interfaceSymbol.AllInterfaces) {
+                Add(declared, seen, inherited, interfaceSymbol.Name);
+            }
+        }
+
+        foreach (var interfaceSymbol in type.AllInterfaces) {
+            Add(viaBaseClass, seen, interfaceSymbol, type.BaseType?.Name);
+        }
+
+        return new ConventionCandidateModel(
+            type.GetTypeDefinition(),
+            declared,
+            viaBaseClass,
+            GreediestConstructor(type),
+            type.InstanceConstructors.Any(c => c.DeclaredAccessibility == Accessibility.Public),
+            LocationModel.None,
+            null,
+            AttributeKeysOf(type),
+            assemblyName);
+    }
+
+    private static void Add(
+        List<ImplementedInterfaceModel> target,
+        HashSet<ITypeDefinition> seen,
+        INamedTypeSymbol interfaceSymbol,
+        string? viaTypeName) {
+
+        var definition = interfaceSymbol.GetTypeDefinition();
+
+        if (!seen.Add(definition)) {
+            return;
+        }
+
+        target.Add(new ImplementedInterfaceModel(
+            definition, ConventionTypeKey.For(definition), viaTypeName));
+    }
+
+    /// <summary>
+    /// The constructor the container would pick, read from symbols.
+    /// </summary>
+    /// <remarks>
+    /// The greediest public one, matching what the syntax path does within a declaration.
+    /// Parameter attributes are not carried across: they exist to drive <c>[FromKeyedServices]</c>
+    /// on code being generated alongside, and a package's own constructor parameters are not that.
+    /// </remarks>
+    private static ConstructorInfoModel? GreediestConstructor(INamedTypeSymbol type) {
+        IMethodSymbol? greediest = null;
+
+        foreach (var constructor in type.InstanceConstructors) {
+            if (constructor.DeclaredAccessibility != Accessibility.Public) {
+                continue;
+            }
+
+            if (greediest == null || constructor.Parameters.Length > greediest.Parameters.Length) {
+                greediest = constructor;
+            }
+        }
+
+        if (greediest == null) {
+            return null;
+        }
+
+        var parameters = new List<ParameterInfoModel>(greediest.Parameters.Length);
+
+        foreach (var parameter in greediest.Parameters) {
+            parameters.Add(new ParameterInfoModel(
+                parameter.Name,
+                parameter.Type.GetTypeDefinition(),
+                parameter.HasExplicitDefaultValue ? parameter.ExplicitDefaultValue : null,
+                Array.Empty<AttributeModel>()));
+        }
+
+        return new ConstructorInfoModel(parameters);
+    }
+
+    private static IReadOnlyList<string>? AttributeKeysOf(INamedTypeSymbol type) {
+        var attributes = type.GetAttributes();
+
+        if (attributes.Length == 0) {
+            return null;
+        }
+
+        var keys = new List<string>(attributes.Length);
+
+        foreach (var attribute in attributes) {
+            if (attribute.AttributeClass is { } attributeClass) {
+                keys.Add(ConventionTypeKey.For(attributeClass.GetTypeDefinition()));
+            }
+        }
+
+        return keys.Count > 0 ? keys : null;
+    }
+}

--- a/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
+++ b/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
@@ -8,7 +8,7 @@ Rule ID | Category | Severity | Notes
 DM0001 | DependencyModules | Error | The generator failed; registrations may be missing.
 DM0002 | DependencyModules | Warning | A service type cannot be constructed and was not registered.
 DM0003 | DependencyModules | Error | A module marked with [DependencyModule] is not partial.
-DM0004 | DependencyModules | Error | Two conventions in one module match the same type.
+DM0004 | DependencyModules | Error | Two conventions in one module register a type as the same service type.
 DM0005 | DependencyModules | Warning | A convention matched no types.
 DM0006 | DependencyModules | Warning | A convention matched a type with no accessible constructor.
 DM0007 | DependencyModules | Error | Two decorators of one service share an order.

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
@@ -57,14 +57,25 @@ public static class DependencyModuleDiagnostics {
         isEnabledByDefault: true);
 
     /// <summary>
-    /// Raised when two conventions in one module both match a type. Picking one silently would
-    /// produce a registration nobody can predict from reading the module.
+    /// Raised when two conventions in one module register a type as the <i>same</i> service type.
     /// </summary>
+    /// <remarks>
+    /// Not raised for a type filling more than one role. A class implementing both
+    /// <c>INotificationHandler&lt;OrderPlaced&gt;</c> and <c>IRequestPreProcessor&lt;ShipOrder&gt;</c>
+    /// is the ordinary shape of a MediatR handler, and the two registrations are independently
+    /// predictable from reading the module. It is one service type claimed twice that nobody can
+    /// resolve by reading the source, because one lifetime has to win and the declaration does not
+    /// say which.
+    ///
+    /// Equal lifetimes on the same service type are an error too. The outcome is predictable, but
+    /// the declaration is redundant, and silently collapsing a duplicate is the failure mode this
+    /// codebase avoids.
+    /// </remarks>
     public static readonly DiagnosticDescriptor AmbiguousConventionMatch = new(
         id: "DM0004",
         title: "Convention match is ambiguous",
         messageFormat:
-        "'{0}' is matched by more than one convention in '{1}' — as '{2}' and as '{3}'. " +
+        "'{0}' is matched by two conventions in '{1}' that both register it as '{2}'. {3} " +
         "Narrow one of them, or move it to another module.",
         category: Category,
         defaultSeverity: DiagnosticSeverity.Error,

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
@@ -146,10 +146,31 @@ public class ServiceModelUtility {
             EnvironmentConditionUtility.GetConditions(context, context.Node, cancellationToken));
     }
 
+    /// <summary>
+    /// The constructor the container should use, read from the type's own members.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Direct members rather than <c>DescendantNodes</c>, which walks the entire subtree — every
+    /// method body, every statement, every expression — to find nodes that can only ever be direct
+    /// children. Measured on a 2,000-class compilation of ordinary classes, that walk was the
+    /// dominant cost of the candidate transform: the second generator run after editing one file
+    /// took 73 ms with it and 12 ms without.
+    /// </para>
+    /// <para>
+    /// It was also wrong. <c>DescendantNodes</c> finds the constructors of <i>nested</i> types, so a
+    /// class containing a nested class with a constructor could be registered against the nested
+    /// type's parameters.
+    /// </para>
+    /// </remarks>
     public static ConstructorInfoModel? GetConstructorInfo(SyntaxTransformContext context, SyntaxNode node, CancellationToken cancellationToken) {
         var constructorList = new List<ConstructorDeclarationSyntax>();
 
-        foreach (var constructor in node.DescendantNodes().OfType<ConstructorDeclarationSyntax>()) {
+        var members = node is TypeDeclarationSyntax declaration
+            ? declaration.Members.OfType<ConstructorDeclarationSyntax>()
+            : node.DescendantNodes().OfType<ConstructorDeclarationSyntax>();
+
+        foreach (var constructor in members) {
             if (constructor.Modifiers.Any(m => m.IsKind(SyntaxKind.PrivateKeyword))) {
                 continue;
             }

--- a/tests/DependencyModules.Tests/GeneratorTests/ConventionRegistrationTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ConventionRegistrationTests.cs
@@ -522,6 +522,117 @@ public class ConventionRegistrationTests {
         Assert.Empty(assembly.Descriptors("IMarker"));
     }
 
+    /// <summary>
+    /// The expansion does not cross-wire BCL interfaces.
+    /// </summary>
+    /// <remarks>
+    /// Any type whose base implements IDisposable would otherwise become resolvable as IDisposable,
+    /// which is never what "register this as its interfaces" means.
+    /// </remarks>
+    [Fact]
+    public void AsSelfWithInterfacesSkipsSystemInterfaces() {
+        var assembly = Compile(
+            """
+            public interface IMarker { }
+
+            public abstract class ThingBase : System.IDisposable, IMarker {
+                public void Dispose() { }
+            }
+
+            public class Thing : ThingBase { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IMarker>().AsSelfWithInterfaces().AsSingleton().IncludeBaseClasses();
+                }
+            }
+            """);
+
+        Assert.Single(assembly.Descriptors("IMarker"));
+
+        Assert.DoesNotContain(assembly.Services, d => d.ServiceType == typeof(IDisposable));
+    }
+
+    [Fact]
+    public void AsSelfWithInterfacesSkipsGenericSystemInterfaces() {
+        var assembly = Compile(
+            """
+            public interface IRule { }
+            public interface IValidator<T> { }
+
+            public abstract class ValidatorBase<T> : IValidator<T>, System.Collections.Generic.IEnumerable<IRule> {
+                public System.Collections.Generic.IEnumerator<IRule> GetEnumerator() => null!;
+                System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null!;
+            }
+
+            public class Foo { }
+
+            public class FooValidator : ValidatorBase<Foo> { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IValidator<>)).AsSelfWithInterfaces().AsScoped().IncludeBaseClasses();
+                }
+            }
+            """);
+
+        // The validator interface survives; the enumerable ones do not.
+        Assert.Single(assembly.Services, d => d.ServiceType.Name == "IValidator`1");
+
+        Assert.DoesNotContain(assembly.Services, d => d.ServiceType.Namespace?.StartsWith("System") == true);
+    }
+
+    /// <summary>
+    /// The filter is scoped to the expansion. A service type the developer named is honoured
+    /// whatever namespace it lives in — refusing that is a different kind of wrong.
+    /// </summary>
+    [Fact]
+    public void ANamedSystemServiceTypeIsStillRegistered() {
+        var assembly = Compile(
+            """
+            public class Closeable : System.IDisposable {
+                public void Dispose() { }
+            }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<System.IDisposable>().AsSingleton();
+                }
+            }
+            """);
+
+        Assert.Single(assembly.Services, d => d.ServiceType == typeof(IDisposable));
+    }
+
+    /// <summary>
+    /// Filtering everything away degrades to AsSelf rather than to nothing.
+    /// </summary>
+    [Fact]
+    public void ATypeReachingOnlySystemInterfacesRegistersItself() {
+        var assembly = Compile(
+            """
+            public interface IMarker { }
+
+            public abstract class OnlySystemBase : System.IDisposable, IMarker {
+                public void Dispose() { }
+            }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IMarker>().AsSelf().AsSingleton().IncludeBaseClasses();
+                }
+            }
+            """);
+
+        // Nothing to assert beyond the module compiling and registering something; the shape that
+        // matters is covered by AsSelfWithInterfacesSkipsSystemInterfaces.
+        Assert.NotEmpty(assembly.Services);
+    }
+
     [Fact]
     public void UsingChoosesHowTheRegistrationIsAdded() {
         var assembly = Compile(

--- a/tests/DependencyModules.Tests/GeneratorTests/ConventionRegistrationTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ConventionRegistrationTests.cs
@@ -329,6 +329,199 @@ public class ConventionRegistrationTests {
         Assert.Equal(2, registered.Length);
     }
 
+    private const string Marker =
+        """
+        public class HandlerAttribute : System.Attribute { }
+        public class LegacyAttribute : System.Attribute { }
+
+        public interface IFoo { }
+
+        [Handler]
+        public class Marked : IFoo { }
+
+        public class Unmarked : IFoo { }
+
+        [Handler]
+        [Legacy]
+        public class MarkedLegacy : IFoo { }
+        """;
+
+    [Fact]
+    public void WithAttributeLimitsMatchesToTypesCarryingIt() {
+        var assembly = Compile(
+            Marker +
+            """
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().WithAttribute<HandlerAttribute>().AsSingleton();
+                }
+            }
+            """);
+
+        var implementations = assembly.Descriptors("IFoo").Select(d => d.ImplementationType).ToArray();
+
+        Assert.Equal(2, implementations.Length);
+        Assert.Contains(assembly.Type("Marked"), implementations);
+        Assert.Contains(assembly.Type("MarkedLegacy"), implementations);
+        Assert.DoesNotContain(assembly.Type("Unmarked"), implementations);
+    }
+
+    [Fact]
+    public void WithoutAttributeExcludesTypesCarryingIt() {
+        var assembly = Compile(
+            Marker +
+            """
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().WithoutAttribute<LegacyAttribute>().AsSingleton();
+                }
+            }
+            """);
+
+        var implementations = assembly.Descriptors("IFoo").Select(d => d.ImplementationType).ToArray();
+
+        Assert.Equal(2, implementations.Length);
+        Assert.DoesNotContain(assembly.Type("MarkedLegacy"), implementations);
+    }
+
+    [Fact]
+    public void AttributeFiltersCombineWithAnd() {
+        var assembly = Compile(
+            Marker +
+            """
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>()
+                        .WithAttribute<HandlerAttribute>()
+                        .WithoutAttribute<LegacyAttribute>()
+                        .AsSingleton();
+                }
+            }
+            """);
+
+        Assert.Equal(assembly.Type("Marked"), assembly.Descriptor("IFoo").ImplementationType);
+    }
+
+    /// <summary>
+    /// Resolved rather than matched on how it was written, so the qualified form counts.
+    /// </summary>
+    [Fact]
+    public void ANamespaceQualifiedAttributeStillMatches() {
+        var assembly = Compile(
+            Marker +
+            """
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>()
+                        .WithAttribute<TestNamespace.HandlerAttribute>()
+                        .AsSingleton();
+                }
+            }
+            """);
+
+        Assert.Equal(2, assembly.Descriptors("IFoo").Count);
+    }
+
+    [Theory]
+    [InlineData("*Repository", 2)]
+    [InlineData("Order*", 2)]
+    [InlineData("Order?epository", 1)]
+    [InlineData("TestNamespace.*Repository", 2)]
+    [InlineData("*repository", 0)]
+    public void WithNameMatchesTheGlob(string pattern, int expected) {
+        var result = Run(
+            $$"""
+              public class OrderRepository { }
+              public class UserRepository { }
+              public class OrderService { }
+
+              [DependencyModule]
+              public partial class TestModule : IConventionModule {
+                  void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                      conventions.RegisterAll().WithName("{{pattern}}").AsSelf().AsScoped();
+                  }
+              }
+              """);
+
+        // A pattern matching nothing is DM0005 rather than silence.
+        if (expected == 0) {
+            Assert.Contains(result.GeneratorDiagnostics, d => d.Id == "DM0005");
+
+            return;
+        }
+
+        var assembly = GeneratedAssembly.Create(
+            Preamble +
+            $$"""
+              public class OrderRepository { }
+              public class UserRepository { }
+              public class OrderService { }
+
+              [DependencyModule]
+              public partial class TestModule : IConventionModule {
+                  void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                      conventions.RegisterAll().WithName("{{pattern}}").AsSelf().AsScoped();
+                  }
+              }
+              """,
+            withConventions: true);
+
+        Assert.Equal(expected, assembly.Services.Count(d => d.ImplementationType?.Namespace == "TestNamespace"));
+    }
+
+    [Fact]
+    public void AsRegistersEveryMatchAsOneNamedService() {
+        var assembly = Compile(
+            """
+            public interface IFoo { }
+            public interface IMarker { }
+
+            public class Foo : IFoo, IMarker { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().As<IMarker>().AsSingleton();
+                }
+            }
+            """);
+
+        Assert.Empty(assembly.Descriptors("IFoo"));
+        Assert.Equal(assembly.Type("Foo"), assembly.Descriptor("IMarker").ImplementationType);
+    }
+
+    [Fact]
+    public void AsMatchingInterfaceRegistersFooAsIFoo() {
+        var assembly = Compile(
+            """
+            public interface IMarker { }
+            public interface IFoo : IMarker { }
+            public interface IBar : IMarker { }
+
+            public class Foo : IFoo { }
+            public class Bar : IBar { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IMarker>().AsMatchingInterface().AsSingleton();
+                }
+            }
+            """);
+
+        Assert.Equal(assembly.Type("Foo"), assembly.Descriptor("IFoo").ImplementationType);
+        Assert.Equal(assembly.Type("Bar"), assembly.Descriptor("IBar").ImplementationType);
+        Assert.Empty(assembly.Descriptors("IMarker"));
+    }
+
     [Fact]
     public void UsingChoosesHowTheRegistrationIsAdded() {
         var assembly = Compile(

--- a/tests/DependencyModules.Tests/GeneratorTests/ConventionRegistrationTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ConventionRegistrationTests.cs
@@ -70,6 +70,514 @@ public class ConventionRegistrationTests {
         Assert.Equal(expected, assembly.Descriptors("IFoo").Count);
     }
 
+    /// <summary>
+    /// A partial class whose parts each reach the scanned interface is one candidate, not two.
+    /// </summary>
+    /// <remarks>
+    /// The candidate provider runs per declaration, so a two-part partial produced two candidate
+    /// models with the same implementation type, and the ambiguity check — which groups by
+    /// implementation type — read that as one class matched by two conventions. It reported DM0004
+    /// and registered nothing. One convention, named twice.
+    /// </remarks>
+    [Fact]
+    public void APartialClassReachingTheServiceFromTwoPartsIsNotAmbiguous() {
+        const string source =
+            """
+            public interface IFoo { }
+
+            public abstract class FooBase : IFoo { }
+
+            public partial class Foo : IFoo { }
+            public partial class Foo : FooBase { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSingleton().IncludeBaseClasses();
+                }
+            }
+            """;
+
+        Assert.DoesNotContain(Run(source).GeneratorDiagnostics, d => d.Id == "DM0004");
+
+        var assembly = Compile(source);
+
+        Assert.Equal(assembly.Type("Foo"), assembly.Descriptor("IFoo").ImplementationType);
+    }
+
+    /// <summary>
+    /// Two parts declaring different interfaces that both reach the scanned one is still one class.
+    /// </summary>
+    [Fact]
+    public void APartialClassDeclaringTheServiceTwiceIsNotAmbiguous() {
+        const string source =
+            """
+            public interface IFoo { }
+            public interface IFooPrime : IFoo { }
+
+            public partial class Foo : IFoo { }
+            public partial class Foo : IFooPrime { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSingleton();
+                }
+            }
+            """;
+
+        Assert.DoesNotContain(Run(source).GeneratorDiagnostics, d => d.Id == "DM0004");
+
+        Assert.Single(Compile(source).Descriptors("IFoo"));
+    }
+
+    /// <summary>
+    /// Declaring the interface in any part is a declared match, so the base-class opt-in is not
+    /// needed even when another part reaches the same interface through a base class.
+    /// </summary>
+    [Fact]
+    public void APartDeclaringTheServiceMakesItADeclaredMatch() {
+        const string source =
+            """
+            public interface IFoo { }
+
+            public abstract class FooBase : IFoo { }
+
+            public partial class Foo : IFoo { }
+            public partial class Foo : FooBase { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSingleton();
+                }
+            }
+            """;
+
+        Assert.Single(Compile(source).Descriptors("IFoo"));
+    }
+
+    /// <summary>
+    /// The constructor can be declared in a different part from the one that names the interface.
+    /// </summary>
+    /// <remarks>
+    /// Each part reports its own constructors, and a part that declares none reports an empty
+    /// parameter list. Taking the first part's would emit a call to a constructor the type does not
+    /// have, which is a CS error inside generated code.
+    /// </remarks>
+    [Fact]
+    public void TheConstructorMayBeDeclaredInAnotherPart() {
+        const string source =
+            """
+            public interface IDep { }
+
+            [SingletonService]
+            public class Dep : IDep { }
+
+            public interface IFoo { }
+
+            public abstract class FooBase : IFoo { }
+
+            public partial class Foo : IFoo { }
+
+            public partial class Foo : FooBase {
+                public Foo(IDep dep) { Dep = dep; }
+                public IDep Dep { get; }
+            }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSingleton();
+                }
+            }
+            """;
+
+        var assembly = Compile(source);
+
+        Assert.IsType(assembly.Type("Foo"), assembly.ResolveRequired("IFoo"));
+    }
+
+    /// <summary>
+    /// A type filling two roles registers as both. This is the ordinary shape of a MediatR handler,
+    /// and the two registrations are independently predictable from reading the module.
+    /// </summary>
+    [Fact]
+    public void ATypeMatchedThroughDifferentInterfacesRegistersAsBoth() {
+        const string source =
+            """
+            public interface IFoo { }
+            public interface IBar { }
+
+            public partial class Thing : IFoo { }
+            public partial class Thing : IBar { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSingleton();
+                    conventions.RegisterAll<IBar>().AsSingleton();
+                }
+            }
+            """;
+
+        Assert.DoesNotContain(Run(source).GeneratorDiagnostics, d => d.Id == "DM0004");
+
+        var assembly = Compile(source);
+
+        Assert.Equal(assembly.Type("Thing"), assembly.Descriptor("IFoo").ImplementationType);
+        Assert.Equal(assembly.Type("Thing"), assembly.Descriptor("IBar").ImplementationType);
+    }
+
+    /// <summary>
+    /// Each role keeps its own lifetime, and two singletons of one implementation registered under
+    /// different service types are two instances — which is what Scrutor and MediatR both produce.
+    /// Sharing one instance is <c>AsSelfWithInterfaces</c>, and it is opt-in.
+    /// </summary>
+    [Fact]
+    public void EachRoleKeepsItsOwnLifetimeAndItsOwnInstance() {
+        var assembly = Compile(
+            """
+            public interface IFoo { }
+            public interface IBar { }
+
+            public class Thing : IFoo, IBar { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSingleton();
+                    conventions.RegisterAll<IBar>().AsScoped();
+                }
+            }
+            """);
+
+        Assert.Equal(ServiceLifetime.Singleton, assembly.Descriptor("IFoo").Lifetime);
+        Assert.Equal(ServiceLifetime.Scoped, assembly.Descriptor("IBar").Lifetime);
+
+        var provider = assembly.BuildProvider();
+
+        Assert.NotSame(
+            provider.GetService(assembly.Type("IFoo")),
+            provider.GetService(assembly.Type("IBar")));
+    }
+
+    /// <summary>
+    /// A handler covering several messages registers against every closing it implements.
+    /// </summary>
+    /// <remarks>
+    /// The MediatR shape. Registering only the first closing left the second silently unregistered:
+    /// green build, no diagnostic, and an event that never fires.
+    /// </remarks>
+    [Fact]
+    public void OneConventionRegistersEveryClosingACandidateImplements() {
+        var assembly = Compile(
+            """
+            public interface INotificationHandler<T> { }
+
+            public class OrderPlaced { }
+            public class OrderShipped { }
+
+            public class OrderEvents : INotificationHandler<OrderPlaced>, INotificationHandler<OrderShipped> { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(INotificationHandler<>)).AsTransient();
+                }
+            }
+            """);
+
+        var handlerType = assembly.Type("INotificationHandler`1");
+
+        var placed = handlerType.MakeGenericType(assembly.Type("OrderPlaced"));
+        var shipped = handlerType.MakeGenericType(assembly.Type("OrderShipped"));
+
+        var provider = assembly.BuildProvider();
+
+        Assert.IsType(assembly.Type("OrderEvents"), provider.GetService(placed));
+        Assert.IsType(assembly.Type("OrderEvents"), provider.GetService(shipped));
+    }
+
+    /// <summary>
+    /// Several closings on one type are one implementation with several registrations, not several
+    /// implementations — the shape the attribute path produces and the writer relies on.
+    /// </summary>
+    [Fact]
+    public void SeveralClosingsProduceOneImplementationWithSeveralRegistrations() {
+        var assembly = Compile(
+            """
+            public interface IHandler<T> { }
+
+            public class A { }
+            public class B { }
+
+            public class Both : IHandler<A>, IHandler<B> { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IHandler<>)).AsTransient();
+                }
+            }
+            """);
+
+        var registered = assembly.Services
+            .Where(d => d.ImplementationType == assembly.Type("Both"))
+            .ToArray();
+
+        Assert.Equal(2, registered.Length);
+    }
+
+    [Fact]
+    public void UsingChoosesHowTheRegistrationIsAdded() {
+        var assembly = Compile(
+            """
+            public interface IFoo { }
+            public class FooOne : IFoo { }
+            public class FooTwo : IFoo { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSingleton().Using(RegistrationType.Try);
+                }
+            }
+            """);
+
+        // Try registers the service type once and skips the second match.
+        Assert.Single(assembly.Descriptors("IFoo"));
+    }
+
+    [Fact]
+    public void WithKeyRegistersUnderAServiceKey() {
+        var assembly = Compile(
+            """
+            public interface IFoo { }
+            public class Foo : IFoo { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSingleton().WithKey("primary");
+                }
+            }
+            """);
+
+        var descriptor = assembly.Descriptor("IFoo");
+
+        Assert.True(descriptor.IsKeyedService);
+        Assert.Equal("primary", descriptor.ServiceKey);
+
+        Assert.IsType(
+            assembly.Type("Foo"),
+            assembly.BuildProvider().GetRequiredKeyedService(assembly.Type("IFoo"), "primary"));
+    }
+
+    /// <summary>
+    /// The case DM0004 exists for: one service type claimed twice, so one lifetime has to win and
+    /// the source does not say which.
+    /// </summary>
+    [Fact]
+    public void TwoConventionsRegisteringOneServiceTypeIsAmbiguous() {
+        var result = Run(
+            """
+            public interface IFoo { }
+            public interface IFooPrime : IFoo { }
+
+            public class Thing : IFooPrime { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsScoped();
+                    conventions.RegisterAll<IFoo>().AsSingleton();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0004");
+
+        Assert.Contains("different lifetimes", diagnostic.GetMessage());
+        Assert.Contains("IFoo", diagnostic.GetMessage());
+    }
+
+    /// <summary>
+    /// Equal lifetimes are still an error. The outcome is predictable, but the declaration is
+    /// redundant and collapsing it silently is the failure mode this codebase avoids.
+    /// </summary>
+    [Fact]
+    public void ADuplicatedConventionIsAmbiguousEvenWithEqualLifetimes() {
+        var result = Run(
+            """
+            public interface IFoo { }
+
+            public class Thing : IFoo { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSingleton();
+                    conventions.RegisterAll<IFoo>().AsSingleton();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0004");
+
+        Assert.Contains("duplicated", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void AsSelfRegistersTheConcreteTypeRatherThanTheService() {
+        var assembly = Compile(
+            """
+            public interface IFoo { }
+            public class Foo : IFoo { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSelf().AsSingleton();
+                }
+            }
+            """);
+
+        Assert.Empty(assembly.Descriptors("IFoo"));
+        Assert.Single(assembly.Descriptors("Foo"));
+    }
+
+    /// <summary>
+    /// AsSelfWithInterfaces promises one instance reachable through the type and every interface,
+    /// which is why it emits the cross-wire shape rather than two independent registrations.
+    /// </summary>
+    [Fact]
+    public void AsSelfWithInterfacesSharesOneInstance() {
+        var assembly = Compile(
+            """
+            public interface IFoo { }
+            public interface IBar { }
+            public class Foo : IFoo, IBar { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSelfWithInterfaces().AsSingleton();
+                }
+            }
+            """);
+
+        var provider = assembly.BuildProvider();
+
+        var asFoo = provider.GetService(assembly.Type("Foo"));
+        var asIFoo = provider.GetService(assembly.Type("IFoo"));
+        var asIBar = provider.GetService(assembly.Type("IBar"));
+
+        Assert.NotNull(asFoo);
+        Assert.Same(asFoo, asIFoo);
+        Assert.Same(asFoo, asIBar);
+    }
+
+    /// <summary>
+    /// The hole this closes: a concrete class implementing nothing, selected by namespace.
+    /// </summary>
+    [Fact]
+    public void AConcreteTypeWithNoInterfaceRegistersByNamespace() {
+        var assembly = Compile(
+            """
+            public class OrderCalculator { }
+            public class OrderValidator { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll().InNamespaceOf<OrderCalculator>().AsSelf().AsScoped();
+                }
+            }
+            """);
+
+        Assert.Single(assembly.Descriptors("OrderCalculator"));
+        Assert.Single(assembly.Descriptors("OrderValidator"));
+    }
+
+    [Fact]
+    public void NamespaceFiltersNarrowAnAssignabilityConvention() {
+        var result = Run(
+            """
+            public interface IFoo { }
+            public class Foo : IFoo { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().InNamespaces("SomewhereElse").AsSingleton();
+                }
+            }
+            """);
+
+        // Filtered out entirely, which is DM0005 rather than silence.
+        Assert.Contains(result.GeneratorDiagnostics, d => d.Id == "DM0005");
+    }
+
+    [Fact]
+    public void NotInNamespacesExcludesAfterInclusions() {
+        var assembly = Compile(
+            """
+            public interface IFoo { }
+            public class Foo : IFoo { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().NotInNamespaces("TestNamespace").AsSingleton();
+                }
+            }
+            """);
+
+        Assert.Empty(assembly.Descriptors("IFoo"));
+    }
+
+    [Fact]
+    public void RegisterAllWithNoServiceTypeNeedsAShape() {
+        var result = Run(
+            """
+            public class Thing { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll().InNamespaceOf<Thing>().AsScoped();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0009");
+
+        Assert.Contains("AsSelf", diagnostic.GetMessage());
+    }
+
+    /// <summary>
+    /// Without a filter it would match every class in the compilation, so it is refused.
+    /// </summary>
+    [Fact]
+    public void RegisterAllWithNoServiceTypeAndNoFilterIsRefused() {
+        var result = Run(
+            """
+            public class Thing { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll().AsSelf().AsScoped();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0009");
+
+        Assert.Contains("every class", diagnostic.GetMessage());
+    }
+
     [Fact]
     public void RegistersEveryTypeDeclaringTheServiceInterface() {
         var assembly = Compile(
@@ -333,28 +841,11 @@ public class ConventionRegistrationTests {
         Assert.Contains(result.GeneratorDiagnostics, d => d.Id == "DM0009");
     }
 
-    [Fact]
-    public void TwoConventionsMatchingOneTypeIsAmbiguous() {
-        var result = Run(
-            """
-            public interface IFoo { }
-            public interface IBar { }
-
-            public class Both : IFoo, IBar { }
-
-            [DependencyModule]
-            public partial class TestModule : IConventionModule {
-                void IConventionModule.Conventions(IConventionDefinitions conventions) {
-                    conventions.RegisterAll<IFoo>().AsSingleton();
-                    conventions.RegisterAll<IBar>().AsScoped();
-                }
-            }
-            """);
-
-        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0004");
-
-        Assert.Contains("Both", diagnostic.GetMessage());
-    }
+    // TwoConventionsMatchingOneTypeIsAmbiguous lived here. It asserted DM0004 for a type matched
+    // through two different interfaces, which is now a legal two-role registration; see
+    // EachRoleKeepsItsOwnLifetimeAndItsOwnInstance, which covers the same source and asserts what it
+    // registers rather than that it refuses. TwoConventionsRegisteringOneServiceTypeIsAmbiguous
+    // keeps DM0004 honest for the case it exists for.
 
     [Fact]
     public void AConcreteTypeWithNoAccessibleConstructorIsReported() {

--- a/tests/DependencyModules.Tests/GeneratorTests/ConventionRegistrationTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ConventionRegistrationTests.cs
@@ -633,6 +633,158 @@ public class ConventionRegistrationTests {
         Assert.NotEmpty(assembly.Services);
     }
 
+    private const string Validators =
+        """
+        public interface IRule { }
+        public interface IValidator { }
+        public interface IValidator<T> : IValidator { }
+
+        public abstract class AbstractValidator<T> : IValidator<T>, System.Collections.Generic.IEnumerable<IRule> {
+            public System.Collections.Generic.IEnumerator<IRule> GetEnumerator() => null!;
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => null!;
+        }
+
+        public class Foo { }
+
+        public class FooValidator : AbstractValidator<Foo> { }
+        """;
+
+    /// <summary>
+    /// The FluentValidation shape: registered as the matched interface and as the concrete type.
+    /// </summary>
+    [Fact]
+    public void AlsoAsSelfRegistersTheInterfaceAndTheType() {
+        var assembly = Compile(
+            Validators +
+            """
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IValidator<>)).IncludeBaseClasses().AlsoAsSelf().AsScoped();
+                }
+            }
+            """);
+
+        Assert.Contains(assembly.Services, d => d.ServiceType.Name == "IValidator`1");
+        Assert.Contains(assembly.Services, d => d.ServiceType == assembly.Type("FooValidator"));
+    }
+
+    /// <summary>
+    /// Cross-wired, so both routes give one instance per scope. FluentValidation registers the pair
+    /// independently and hands you two; this is a deliberate difference.
+    /// </summary>
+    [Fact]
+    public void AlsoAsSelfSharesOneInstance() {
+        var assembly = Compile(
+            Validators +
+            """
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IValidator<>)).IncludeBaseClasses().AlsoAsSelf().AsScoped();
+                }
+            }
+            """);
+
+        var provider = assembly.BuildProvider();
+        using var scope = provider.CreateScope();
+
+        var validatorInterface = assembly.Services
+            .First(d => d.ServiceType.Name == "IValidator`1").ServiceType;
+
+        Assert.Same(
+            scope.ServiceProvider.GetService(validatorInterface),
+            scope.ServiceProvider.GetService(assembly.Type("FooValidator")));
+    }
+
+    /// <summary>
+    /// Only the interfaces the convention matched, not everything the type can reach.
+    /// </summary>
+    [Fact]
+    public void AlsoAsSelfDoesNotPullInUnmatchedInterfaces() {
+        var assembly = Compile(
+            Validators +
+            """
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IValidator<>)).IncludeBaseClasses().AlsoAsSelf().AsScoped();
+                }
+            }
+            """);
+
+        // IValidator and the enumerable interfaces are reachable but were not matched.
+        Assert.DoesNotContain(assembly.Services, d => d.ServiceType == assembly.Type("IValidator"));
+        Assert.DoesNotContain(assembly.Services, d => d.ServiceType.Namespace?.StartsWith("System") == true);
+    }
+
+    [Fact]
+    public void AsSelfAndAlsoAsSelfTogetherIsRefused() {
+        var result = Run(
+            """
+            public interface IFoo { }
+            public class Foo : IFoo { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IFoo>().AsSelf().AlsoAsSelf().AsSingleton();
+                }
+            }
+            """);
+
+        Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0009");
+    }
+
+    /// <summary>
+    /// A handler closing two messages asks for the self registration twice and means it once. One
+    /// convention repeating itself is not an ambiguity.
+    /// </summary>
+    [Fact]
+    public void AlsoAsSelfRegistersTheTypeOnceAcrossSeveralClosings() {
+        var result = Run(
+            """
+            public interface IHandler<T> { }
+
+            public class A { }
+            public class B { }
+
+            public class Both : IHandler<A>, IHandler<B> { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IHandler<>)).AlsoAsSelf().AsScoped();
+                }
+            }
+            """);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0004");
+
+        var assembly = Compile(
+            """
+            public interface IHandler<T> { }
+
+            public class A { }
+            public class B { }
+
+            public class Both : IHandler<A>, IHandler<B> { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IHandler<>)).AlsoAsSelf().AsScoped();
+                }
+            }
+            """);
+
+        Assert.Single(assembly.Services, d => d.ServiceType == assembly.Type("Both"));
+        Assert.Equal(2, assembly.Services.Count(d => d.ServiceType.Name == "IHandler`1"));
+    }
+
     [Fact]
     public void UsingChoosesHowTheRegistrationIsAdded() {
         var assembly = Compile(

--- a/tests/DependencyModules.Tests/GeneratorTests/ReferencedAssemblyScanTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ReferencedAssemblyScanTests.cs
@@ -1,0 +1,267 @@
+using DependencyModules.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// Scanning a referenced assembly with <c>InAssemblyOf&lt;T&gt;</c>.
+/// </summary>
+/// <remarks>
+/// The library is compiled to real metadata and referenced, so the consuming compilation contains no
+/// syntax tree for any of its types. That is the whole point: this path reads symbols out of
+/// metadata, where the in-compilation path reads declarations.
+/// </remarks>
+public class ReferencedAssemblyScanTests {
+
+    private const string LibrarySource =
+        """
+        namespace ThePackage;
+
+        public interface IHandler<TIn, TOut> { }
+
+        public class CreateOrder { }
+        public class RenameOrder { }
+        public class OrderId { }
+
+        public class CreateOrderHandler : IHandler<CreateOrder, OrderId> { }
+        public class RenameOrderHandler : IHandler<RenameOrder, OrderId> { }
+
+        // Invisible across an assembly boundary.
+        internal class HiddenHandler : IHandler<CreateOrder, OrderId> { }
+
+        // Visible, but the container could not construct it.
+        public class UnconstructableHandler : IHandler<RenameOrder, OrderId> {
+            private UnconstructableHandler() { }
+        }
+
+        public class Unrelated { }
+        """;
+
+    private const string Preamble =
+        """
+        using DependencyModules.Runtime.Attributes;
+        using DependencyModules.Conventions;
+        using ThePackage;
+
+        namespace TestNamespace;
+
+        """;
+
+    private static (GeneratorResult Result, GeneratedAssembly? Assembly) Run(
+        string module, bool compile = true) {
+
+        var library = GeneratorTestHarness.CompileLibrary(LibrarySource, "ThePackage");
+        var references = new[] { library.Reference };
+
+        var result = GeneratorTestHarness.Run(
+            new Dictionary<string, string> { ["Test.cs"] = Preamble + module },
+            withConventions: true,
+            additionalReferences: references);
+
+        var assembly = compile
+            ? GeneratedAssembly.Create(
+                Preamble + module, withConventions: true, additionalReferences: references)
+            : null;
+
+        return (result, assembly);
+    }
+
+    /// <summary>
+    /// The capability: an open generic matched against a package's types, each registered against
+    /// the closed construction it actually implements.
+    /// </summary>
+    [Fact]
+    public void RegistersTypesFromAReferencedAssembly() {
+        var (result, assembly) = Run(
+            """
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IHandler<,>))
+                        .InAssemblyOf<CreateOrder>()
+                        .AsScoped();
+                }
+            }
+            """);
+
+        result.AssertNoErrors();
+
+        var handlerType = assembly!.Services
+            .Select(d => d.ServiceType)
+            .First(t => t.Name == "IHandler`2");
+
+        var registered = assembly.Services
+            .Where(d => d.ServiceType.Name == "IHandler`2")
+            .Select(d => d.ImplementationType!.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(new[] { "CreateOrderHandler", "RenameOrderHandler" }, registered);
+        Assert.NotNull(handlerType);
+    }
+
+    /// <summary>
+    /// An internal type is not visible across the boundary, and an unconstructable one is refused
+    /// the same way it would be in the compilation being built.
+    /// </summary>
+    [Fact]
+    public void SkipsWhatItCannotSeeOrConstruct() {
+        var (result, assembly) = Run(
+            """
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IHandler<,>))
+                        .InAssemblyOf<CreateOrder>()
+                        .AsScoped();
+                }
+            }
+            """);
+
+        var registered = assembly!.Services
+            .Where(d => d.ServiceType.Name == "IHandler`2")
+            .Select(d => d.ImplementationType!.Name)
+            .ToArray();
+
+        Assert.DoesNotContain("HiddenHandler", registered);
+        Assert.DoesNotContain("UnconstructableHandler", registered);
+
+        // Refused rather than dropped in silence.
+        Assert.Contains(result.GeneratorDiagnostics, d => d.Id == "DM0006");
+    }
+
+    /// <summary>
+    /// A registered service from the package resolves.
+    /// </summary>
+    [Fact]
+    public void TheRegistrationsResolve() {
+        var (_, assembly) = Run(
+            """
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IHandler<,>))
+                        .InAssemblyOf<CreateOrder>()
+                        .AsScoped();
+                }
+            }
+            """);
+
+        var descriptor = assembly!.Services.First(
+            d => d.ServiceType.Name == "IHandler`2" &&
+                 d.ImplementationType!.Name == "CreateOrderHandler");
+
+        var provider = assembly.BuildProvider();
+
+        Assert.NotNull(provider.GetService(descriptor.ServiceType));
+    }
+
+    /// <summary>
+    /// One source or the other. A convention naming an assembly must not pick up local types, and
+    /// one that names none must not reach into the package.
+    /// </summary>
+    [Fact]
+    public void AConventionSeesOneSourceOnly() {
+        var (_, assembly) = Run(
+            """
+            public class LocalHandler : IHandler<CreateOrder, OrderId> { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IHandler<,>))
+                        .InAssemblyOf<CreateOrder>()
+                        .AsScoped();
+                }
+            }
+            """);
+
+        var registered = assembly!.Services
+            .Where(d => d.ServiceType.Name == "IHandler`2")
+            .Select(d => d.ImplementationType!.Name)
+            .ToArray();
+
+        Assert.DoesNotContain("LocalHandler", registered);
+    }
+
+    /// <summary>
+    /// Absent the call, a convention scans the compilation being built — unchanged behaviour.
+    /// </summary>
+    [Fact]
+    public void WithoutTheCallOnlyLocalTypesMatch() {
+        var (_, assembly) = Run(
+            """
+            public class LocalHandler : IHandler<CreateOrder, OrderId> { }
+
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IHandler<,>)).AsScoped();
+                }
+            }
+            """);
+
+        var registered = assembly!.Services
+            .Where(d => d.ServiceType.Name == "IHandler`2")
+            .Select(d => d.ImplementationType!.Name)
+            .ToArray();
+
+        Assert.Equal(new[] { "LocalHandler" }, registered);
+    }
+
+    /// <summary>
+    /// A match from a referenced assembly has no class to squiggle, so its diagnostics report at
+    /// the convention that asked for it rather than nowhere.
+    /// </summary>
+    [Fact]
+    public void DiagnosticsForMetadataMatchesReportAtTheConvention() {
+        var (result, _) = Run(
+            """
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IHandler<,>))
+                        .InAssemblyOf<CreateOrder>()
+                        .AsScoped();
+                }
+            }
+            """,
+            compile: false);
+
+        var exposures = result.GeneratorDiagnostics.Where(d => d.Id == "DM0010").ToArray();
+
+        Assert.NotEmpty(exposures);
+
+        Assert.All(exposures, diagnostic => {
+            Assert.NotEqual(Location.None, diagnostic.Location);
+            Assert.Contains("Test.cs", diagnostic.Location.GetLineSpan().Path);
+        });
+    }
+
+    /// <summary>
+    /// Filters apply to metadata types the same way they apply to local ones.
+    /// </summary>
+    [Fact]
+    public void FiltersApplyToMetadataTypes() {
+        var (_, assembly) = Run(
+            """
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IHandler<,>))
+                        .InAssemblyOf<CreateOrder>()
+                        .WithName("Create*")
+                        .AsScoped();
+                }
+            }
+            """);
+
+        var registered = assembly!.Services
+            .Where(d => d.ServiceType.Name == "IHandler`2")
+            .Select(d => d.ImplementationType!.Name)
+            .ToArray();
+
+        Assert.Equal(new[] { "CreateOrderHandler" }, registered);
+    }
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/TypeShapeTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/TypeShapeTests.cs
@@ -309,6 +309,45 @@ public class TypeShapeTests {
     }
 
     /// <summary>
+    /// A nested type's constructor is not the outer type's.
+    /// </summary>
+    /// <remarks>
+    /// GetConstructorInfo used to walk DescendantNodes, which reaches into nested declarations, so a
+    /// service containing a nested class with a parameterised constructor was registered against
+    /// that constructor's parameters. It now reads the type's own members.
+    /// </remarks>
+    [Fact]
+    public void ANestedTypesConstructorIsNotTheOuterTypes() {
+        // With factory generation on, the constructor reaches the emitted code as a literal
+        // new Outer(...) call. Without it the container picks the constructor at run time and the
+        // mistake is invisible, which is why this test sets the property.
+        var assembly = GeneratedAssembly.Create(
+            """
+            using DependencyModules.Runtime.Attributes;
+
+            namespace TestNamespace;
+
+            public interface IOuter { }
+
+            [SingletonService]
+            public class Outer : IOuter {
+                public class Nested {
+                    public Nested(string required) { Required = required; }
+                    public string Required { get; }
+                }
+            }
+
+            [DependencyModule]
+            public partial class TestModule;
+            """,
+            buildProperties: new Dictionary<string, string> {
+                ["DependencyModules_GenerateFactories"] = "true"
+            });
+
+        Assert.IsType(assembly.Type("Outer"), assembly.ResolveRequired("IOuter"));
+    }
+
+    /// <summary>
     /// Compiles the supplied declarations alongside a module and returns the registration file.
     /// </summary>
     private static string Generate(string body) {

--- a/tests/DependencyModules.Tests/Infrastructure/GeneratedAssembly.cs
+++ b/tests/DependencyModules.Tests/Infrastructure/GeneratedAssembly.cs
@@ -50,7 +50,8 @@ public class GeneratedAssembly {
         string moduleName = "TestModule",
         IReadOnlyDictionary<string, string>? buildProperties = null,
         bool withConventions = false,
-        IModuleEnvironment? environment = null) {
+        IModuleEnvironment? environment = null,
+        IReadOnlyList<MetadataReference>? additionalReferences = null) {
 
         var assemblyName = "GeneratedAssemblyTest" + Interlocked.Increment(ref _assemblyCounter);
 
@@ -58,7 +59,8 @@ public class GeneratedAssembly {
             new Dictionary<string, string> { ["Test.cs"] = source },
             buildProperties,
             assemblyName: assemblyName,
-            withConventions: withConventions);
+            withConventions: withConventions,
+            additionalReferences: additionalReferences);
 
         result.AssertNoErrors();
 

--- a/tests/DependencyModules.Tests/Infrastructure/GeneratorTestHarness.cs
+++ b/tests/DependencyModules.Tests/Infrastructure/GeneratorTestHarness.cs
@@ -35,7 +35,8 @@ public static class GeneratorTestHarness {
         IReadOnlyDictionary<string, string>? buildProperties = null,
         OutputKind outputKind = OutputKind.DynamicallyLinkedLibrary,
         string assemblyName = "GeneratorTestAssembly",
-        bool withConventions = false) {
+        bool withConventions = false,
+        IReadOnlyList<MetadataReference>? additionalReferences = null) {
 
         // MSBuild hands the compiler absolute paths, and the generator compares a file's location
         // against ProjectDir to decide whether it owns the auto-generated ApplicationModule.
@@ -52,7 +53,9 @@ public static class GeneratorTestHarness {
         var compilation = CSharpCompilation.Create(
             assemblyName,
             syntaxTrees,
-            References.Value,
+            additionalReferences == null
+                ? References.Value
+                : References.Value.Concat(additionalReferences),
             new CSharpCompilationOptions(outputKind, nullableContextOptions: NullableContextOptions.Enable));
 
         var driver = CSharpGeneratorDriver.Create(
@@ -166,6 +169,61 @@ public static class GeneratorTestHarness {
         buildProperties != null && buildProperties.TryGetValue("ProjectDir", out var configured)
             ? configured
             : DefaultProjectDir;
+
+    /// <summary>
+    /// Compiles a standalone library and returns a reference to it, plus the loaded assembly.
+    /// </summary>
+    /// <remarks>
+    /// The only honest way to test scanning a referenced assembly: the types have to live in real
+    /// metadata with no syntax tree in the consuming compilation, which is exactly the situation
+    /// InAssemblyOf exists for. Loading it as well lets a behavioural test resolve the services the
+    /// generated code registers.
+    /// </remarks>
+    public static (MetadataReference Reference, System.Reflection.Assembly Assembly) CompileLibrary(
+        string source, string assemblyName) {
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            References.Value,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+
+        var result = compilation.Emit(stream);
+
+        Xunit.Assert.True(result.Success,
+            "The test library did not compile: " + string.Join(
+                Environment.NewLine,
+                result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+
+        var bytes = stream.ToArray();
+        var assembly = System.Reflection.Assembly.Load(bytes);
+
+        // Assembly.Load(byte[]) puts it in the default context but does not make it discoverable by
+        // name, so generated code referencing it fails to bind at run time. The resolver closes that.
+        lock (LoadedLibraries) {
+            LoadedLibraries[assemblyName] = assembly;
+
+            if (!_resolverHooked) {
+                System.Runtime.Loader.AssemblyLoadContext.Default.Resolving += (_, name) => {
+                    lock (LoadedLibraries) {
+                        return name.Name != null && LoadedLibraries.TryGetValue(name.Name, out var found)
+                            ? found
+                            : null;
+                    }
+                };
+
+                _resolverHooked = true;
+            }
+        }
+
+        return (MetadataReference.CreateFromImage(bytes), assembly);
+    }
+
+    private static readonly Dictionary<string, System.Reflection.Assembly> LoadedLibraries = new();
+
+    private static bool _resolverHooked;
 
     private static ImmutableArray<MetadataReference> BuildReferences() {
         var builder = ImmutableArray.CreateBuilder<MetadataReference>();


### PR DESCRIPTION
The whole Scrutor parity plan from `docs/design/convention-registration-and-decorators.md` — steps 1 through 8 — plus two performance fixes and one defect the work exposed.

## Silent or wrong behaviours, fixed

**A partial class was two candidates.** The provider runs per declaration and reads the base list in front of it, so `partial class Foo : IFoo` in one part and `partial class Foo : FooBase` in another each saw half the picture — and the ambiguity check refused both with `matched by more than one convention — as 'IFoo' and as 'IFoo'`. One convention, named twice.

**A handler covering two messages registered one.** Silently — green build, no diagnostic, an event that never fires. `FirstMatchingInterface` is now `AllMatchingInterfaces`.

**A nested type's constructor was the outer type's.** `GetConstructorInfo` walked `DescendantNodes`, which reaches into nested declarations. Only visible with `GenerateFactories` on, which is why the test that pins it sets the property and fails against the old walk.

**`AsSelfWithInterfaces` cross-wired BCL interfaces.** Anything whose base implements `IDisposable` became resolvable as `IDisposable`; a FluentValidation validator became resolvable as `IEnumerable<IValidationRule>`. Now skips `System.*` — one rule rather than the growing blocklist Autofac and Scrutor each maintain half of.

## DM0004 now means what it says

Keyed on `(implementation, service type)` rather than the implementation alone. A type filling two roles is the ordinary shape of a MediatR handler and registers twice; one service type claimed by two conventions still fails, because one lifetime has to win and the source does not say which.

## The API

```csharp
conventions.RegisterAll<IFoo>().AsSelf().AsSingleton();
conventions.RegisterAll<IFoo>().AsSelfWithInterfaces().AsSingleton();
conventions.RegisterAll<IMarker>().AsMatchingInterface().AsSingleton();
conventions.RegisterAll<IFoo>().As<IMarker>().AsSingleton();

conventions.RegisterAll().InNamespaceOf<OrderMarker>().AsSelf().AsScoped();
conventions.RegisterAll().WithName("*Repository").AsSelf().AsScoped();
conventions.RegisterAll<IFoo>().WithAttribute<HandlerAttribute>().AsSingleton();
conventions.RegisterAll<IFoo>().WithoutAttribute<LegacyAttribute>().AsSingleton();
conventions.RegisterAll<IFoo>().NotInNamespaces("MyApp.Internal").AsSingleton();

conventions.RegisterAll<IFoo>().AsSingleton().Using(RegistrationType.Try);
conventions.RegisterAll<IFoo>().AsSingleton().WithKey("primary");

conventions.RegisterAll(typeof(IHandler<,>)).InAssemblyOf<SomePackageType>().AsScoped();
```

Multi-interface registration is **N instances**, matching Scrutor and MediatR; one shared instance is `AsSelfWithInterfaces()`, opt-in. Attributes and service types are **resolved**, not matched on how they were written — name-matching is how a namespace-qualified usage came to be silently ignored here once already.

## Referenced assemblies, and why it is AOT-safe

`InAssemblyOf<T>()` reads types as Roslyn symbols at compile time and emits a literal `typeof()` per match — a static reference the trimmer roots, which also lets the `DynamicallyAccessedMembers` annotation on `ServiceDescriptor` flow to a known type so the constructor survives. **Nothing is loaded at run time.** That is the difference from Scrutor, whose scan is reflection and finds nothing once the trimmer has run.

The assembly is always named, by a type rather than a string, so an unreferenced assembly cannot be asked for. There is no scan-everything: walking every reference visits thousands of types per keystroke where one named assembly visits its own.

## Performance

Admitting concrete types with no interface meant the predicate could no longer reject declarations with no base list, and providers cannot see each other, so the cost is unconditional. Measured, 2,000 ordinary classes, second generator run after editing one file:

| | after one edit |
|---|---|
| before this branch | 9 ms |
| naive widening | 73 ms |
| constructors from members | 40 ms |
| syntax-only path for types with no base list | **12 ms** |

The constructor fix applies to the convention path that already shipped — 29 ms to 17 ms on the same workload. The metadata provider adds nothing when no convention names an assembly.

The benchmark is kept, in the solution so it cannot rot and out of the coverage gate. Four things in it are load-bearing and each produced a believable but wrong number first: time only `RunGeneratorsAndUpdateCompilation`, one syntax tree per class, real class bodies, and measure the run after an edit rather than the cold one.

## Verification

- `dotnet build -c Release --no-incremental` — **0 warnings**
- `./scripts/coverage.sh 85` — **590 tests pass, 87.8% coverage**
- `./scripts/verify-packages.sh` — clean

Behaviour is asserted by compiling and executing generated assemblies. Every defect here was reproduced before being fixed.

## Not in this PR

`AlsoAsSelf` — item 1 of `docs/design/convention-self-registration.md`, the shape between `Interfaces` and `SelfAndInterfaces` that FluentValidation wants. Item 2 of that doc is done.

The lambda-taking Scrutor overloads have no compile-time equivalent; `IServiceCollectionConfiguration.ConfigureServices` is the escape hatch. `FromApplicationDependencies` and friends load assemblies by name at run time and are deliberately out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C56x6Vv6HJ6ArfqwKsuSb9