### PR TITLE
A decorator is not a convention candidate

### DIFF
--- a/src/DependencyModules.Conventions/Utilities/ConventionCandidateUtility.cs
+++ b/src/DependencyModules.Conventions/Utilities/ConventionCandidateUtility.cs
@@ -29,11 +29,25 @@ namespace DependencyModules.Conventions.Utilities;
 /// </remarks>
 public static class ConventionCandidateUtility {
 
+    /// <summary>
+    /// Attributes that take a type out of convention matching.
+    /// </summary>
+    /// <remarks>
+    /// The service attributes, because an explicit registration always wins — and
+    /// <c>[Decorator]</c>, because a decorator is not a service. A decorator implements the
+    /// interface it decorates, so a convention scanning that interface matched the decorator too and
+    /// registered it as an ordinary implementation. For a generic decorator that is worse than a
+    /// stray registration: it closes nothing, so it registered as the <i>open</i> generic, and
+    /// decoration then refused the whole thing because an open generic registration cannot be
+    /// decorated. One open generic decorator over convention-registered handlers — the ordinary
+    /// MediatR and FluentValidation shape — failed at the composition root because of it.
+    /// </remarks>
     private static readonly string[] ServiceAttributeNames = {
         "SingletonService", "SingletonServiceAttribute",
         "ScopedService", "ScopedServiceAttribute",
         "TransientService", "TransientServiceAttribute",
         "CrossWireService", "CrossWireServiceAttribute",
+        "Decorator", "DecoratorAttribute",
     };
 
     /// <summary>

--- a/tests/DependencyModules.Tests/GeneratorTests/ConventionDecoratorTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ConventionDecoratorTests.cs
@@ -1,0 +1,140 @@
+using DependencyModules.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// Conventions and decorators together.
+/// </summary>
+/// <remarks>
+/// A decorator implements the interface it decorates, so a convention scanning that interface used
+/// to match the decorator itself. For a generic decorator that was worse than a stray registration:
+/// closing nothing, it registered as the <i>open</i> generic, and decoration then refused everything
+/// because an open generic registration cannot be decorated. The error blamed the open generic
+/// limitation, which is a long way from the cause.
+/// </remarks>
+public class ConventionDecoratorTests {
+
+    private const string Preamble =
+        """
+        using System.Collections.Generic;
+        using DependencyModules.Runtime.Attributes;
+        using DependencyModules.Conventions;
+
+        namespace TestNamespace;
+
+        [SingletonService]
+        public class Log { public List<string> Lines { get; } = new(); }
+
+        public interface IRequestHandler<TRequest, TResponse> { TResponse Handle(TRequest request); }
+
+        public class CreateOrder { }
+        public class RenameOrder { }
+        public class OrderId { public string Value = ""; }
+
+        public class CreateOrderHandler : IRequestHandler<CreateOrder, OrderId> {
+            public OrderId Handle(CreateOrder r) => new OrderId { Value = "created" };
+        }
+
+        public class RenameOrderHandler : IRequestHandler<RenameOrder, OrderId> {
+            public OrderId Handle(RenameOrder r) => new OrderId { Value = "renamed" };
+        }
+
+        [Decorator]
+        public class LoggingHandler<TRequest, TResponse>(
+            IRequestHandler<TRequest, TResponse> inner, Log log)
+            : IRequestHandler<TRequest, TResponse> {
+
+            public TResponse Handle(TRequest request) {
+                log.Lines.Add("handling " + typeof(TRequest).Name);
+                return inner.Handle(request);
+            }
+        }
+
+        """;
+
+    private static GeneratedAssembly Compile(string module) =>
+        GeneratedAssembly.Create(Preamble + module, withConventions: true);
+
+    /// <summary>
+    /// One open generic decorator over every handler a convention registered — the ordinary MediatR
+    /// shape, and the reason this combination has to work.
+    /// </summary>
+    [Fact]
+    public void OneDecoratorWrapsEveryConventionRegisteredHandler() {
+        var assembly = Compile(
+            """
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IRequestHandler<,>)).AsScoped();
+                }
+            }
+            """);
+
+        var provider = assembly.BuildProvider();
+        var log = provider.GetRequiredService(assembly.Type("Log"));
+        var lines = (List<string>)log.GetType().GetProperty("Lines")!.GetValue(log)!;
+
+        var handler = assembly.Type("IRequestHandler`2");
+        var orderId = assembly.Type("OrderId");
+
+        foreach (var request in new[] { "CreateOrder", "RenameOrder" }) {
+            var requestType = assembly.Type(request);
+            var service = provider.GetRequiredService(handler.MakeGenericType(requestType, orderId));
+
+            // Every handler resolves as the decorator, not as the implementation.
+            Assert.Equal("LoggingHandler`2", service.GetType().Name);
+
+            service.GetType().GetMethod("Handle")!.Invoke(
+                service, new[] { Activator.CreateInstance(requestType) });
+        }
+
+        Assert.Equal(["handling CreateOrder", "handling RenameOrder"], lines);
+    }
+
+    /// <summary>
+    /// The decorator itself is not registered as a service.
+    /// </summary>
+    [Fact]
+    public void ADecoratorIsNotAConventionCandidate() {
+        var assembly = Compile(
+            """
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll(typeof(IRequestHandler<,>)).AsScoped();
+                }
+            }
+            """);
+
+        // Two handlers, two registrations. The decorator rewrote them in place rather than adding
+        // a third, and never registered itself as an open generic.
+        Assert.Equal(2, assembly.Services.Count(d => d.ServiceType.Name == "IRequestHandler`2"));
+
+        Assert.DoesNotContain(assembly.Services, d => d.ServiceType.IsGenericTypeDefinition);
+    }
+
+    /// <summary>
+    /// The exclusion is on the declaration, so it holds however the convention selects.
+    /// </summary>
+    [Fact]
+    public void ADecoratorIsExcludedWhenSelectedByFilterRatherThanInterface() {
+        var assembly = Compile(
+            """
+            [DependencyModule]
+            public partial class TestModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll().WithName("*Handler").AsSelf().AsScoped();
+                }
+            }
+            """);
+
+        Assert.Contains(assembly.Services, d => d.ServiceType == assembly.Type("CreateOrderHandler"));
+        Assert.Contains(assembly.Services, d => d.ServiceType == assembly.Type("RenameOrderHandler"));
+
+        // LoggingHandler ends in "Handler" and would otherwise match.
+        Assert.DoesNotContain(assembly.Services, d => d.ServiceType.Name == "LoggingHandler`2");
+    }
+}


### PR DESCRIPTION
One open generic decorator over convention-registered handlers — the ordinary MediatR and FluentValidation shape — failed at the composition root.

```csharp
public class CreateOrderHandler : IRequestHandler<CreateOrder, OrderId> { }
public class RenameOrderHandler : IRequestHandler<RenameOrder, OrderId> { }

[Decorator]
public class LoggingHandler<TRequest, TResponse>(IRequestHandler<TRequest, TResponse> inner, Log log)
    : IRequestHandler<TRequest, TResponse> { … }

conventions.RegisterAll(typeof(IRequestHandler<,>)).AsScoped();
```

```
InvalidOperationException: 'IRequestHandler`2' is registered as an open generic and
cannot be decorated by 'LoggingHandler`2'.
```

## Cause

A decorator implements the interface it decorates, so the convention matched **the decorator itself** and registered it as an ordinary service. Being generic and closing nothing, it registered as the **open generic** — and decoration then refused everything, because an open generic registration cannot be decorated.

The message blames the open generic limitation, which is a long way from the cause. It is the right message for the case it was written for and the wrong one here, and it sends you at a problem you do not have: keyed services, generated shims, registering closed constructions — none of which were needed.

## Fix

`[Decorator]` joins the service attributes in taking a type out of convention matching. The service attributes are excluded because an explicit registration always wins; a decorator is excluded because **it is not a service**.

One entry in `ConventionCandidateUtility.ServiceAttributeNames`.

## Tests

Three behavioural tests, each of which fails without the fix:

- every convention-registered handler resolves as `LoggingHandler` and the decorator actually runs for both closings
- the decorator adds no registration of its own, and nothing registers as an open generic
- the exclusion holds when the convention selects by **name** rather than by interface, where `LoggingHandler` would otherwise match `"*Handler"`

Verified by reverting the fix: 3 failed, 0 passed.

## What this does not change

Decorating a service genuinely **registered as** an open generic — a single generic implementation serving every closing, `class Repo<T> : IRepo<T>` — is still refused, and the message above is still the right one for that case. It is now much rarer, since the common way to trigger it accidentally was this bug.

## Verification

- `dotnet build -c Release --no-incremental` — **0 warnings**
- `./scripts/coverage.sh 85` — **598 tests pass, 87.6% coverage**
- `./scripts/verify-packages.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C56x6Vv6HJ6ArfqwKsuSb9