### PR TITLE
Integration coverage for the convention features

### DIFF
--- a/integ-tests/SecondarySutProject/PackagePolicies.cs
+++ b/integ-tests/SecondarySutProject/PackagePolicies.cs
@@ -1,0 +1,30 @@
+namespace SecondarySutProject;
+
+// Types with no DependencyModules attributes, standing in for a third-party package: something a
+// consuming project can scan with InAssemblyOf<T> because it cannot add a module to it.
+//
+// This project does not reference the conventions analyzer, so nothing here registers itself.
+
+/// <summary>A policy contract a consumer might scan for.</summary>
+public interface IPackagePolicy {
+    /// <summary>Identifies the policy in assertions.</summary>
+    string Name { get; }
+}
+
+/// <summary>A public policy, visible across the assembly boundary.</summary>
+public class FirstPackagePolicy : IPackagePolicy {
+    /// <inheritdoc />
+    public string Name => "first";
+}
+
+/// <summary>A second public policy, so the scan has more than one match.</summary>
+public class SecondPackagePolicy : IPackagePolicy {
+    /// <inheritdoc />
+    public string Name => "second";
+}
+
+// Internal, so it is invisible across the boundary — the difference between scanning metadata and
+// scanning the compilation being built.
+internal class HiddenPackagePolicy : IPackagePolicy {
+    public string Name => "hidden";
+}

--- a/integ-tests/SutProject.Tests/ConventionTests/ConventionEdgeModules.cs
+++ b/integ-tests/SutProject.Tests/ConventionTests/ConventionEdgeModules.cs
@@ -1,0 +1,220 @@
+using DependencyModules.Conventions;
+using DependencyModules.Runtime.Attributes;
+using SecondarySutProject;
+using SutProject.Tests.ConventionTests.Nested;
+
+namespace SutProject.Tests.ConventionTests;
+
+// The corners: module-level decoration, two modules over one interface, negative and exact
+// filters, open generics resolved at several closings, lifetime and disposal, internal visibility,
+// and a metadata scan with filters and a shape.
+//
+// Every convention here matches at least one type on purpose. A convention that matches nothing is
+// DM0005, a warning, and this solution builds under a zero-warning gate.
+
+// ---------------------------------------------------------------------------
+// [Decorate] on the module rather than [Decorator] on the class. Different code path, and the one
+// to use when the decorator or the service comes from an assembly you do not control.
+// ---------------------------------------------------------------------------
+
+public interface IModuleDecorated {
+    string Describe();
+}
+
+public class ModuleDecoratedCore : IModuleDecorated {
+    public string Describe() => "core";
+}
+
+/// <summary>Carries no [Decorator]; the module names it instead.</summary>
+public class ModuleDecoratedWrapper(IModuleDecorated inner) : IModuleDecorated {
+    public string Describe() => $"wrapped({inner.Describe()})";
+}
+
+[DependencyModule]
+[Decorate(typeof(IModuleDecorated), typeof(ModuleDecoratedWrapper))]
+public partial class ConventionModuleDecorateModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        // The wrapper implements the interface too, so it would match. Excluding it by name is the
+        // cost of declaring decoration on the module rather than on the class.
+        conventions.RegisterAll<IModuleDecorated>().WithoutName("*Wrapper").AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Two modules scanning one interface, composed into the same application.
+// ---------------------------------------------------------------------------
+
+public interface IShared {
+    string Name { get; }
+}
+
+public class SharedFirst : IShared {
+    public string Name => "first";
+}
+
+public class SharedSecond : IShared {
+    public string Name => "second";
+}
+
+[DependencyModule]
+public partial class ConventionSharedFirstModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IShared>().WithName("SharedFirst").AsSingleton();
+    }
+}
+
+[DependencyModule]
+public partial class ConventionSharedSecondModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IShared>().WithName("SharedSecond").AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Exact versus prefix namespaces, and the negative form.
+// ---------------------------------------------------------------------------
+
+public interface INamespaceScanned {
+    string Name { get; }
+}
+
+public class RootLevelScanned : INamespaceScanned {
+    public string Name => "root";
+}
+
+/// <summary>Prefix filters reach into nested namespaces; exact ones do not.</summary>
+[DependencyModule]
+public partial class ConventionPrefixNamespaceModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<INamespaceScanned>().InNamespaceOf<RootLevelScanned>().AsSingleton();
+    }
+}
+
+[DependencyModule]
+public partial class ConventionExactNamespaceModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<INamespaceScanned>()
+            .InExactNamespaces("SutProject.Tests.ConventionTests")
+            .AsSingleton();
+    }
+}
+
+[DependencyModule]
+public partial class ConventionExcludedNamespaceModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<INamespaceScanned>()
+            .NotInNamespaceOf<NestedScanned>()
+            .AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// An open generic implementation, resolved at several closings.
+// ---------------------------------------------------------------------------
+
+public interface IOpenCache<T> {
+    string Describe();
+}
+
+/// <summary>Closes nothing, so it registers as the open generic.</summary>
+public class OpenPassThroughCache<T> : IOpenCache<T> {
+    public string Describe() => "cache:" + typeof(T).Name;
+}
+
+[DependencyModule]
+public partial class ConventionOpenGenericModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll(typeof(IOpenCache<>)).AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lifetime, disposal, and an internal candidate.
+// ---------------------------------------------------------------------------
+
+public interface IScopedByConvention {
+    Guid Id { get; }
+}
+
+public class ScopedByConvention : IScopedByConvention {
+    public Guid Id { get; } = Guid.NewGuid();
+}
+
+public interface IDisposableByConvention {
+    bool Disposed { get; }
+}
+
+public class DisposableByConvention : IDisposableByConvention, IDisposable {
+    public bool Disposed { get; private set; }
+
+    public void Dispose() => Disposed = true;
+}
+
+/// <summary>Internal, and still a candidate — the compilation being built sees its own internals.</summary>
+public interface IInternallyImplemented {
+    string Name { get; }
+}
+
+internal class InternalCandidate : IInternallyImplemented {
+    public string Name => "internal";
+}
+
+[DependencyModule]
+public partial class ConventionLifetimeModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IScopedByConvention>().AsScoped();
+        conventions.RegisterAll<IDisposableByConvention>().AsSingleton();
+        conventions.RegisterAll<IInternallyImplemented>().AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A decorator whose own dependencies are convention-registered. Decoration builds through
+// ActivatorUtilities, so everything but the inner instance is resolved from the container.
+// ---------------------------------------------------------------------------
+
+public interface IDecoratorDependency {
+    string Value { get; }
+}
+
+public class DecoratorDependency : IDecoratorDependency {
+    public string Value => "dep";
+}
+
+public interface IDependentlyDecorated {
+    string Describe();
+}
+
+public class DependentlyDecoratedCore : IDependentlyDecorated {
+    public string Describe() => "core";
+}
+
+[Decorator]
+public class DependentlyDecorating(IDependentlyDecorated inner, IDecoratorDependency dependency)
+    : IDependentlyDecorated {
+
+    public string Describe() => $"{dependency.Value}({inner.Describe()})";
+}
+
+[DependencyModule]
+public partial class ConventionDecoratorDependencyModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IDependentlyDecorated>().AsSingleton();
+        conventions.RegisterAll<IDecoratorDependency>().AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A metadata scan narrowed by a filter and reshaped, rather than the plain form.
+// ---------------------------------------------------------------------------
+
+[DependencyModule]
+public partial class ConventionFilteredScanModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IPackagePolicy>()
+            .InAssemblyOf<FirstPackagePolicy>()
+            .WithName("First*")
+            .AsSelf()
+            .AsSingleton();
+    }
+}

--- a/integ-tests/SutProject.Tests/ConventionTests/ConventionEdgeTests.cs
+++ b/integ-tests/SutProject.Tests/ConventionTests/ConventionEdgeTests.cs
@@ -1,0 +1,161 @@
+using DependencyModules.Runtime;
+using DependencyModules.Runtime.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using SecondarySutProject;
+using Xunit;
+
+namespace SutProject.Tests.ConventionTests;
+
+/// <summary>
+/// The corners of convention registration.
+/// </summary>
+public class ConventionEdgeTests {
+
+    private static ServiceProvider Provider(params IDependencyModule[] modules) {
+        var collection = new ServiceCollection();
+
+        collection.AddModules(modules);
+
+        return collection.BuildServiceProvider();
+    }
+
+    /// <summary>
+    /// Decoration declared on the module rather than on the class — the form to use when the
+    /// decorator or the service comes from an assembly you do not control.
+    /// </summary>
+    [Fact]
+    public void ModuleLevelDecorateWrapsAConventionRegistration() {
+        var provider = Provider(new ConventionModuleDecorateModule());
+
+        Assert.Equal("wrapped(core)", provider.GetRequiredService<IModuleDecorated>().Describe());
+    }
+
+    /// <summary>
+    /// Two modules scanning one interface, composed into one application. Convention registrations
+    /// name their declaring module as their realm, so both arrive rather than one displacing the
+    /// other.
+    /// </summary>
+    [Fact]
+    public void TwoModulesScanningOneInterfaceBothContribute() {
+        var names = Provider(new ConventionSharedFirstModule(), new ConventionSharedSecondModule())
+            .GetServices<IShared>()
+            .Select(shared => shared.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(["first", "second"], names);
+    }
+
+    /// <summary>
+    /// A namespace filter reaches the namespaces beneath it, or "MyApp.Order" would not cover
+    /// "MyApp.Order.Handlers".
+    /// </summary>
+    [Fact]
+    public void InNamespaceOfReachesNestedNamespaces() {
+        var names = Provider(new ConventionPrefixNamespaceModule())
+            .GetServices<INamespaceScanned>()
+            .Select(scanned => scanned.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(["nested", "root"], names);
+    }
+
+    /// <summary>And InExactNamespaces is how you say you meant only that one.</summary>
+    [Fact]
+    public void InExactNamespacesExcludesNestedNamespaces() {
+        var names = Provider(new ConventionExactNamespaceModule())
+            .GetServices<INamespaceScanned>()
+            .Select(scanned => scanned.Name)
+            .ToArray();
+
+        Assert.Equal(["root"], names);
+    }
+
+    [Fact]
+    public void NotInNamespaceOfExcludesThatNamespace() {
+        var names = Provider(new ConventionExcludedNamespaceModule())
+            .GetServices<INamespaceScanned>()
+            .Select(scanned => scanned.Name)
+            .ToArray();
+
+        Assert.Equal(["root"], names);
+    }
+
+    /// <summary>
+    /// A generic implementation closing nothing registers as the open generic, and the container
+    /// closes it per request.
+    /// </summary>
+    [Fact]
+    public void AnOpenGenericRegistrationResolvesAtEveryClosing() {
+        var provider = Provider(new ConventionOpenGenericModule());
+
+        Assert.Equal("cache:String", provider.GetRequiredService<IOpenCache<string>>().Describe());
+        Assert.Equal("cache:Int32", provider.GetRequiredService<IOpenCache<int>>().Describe());
+    }
+
+    [Fact]
+    public void ADeclaredScopedLifetimeActuallyScopes() {
+        var provider = Provider(new ConventionLifetimeModule());
+
+        using var first = provider.CreateScope();
+        using var second = provider.CreateScope();
+
+        var one = first.ServiceProvider.GetRequiredService<IScopedByConvention>();
+
+        Assert.Same(one, first.ServiceProvider.GetRequiredService<IScopedByConvention>());
+        Assert.NotSame(one, second.ServiceProvider.GetRequiredService<IScopedByConvention>());
+    }
+
+    /// <summary>
+    /// The container owns what it constructed, however the registration was declared.
+    /// </summary>
+    [Fact]
+    public void AConventionRegisteredSingletonIsDisposedWithTheProvider() {
+        var provider = Provider(new ConventionLifetimeModule());
+        var disposable = provider.GetRequiredService<IDisposableByConvention>();
+
+        Assert.False(disposable.Disposed);
+
+        provider.Dispose();
+
+        Assert.True(disposable.Disposed);
+    }
+
+    /// <summary>
+    /// An internal implementation is a candidate in the compilation being built. The same type in a
+    /// referenced assembly is not, because only public types cross the boundary — a difference
+    /// nothing can report, since it cannot see what it cannot see.
+    /// </summary>
+    [Fact]
+    public void AnInternalImplementationIsACandidateInThisCompilation() {
+        var provider = Provider(new ConventionLifetimeModule());
+
+        Assert.Equal("internal", provider.GetRequiredService<IInternallyImplemented>().Name);
+    }
+
+    /// <summary>
+    /// Decoration passes the wrapped instance positionally and resolves everything else from the
+    /// container, so a decorator's own dependencies can be convention-registered too.
+    /// </summary>
+    [Fact]
+    public void ADecoratorResolvesItsOwnConventionRegisteredDependencies() {
+        var provider = Provider(new ConventionDecoratorDependencyModule());
+
+        Assert.Equal("dep(core)", provider.GetRequiredService<IDependentlyDecorated>().Describe());
+    }
+
+    /// <summary>
+    /// Filters and shapes apply to a metadata scan the same way they apply to local types.
+    /// </summary>
+    [Fact]
+    public void AFilteredMetadataScanRegistersTheConcreteType() {
+        var provider = Provider(new ConventionFilteredScanModule());
+
+        Assert.Equal("first", provider.GetRequiredService<FirstPackagePolicy>().Name);
+
+        // Narrowed by name, and reshaped, so neither the interface nor the other policy is there.
+        Assert.Null(provider.GetService<IPackagePolicy>());
+        Assert.Null(provider.GetService<SecondPackagePolicy>());
+    }
+}

--- a/integ-tests/SutProject.Tests/ConventionTests/ConventionFeatureModules.cs
+++ b/integ-tests/SutProject.Tests/ConventionTests/ConventionFeatureModules.cs
@@ -1,0 +1,293 @@
+using DependencyModules.Conventions;
+using DependencyModules.Runtime.Attributes;
+using SecondarySutProject;
+
+namespace SutProject.Tests.ConventionTests;
+
+// Types and modules for the selection, shape and decoration features, compiled by the real analyzer
+// through MSBuild rather than driven in memory.
+//
+// Every convention here matches at least one type on purpose. A convention that matches nothing is
+// DM0005, a warning, and this solution builds under a zero-warning gate.
+
+// ---------------------------------------------------------------------------
+// Shape: AsSelf, AsSelfWithInterfaces, AlsoAsSelf.
+// ---------------------------------------------------------------------------
+
+public interface IShapeService {
+    string Name { get; }
+}
+
+public interface IAlsoShaped { }
+
+public class SelfShaped : IShapeService {
+    public string Name => "self";
+}
+
+public class CrossWiredShape : IShapeService, IAlsoShaped, IDisposable {
+    public string Name => "crosswired";
+
+    public void Dispose() { }
+}
+
+/// <summary>The only implementor of its interface, so AlsoAsSelf has one match to resolve.</summary>
+public interface IAlsoSelfService { }
+
+public class AlsoSelfShape : IShapeService, IAlsoSelfService {
+    public string Name => "alsoself";
+}
+
+/// <summary>Registers the concrete type instead of the interface.</summary>
+[DependencyModule]
+public partial class ConventionAsSelfModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IShapeService>().AsSelf().AsSingleton();
+    }
+}
+
+/// <summary>
+/// Registers every interface the type reaches, sharing one instance — and skipping IDisposable,
+/// which is reachable but is never what "as its interfaces" means.
+/// </summary>
+[DependencyModule]
+public partial class ConventionCrossWireModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IAlsoShaped>().AsSelfWithInterfaces().AsSingleton();
+    }
+}
+
+/// <summary>Registers the matched interface and the concrete type, sharing one instance.</summary>
+[DependencyModule]
+public partial class ConventionAlsoAsSelfModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IAlsoSelfService>().AlsoAsSelf().AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filters: attribute, name, namespace.
+// ---------------------------------------------------------------------------
+
+/// <summary>Marks a type for the attribute filter.</summary>
+[AttributeUsage(AttributeTargets.Class)]
+public class PolicyAttribute : Attribute { }
+
+public interface IFiltered {
+    string Name { get; }
+}
+
+[Policy]
+public class MarkedRepository : IFiltered {
+    public string Name => "marked";
+}
+
+public class UnmarkedRepository : IFiltered {
+    public string Name => "unmarked";
+}
+
+public class MarkedHelper : IFiltered {
+    public string Name => "helper";
+}
+
+/// <summary>Only the type carrying the attribute.</summary>
+[DependencyModule]
+public partial class ConventionAttributeFilterModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IFiltered>().WithAttribute<PolicyAttribute>().AsSingleton();
+    }
+}
+
+/// <summary>Only the names matching the glob.</summary>
+[DependencyModule]
+public partial class ConventionNameFilterModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IFiltered>().WithName("*Repository").AsSingleton();
+    }
+}
+
+/// <summary>Selected by namespace alone, with no interface to match on.</summary>
+[DependencyModule]
+public partial class ConventionNamespaceModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll()
+            .InNamespaceOf<NamespaceOnlyMarker>()
+            .WithName("NamespaceOnly*")
+            .AsSelf()
+            .AsScoped();
+    }
+}
+
+public class NamespaceOnlyMarker { }
+
+public class NamespaceOnlyCalculator { }
+
+// ---------------------------------------------------------------------------
+// Shape: As<T> and AsMatchingInterface.
+// ---------------------------------------------------------------------------
+
+public interface INamedRoot { }
+
+public interface IRenamer : INamedRoot { }
+
+public class Renamer : IRenamer { }
+
+public interface IExplicitTarget { }
+
+public interface IExplicitSource { }
+
+public class ExplicitlyRegistered : IExplicitSource, IExplicitTarget { }
+
+/// <summary>Registers each match as the interface named after it.</summary>
+[DependencyModule]
+public partial class ConventionMatchingInterfaceModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<INamedRoot>().AsMatchingInterface().AsSingleton();
+    }
+}
+
+/// <summary>Registers every match as one named service type.</summary>
+[DependencyModule]
+public partial class ConventionAsModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IExplicitSource>().As<IExplicitTarget>().AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Registration type and service key.
+// ---------------------------------------------------------------------------
+
+public interface IKeyedService {
+    string Name { get; }
+}
+
+public class KeyedOne : IKeyedService {
+    public string Name => "keyed-one";
+}
+
+/// <summary>Registered under a service key.</summary>
+[DependencyModule]
+public partial class ConventionKeyModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IKeyedService>().WithKey("primary").AsSingleton();
+    }
+}
+
+public interface ITriedService {
+    string Name { get; }
+}
+
+public class TriedOne : ITriedService {
+    public string Name => "one";
+}
+
+public class TriedTwo : ITriedService {
+    public string Name => "two";
+}
+
+/// <summary>Try registers the service type once and skips the second match.</summary>
+[DependencyModule]
+public partial class ConventionUsingModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<ITriedService>().Using(RegistrationType.Try).AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A type filling two roles, and one filling several closings of one interface.
+// ---------------------------------------------------------------------------
+
+public interface IFirstRole { }
+
+public interface ISecondRole { }
+
+public class TwoRoles : IFirstRole, ISecondRole { }
+
+[DependencyModule]
+public partial class ConventionTwoRolesModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IFirstRole>().AsSingleton();
+        conventions.RegisterAll<ISecondRole>().AsScoped();
+    }
+}
+
+public interface INotification<T> { }
+
+public class OrderPlaced { }
+
+public class OrderShipped { }
+
+public class OrderEvents : INotification<OrderPlaced>, INotification<OrderShipped> { }
+
+[DependencyModule]
+public partial class ConventionClosingsModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll(typeof(INotification<>)).AsTransient();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conventions and decorators together — the MediatR shape.
+// ---------------------------------------------------------------------------
+
+public interface IRequestHandler<TRequest, TResponse> {
+    TResponse Handle(TRequest request);
+}
+
+public class CreateThing { }
+
+public class RenameThing { }
+
+public class ThingResult {
+    public string Value { get; set; } = "";
+}
+
+public class CreateThingHandler : IRequestHandler<CreateThing, ThingResult> {
+    public ThingResult Handle(CreateThing request) => new() { Value = "created" };
+}
+
+public class RenameThingHandler : IRequestHandler<RenameThing, ThingResult> {
+    public ThingResult Handle(RenameThing request) => new() { Value = "renamed" };
+}
+
+/// <summary>Records what the decorator saw, so a test can prove it ran.</summary>
+[SingletonService]
+public class HandlerLog {
+    public List<string> Lines { get; } = new();
+}
+
+/// <summary>
+/// One decorator over every handler. It implements the interface it decorates, so a convention
+/// scanning that interface must not match it — it is not a service.
+/// </summary>
+[Decorator]
+public class LoggingRequestHandler<TRequest, TResponse>(
+    IRequestHandler<TRequest, TResponse> inner, HandlerLog log)
+    : IRequestHandler<TRequest, TResponse> {
+
+    public TResponse Handle(TRequest request) {
+        log.Lines.Add("handling " + typeof(TRequest).Name);
+
+        return inner.Handle(request);
+    }
+}
+
+[DependencyModule]
+public partial class ConventionDecoratedHandlerModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll(typeof(IRequestHandler<,>)).AsScoped();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Scanning a referenced assembly, which is the one case with no syntax to read.
+// ---------------------------------------------------------------------------
+
+[DependencyModule]
+public partial class ConventionAssemblyScanModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IPackagePolicy>()
+            .InAssemblyOf<FirstPackagePolicy>()
+            .AsSingleton();
+    }
+}

--- a/integ-tests/SutProject.Tests/ConventionTests/ConventionFeatureTests.cs
+++ b/integ-tests/SutProject.Tests/ConventionTests/ConventionFeatureTests.cs
@@ -1,0 +1,214 @@
+using DependencyModules.Runtime;
+using Microsoft.Extensions.DependencyInjection;
+using SecondarySutProject;
+using Xunit;
+
+namespace SutProject.Tests.ConventionTests;
+
+/// <summary>
+/// The selection, shape and decoration features, compiled by the real analyzer through MSBuild.
+/// </summary>
+/// <remarks>
+/// The generator unit tests drive Roslyn in memory. They cannot show that the analyzer loads from an
+/// ordinary ProjectReference, that both analyzer packages contribute to one partial module without
+/// colliding, or — for <c>InAssemblyOf</c> — that a genuine compile-time assembly reference is what
+/// gets scanned. That is what this file is for.
+/// </remarks>
+public class ConventionFeatureTests {
+
+    private static ServiceProvider Provider(params DependencyModules.Runtime.Interfaces.IDependencyModule[] modules) {
+        var collection = new ServiceCollection();
+
+        collection.AddModules(modules);
+
+        return collection.BuildServiceProvider();
+    }
+
+    private static IServiceCollection Collection(
+        params DependencyModules.Runtime.Interfaces.IDependencyModule[] modules) {
+
+        var collection = new ServiceCollection();
+
+        collection.AddModules(modules);
+
+        return collection;
+    }
+
+    [Fact]
+    public void AsSelfRegistersTheConcreteType() {
+        var provider = Provider(new ConventionAsSelfModule());
+
+        Assert.NotNull(provider.GetService<SelfShaped>());
+        Assert.Null(provider.GetService<IShapeService>());
+    }
+
+    [Fact]
+    public void AsSelfWithInterfacesSharesOneInstanceAndSkipsSystemInterfaces() {
+        var provider = Provider(new ConventionCrossWireModule());
+
+        var asConcrete = provider.GetRequiredService<CrossWiredShape>();
+
+        Assert.Same(asConcrete, provider.GetRequiredService<IAlsoShaped>());
+        Assert.Same(asConcrete, provider.GetRequiredService<IShapeService>());
+
+        // Reachable, but cross-wiring a BCL interface is never what "as its interfaces" means.
+        Assert.Null(provider.GetService<IDisposable>());
+    }
+
+    [Fact]
+    public void AlsoAsSelfRegistersBothAndSharesOneInstance() {
+        var provider = Provider(new ConventionAlsoAsSelfModule());
+
+        var asInterface = provider.GetRequiredService<IAlsoSelfService>();
+        var asConcrete = provider.GetRequiredService<AlsoSelfShape>();
+
+        Assert.Same(asInterface, asConcrete);
+
+        // Only the interfaces the convention matched, not everything the type reaches.
+        Assert.Null(provider.GetService<IShapeService>());
+    }
+
+    [Fact]
+    public void WithAttributeSelectsOnlyMarkedTypes() {
+        var services = Provider(new ConventionAttributeFilterModule())
+            .GetServices<IFiltered>()
+            .Select(service => service.Name)
+            .ToArray();
+
+        Assert.Equal(["marked"], services);
+    }
+
+    [Fact]
+    public void WithNameSelectsOnTheGlob() {
+        var services = Provider(new ConventionNameFilterModule())
+            .GetServices<IFiltered>()
+            .Select(service => service.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(["marked", "unmarked"], services);
+    }
+
+    /// <summary>
+    /// A concrete type with no interface, selected by namespace and name alone.
+    /// </summary>
+    [Fact]
+    public void RegisterAllWithFiltersRegistersTypesThatImplementNothing() {
+        var provider = Provider(new ConventionNamespaceModule());
+
+        Assert.NotNull(provider.GetService<NamespaceOnlyCalculator>());
+        Assert.NotNull(provider.GetService<NamespaceOnlyMarker>());
+    }
+
+    [Fact]
+    public void AsMatchingInterfaceRegistersRenamerAsIRenamer() {
+        var provider = Provider(new ConventionMatchingInterfaceModule());
+
+        Assert.IsType<Renamer>(provider.GetRequiredService<IRenamer>());
+        Assert.Null(provider.GetService<INamedRoot>());
+    }
+
+    [Fact]
+    public void AsRegistersUnderTheNamedServiceType() {
+        var provider = Provider(new ConventionAsModule());
+
+        Assert.IsType<ExplicitlyRegistered>(provider.GetRequiredService<IExplicitTarget>());
+        Assert.Null(provider.GetService<IExplicitSource>());
+    }
+
+    [Fact]
+    public void WithKeyRegistersUnderAServiceKey() {
+        var provider = Provider(new ConventionKeyModule());
+
+        Assert.IsType<KeyedOne>(provider.GetRequiredKeyedService<IKeyedService>("primary"));
+        Assert.Null(provider.GetService<IKeyedService>());
+    }
+
+    [Fact]
+    public void UsingTryRegistersTheServiceTypeOnce() {
+        Assert.Single(
+            Collection(new ConventionUsingModule()),
+            descriptor => descriptor.ServiceType == typeof(ITriedService));
+    }
+
+    /// <summary>
+    /// A type filling two roles registers as both, each with its own lifetime.
+    /// </summary>
+    [Fact]
+    public void ATypeMatchedThroughTwoInterfacesRegistersAsBoth() {
+        var collection = Collection(new ConventionTwoRolesModule());
+
+        Assert.Equal(
+            ServiceLifetime.Singleton,
+            Assert.Single(collection, d => d.ServiceType == typeof(IFirstRole)).Lifetime);
+
+        Assert.Equal(
+            ServiceLifetime.Scoped,
+            Assert.Single(collection, d => d.ServiceType == typeof(ISecondRole)).Lifetime);
+    }
+
+    /// <summary>
+    /// One convention registers every closing a candidate implements. Registering only the first
+    /// left the second silently unregistered.
+    /// </summary>
+    [Fact]
+    public void OneConventionRegistersEveryClosing() {
+        var provider = Provider(new ConventionClosingsModule());
+
+        Assert.IsType<OrderEvents>(provider.GetRequiredService<INotification<OrderPlaced>>());
+        Assert.IsType<OrderEvents>(provider.GetRequiredService<INotification<OrderShipped>>());
+    }
+
+    /// <summary>
+    /// One open generic decorator over every handler a convention registered — the MediatR shape.
+    /// </summary>
+    [Fact]
+    public void ADecoratorWrapsEveryConventionRegisteredHandler() {
+        var provider = Provider(new ConventionDecoratedHandlerModule());
+        var log = provider.GetRequiredService<HandlerLog>();
+
+        var create = provider.GetRequiredService<IRequestHandler<CreateThing, ThingResult>>();
+        var rename = provider.GetRequiredService<IRequestHandler<RenameThing, ThingResult>>();
+
+        Assert.IsType<LoggingRequestHandler<CreateThing, ThingResult>>(create);
+        Assert.IsType<LoggingRequestHandler<RenameThing, ThingResult>>(rename);
+
+        Assert.Equal("created", create.Handle(new CreateThing()).Value);
+        Assert.Equal("renamed", rename.Handle(new RenameThing()).Value);
+
+        Assert.Equal(["handling CreateThing", "handling RenameThing"], log.Lines);
+    }
+
+    /// <summary>
+    /// The decorator is not itself registered. It implements the interface it decorates, so a
+    /// convention scanning that interface would otherwise match it — and being generic and closing
+    /// nothing, it would register as the open generic and make the whole module undecoratable.
+    /// </summary>
+    [Fact]
+    public void ADecoratorIsNotRegisteredAsAService() {
+        var collection = Collection(new ConventionDecoratedHandlerModule());
+
+        Assert.DoesNotContain(collection, descriptor => descriptor.ServiceType.IsGenericTypeDefinition);
+
+        Assert.Equal(
+            2,
+            collection.Count(descriptor =>
+                descriptor.ServiceType.IsGenericType &&
+                descriptor.ServiceType.GetGenericTypeDefinition() == typeof(IRequestHandler<,>)));
+    }
+
+    /// <summary>
+    /// Scanning a genuinely referenced assembly, where there is no syntax to read.
+    /// </summary>
+    [Fact]
+    public void InAssemblyOfRegistersPublicTypesFromTheReferencedAssembly() {
+        var policies = Provider(new ConventionAssemblyScanModule())
+            .GetServices<IPackagePolicy>()
+            .Select(policy => policy.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        // The internal policy in that assembly is invisible across the boundary.
+        Assert.Equal(["first", "second"], policies);
+    }
+}

--- a/integ-tests/SutProject.Tests/ConventionTests/ConventionInteractionModules.cs
+++ b/integ-tests/SutProject.Tests/ConventionTests/ConventionInteractionModules.cs
@@ -1,0 +1,209 @@
+using DependencyModules.Conventions;
+using DependencyModules.Runtime.Attributes;
+using DependencyModules.Runtime.Interception;
+
+namespace SutProject.Tests.ConventionTests;
+
+// Conventions crossed with everything else the library does: interception, decoration with an
+// order, keyed registration, realms, module composition, environment conditions — and the type
+// shapes people actually write, which are not all plain classes.
+//
+// Every convention here matches at least one type on purpose. A convention that matches nothing is
+// DM0005, a warning, and this solution builds under a zero-warning gate.
+
+// ---------------------------------------------------------------------------
+// Conventions and interception. Neither knows about the other; [Intercept] is not a service
+// attribute, so the class stays a convention candidate.
+// ---------------------------------------------------------------------------
+
+/// <summary>Records what the interceptor saw.</summary>
+[SingletonService]
+public class InterceptLog {
+    public List<string> Lines { get; } = new();
+}
+
+[SingletonService]
+public class RecordingInterceptor(InterceptLog log) : IInterceptor {
+    public TResult Intercept<TResult>(InvocationContext<TResult> context) {
+        log.Lines.Add("intercepted " + context.Caller.MemberName);
+
+        return context.Proceed();
+    }
+}
+
+public interface IInterceptedByConvention {
+    string Work();
+}
+
+[Intercept(typeof(RecordingInterceptor))]
+public class InterceptedByConvention : IInterceptedByConvention {
+    public string Work() => "worked";
+}
+
+[DependencyModule]
+public partial class ConventionInterceptModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IInterceptedByConvention>().AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Two decorators with an order, over convention-registered services.
+// ---------------------------------------------------------------------------
+
+public interface IOrdered {
+    string Describe();
+}
+
+public class OrderedCore : IOrdered {
+    public string Describe() => "core";
+}
+
+[Decorator(Order = 10)]
+public class InnerOrdered(IOrdered inner) : IOrdered {
+    public string Describe() => $"inner({inner.Describe()})";
+}
+
+[Decorator(Order = 20)]
+public class OuterOrdered(IOrdered inner) : IOrdered {
+    public string Describe() => $"outer({inner.Describe()})";
+}
+
+[DependencyModule]
+public partial class ConventionOrderedDecoratorModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IOrdered>().AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A keyed convention registration, decorated.
+// ---------------------------------------------------------------------------
+
+public interface IKeyedAndDecorated {
+    string Describe();
+}
+
+public class KeyedCore : IKeyedAndDecorated {
+    public string Describe() => "core";
+}
+
+[Decorator]
+public class KeyedWrapper(IKeyedAndDecorated inner) : IKeyedAndDecorated {
+    public string Describe() => $"wrapped({inner.Describe()})";
+}
+
+[DependencyModule]
+public partial class ConventionKeyedDecoratedModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IKeyedAndDecorated>().WithKey("main").AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Type shapes that are not plain classes: records, nested types, primary constructors.
+// ---------------------------------------------------------------------------
+
+public interface IShaped {
+    string Name { get; }
+}
+
+public record ShapedRecord : IShaped {
+    public string Name => "record";
+}
+
+public record struct NotACandidate;
+
+public class Outer {
+    public class NestedShaped : IShaped {
+        public string Name => "nested";
+    }
+}
+
+public interface IShapedDependency {
+    string Value { get; }
+}
+
+public class ShapedDependency : IShapedDependency {
+    public string Value => "dep";
+}
+
+/// <summary>Primary constructor, injected from another convention registration.</summary>
+public class PrimaryConstructorShaped(IShapedDependency dependency) : IShaped {
+    public string Name => "primary-" + dependency.Value;
+}
+
+[DependencyModule]
+public partial class ConventionShapesModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IShaped>().AsSingleton();
+        conventions.RegisterAll<IShapedDependency>().AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A realm module. OnlyRealm means it takes nothing that did not name it.
+// ---------------------------------------------------------------------------
+
+public interface IRealmScoped {
+    string Name { get; }
+}
+
+public class RealmScoped : IRealmScoped {
+    public string Name => "realm";
+}
+
+[DependencyModule(OnlyRealm = true)]
+public partial class ConventionRealmModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IRealmScoped>().AsSingleton();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A module composed from another. The conventions of a dependency come along with it.
+// ---------------------------------------------------------------------------
+
+public interface IComposedService {
+    string Name { get; }
+}
+
+public class ComposedService : IComposedService {
+    public string Name => "composed";
+}
+
+[DependencyModule]
+public partial class ConventionDependencyModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IComposedService>().AsSingleton();
+    }
+}
+
+/// <summary>Names the module above, so its convention registrations arrive with it.</summary>
+[ConventionDependencyModule]
+[DependencyModule]
+public partial class ConventionCompositionModule;
+
+// ---------------------------------------------------------------------------
+// Environment conditions on convention candidates.
+// ---------------------------------------------------------------------------
+
+public interface IConditionalByConvention {
+    string Name { get; }
+}
+
+public class AlwaysConditional : IConditionalByConvention {
+    public string Name => "always";
+}
+
+[IfEnvironment("Development")]
+public class DevelopmentOnlyConditional : IConditionalByConvention {
+    public string Name => "development";
+}
+
+[DependencyModule]
+public partial class ConventionConditionalModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IConditionalByConvention>().AsSingleton();
+    }
+}

--- a/integ-tests/SutProject.Tests/ConventionTests/ConventionInteractionTests.cs
+++ b/integ-tests/SutProject.Tests/ConventionTests/ConventionInteractionTests.cs
@@ -1,0 +1,135 @@
+using DependencyModules.Runtime;
+using DependencyModules.Runtime.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace SutProject.Tests.ConventionTests;
+
+/// <summary>
+/// Conventions crossed with the rest of the library.
+/// </summary>
+/// <remarks>
+/// Each feature works on its own; what nobody had run is the combinations. Interception and
+/// decoration do not know a service was registered by convention, conventions do not know a
+/// candidate is intercepted, and the type shapes people write are not all plain classes.
+/// </remarks>
+public class ConventionInteractionTests {
+
+    private static ServiceProvider Provider(
+        IModuleEnvironment? environment, params IDependencyModule[] modules) {
+
+        var collection = new ServiceCollection();
+
+        collection.AddModules(environment, modules);
+
+        return collection.BuildServiceProvider();
+    }
+
+    private static ServiceProvider Provider(params IDependencyModule[] modules) =>
+        Provider(null, modules);
+
+    /// <summary>
+    /// A convention-registered service is still intercepted. [Intercept] is not a service
+    /// attribute, so the class stays a candidate, and the two generators have to agree about what
+    /// ends up registered.
+    /// </summary>
+    [Fact]
+    public void AConventionRegisteredServiceIsIntercepted() {
+        var provider = Provider(new ConventionInterceptModule());
+
+        var service = provider.GetRequiredService<IInterceptedByConvention>();
+        var log = provider.GetRequiredService<InterceptLog>();
+
+        Assert.Equal("worked", service.Work());
+        Assert.Equal(["intercepted Work"], log.Lines);
+    }
+
+    /// <summary>
+    /// Two decorators nest by declared order, lower closest to the implementation.
+    /// </summary>
+    [Fact]
+    public void DecoratorsNestByOrderOverAConventionRegistration() {
+        var provider = Provider(new ConventionOrderedDecoratorModule());
+
+        Assert.Equal("outer(inner(core))", provider.GetRequiredService<IOrdered>().Describe());
+    }
+
+    /// <summary>
+    /// Decoration rewrites a keyed registration in place, keeping the key.
+    /// </summary>
+    [Fact]
+    public void AKeyedConventionRegistrationIsDecorated() {
+        var provider = Provider(new ConventionKeyedDecoratedModule());
+
+        Assert.Equal(
+            "wrapped(core)",
+            provider.GetRequiredKeyedService<IKeyedAndDecorated>("main").Describe());
+    }
+
+    /// <summary>
+    /// Records, nested types and primary constructors are all ordinary candidates, and one
+    /// convention registration can be injected into another.
+    /// </summary>
+    [Fact]
+    public void RecordsNestedTypesAndPrimaryConstructorsAreCandidates() {
+        var names = Provider(new ConventionShapesModule())
+            .GetServices<IShaped>()
+            .Select(shaped => shaped.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(["nested", "primary-dep", "record"], names);
+    }
+
+    /// <summary>
+    /// An OnlyRealm module takes its own convention registrations, which name it as their realm.
+    /// </summary>
+    [Fact]
+    public void ARealmModuleTakesItsOwnConventionRegistrations() {
+        var provider = Provider(new ConventionRealmModule());
+
+        Assert.Equal("realm", provider.GetRequiredService<IRealmScoped>().Name);
+    }
+
+    /// <summary>
+    /// Composing a module brings its conventions with it, the same as its attribute registrations.
+    /// </summary>
+    [Fact]
+    public void ComposingAModuleBringsItsConventions() {
+        var provider = Provider(new ConventionCompositionModule());
+
+        Assert.Equal("composed", provider.GetRequiredService<IComposedService>().Name);
+    }
+
+    /// <summary>
+    /// A condition on a convention candidate is honoured. The class carries no service attribute,
+    /// so the convention is its only route into the container — dropping the condition would put a
+    /// development-only service into production.
+    /// </summary>
+    [Theory]
+    [InlineData("Development", new[] { "always", "development" })]
+    [InlineData("Production", new[] { "always" })]
+    public void EnvironmentConditionsApplyToConventionCandidates(
+        string environmentName, string[] expected) {
+
+        var names = Provider(new ModuleEnvironment(environmentName), new ConventionConditionalModule())
+            .GetServices<IConditionalByConvention>()
+            .Select(service => service.Name)
+            .OrderBy(name => name)
+            .ToArray();
+
+        Assert.Equal(expected, names);
+    }
+
+    /// <summary>
+    /// Nothing here registers into another module's realm. Convention registrations name their
+    /// declaring module, so two modules scanning the same interface do not leak into each other.
+    /// </summary>
+    [Fact]
+    public void ConventionRegistrationsDoNotLeakBetweenModules() {
+        var onlyShapes = Provider(new ConventionShapesModule());
+
+        Assert.Empty(onlyShapes.GetServices<IOrdered>());
+        Assert.Empty(onlyShapes.GetServices<IComposedService>());
+    }
+}

--- a/integ-tests/SutProject.Tests/ConventionTests/NestedNamespaceTypes.cs
+++ b/integ-tests/SutProject.Tests/ConventionTests/NestedNamespaceTypes.cs
@@ -1,0 +1,12 @@
+using SutProject.Tests.ConventionTests;
+
+namespace SutProject.Tests.ConventionTests.Nested;
+
+/// <summary>
+/// Lives one namespace below the conventions, so a prefix filter reaches it and an exact one does
+/// not. That difference is the whole point of InExactNamespaces.
+/// </summary>
+public class NestedScanned : INamespaceScanned {
+    /// <inheritdoc />
+    public string Name => "nested";
+}

--- a/src/DependencyModules.Conventions/Utilities/MetadataCandidateUtility.cs
+++ b/src/DependencyModules.Conventions/Utilities/MetadataCandidateUtility.cs
@@ -94,13 +94,43 @@ public static class MetadataCandidateUtility {
     }
 
     /// <summary>
-    /// The metadata counterpart of the syntactic predicate: a constructible public class.
+    /// The metadata counterpart of the syntactic predicate: a constructible public class that has
+    /// not already declared how it is registered.
     /// </summary>
+    /// <remarks>
+    /// The attribute exclusion matters more here than it looks. An assembly whose types carry these
+    /// attributes has its own module and registers them itself, so scanning it as well would
+    /// register everything twice, possibly under a different lifetime — and composing that module is
+    /// what the developer should be doing instead. A decorator is excluded for the same reason it is
+    /// in the compilation being built: it implements the interface it decorates, so a convention
+    /// scanning that interface would match the decorator and register it as a service.
+    /// </remarks>
     private static bool IsCandidate(INamedTypeSymbol type) =>
         type.TypeKind == TypeKind.Class &&
         !type.IsAbstract &&
         !type.IsStatic &&
-        type.DeclaredAccessibility == Accessibility.Public;
+        type.DeclaredAccessibility == Accessibility.Public &&
+        !DeclaresRegistration(type);
+
+    private static bool DeclaresRegistration(INamedTypeSymbol type) {
+        foreach (var attribute in type.GetAttributes()) {
+            var name = attribute.AttributeClass?.Name;
+
+            if (name != null && Array.IndexOf(ExcludedAttributeNames, name) >= 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static readonly string[] ExcludedAttributeNames = {
+        "SingletonServiceAttribute",
+        "ScopedServiceAttribute",
+        "TransientServiceAttribute",
+        "CrossWireServiceAttribute",
+        "DecoratorAttribute",
+    };
 
     private static ConventionCandidateModel BuildCandidate(INamedTypeSymbol type, string assemblyName) {
         var declared = new List<ImplementedInterfaceModel>();

--- a/src/DependencyModules.SourceGenerator.Impl/DecoratorFileWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DecoratorFileWriter.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using CSharpAuthor;
 using DependencyModules.SourceGenerator.Impl.Models;
 using DependencyModules.SourceGenerator.Impl.Utilities;
@@ -38,29 +37,9 @@ public class DecoratorFileWriter {
 
         csharpFile.WriteOutput(outputContext);
 
-        return RecordAware(outputContext.Output(), entryPointModel);
+        return EntryModelUtil.ApplyRecordDeclaration(outputContext.Output(), entryPointModel);
     }
 
-    /// <summary>
-    /// Rewrites the partial declaration when the module is a record.
-    /// </summary>
-    /// <remarks>
-    /// CSharpAuthor has no record class, so every writer that contributes to a module's partial has
-    /// to do this, and DependencyFileWriter and DependencyModuleWriter already did. This one did
-    /// not, so a compilation holding both a record module and any decorator failed to build with
-    /// CS0261 — the decorator file declared the module a class. It went unnoticed because a
-    /// decorator file is only emitted once something in the compilation carries [Decorator].
-    /// </remarks>
-    private static string RecordAware(string output, ModuleEntryPointModel entryPointModel) {
-        if (!entryPointModel.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.IsRecord)) {
-            return output;
-        }
-
-        return Regex.Replace(
-            output,
-            @"partial class " + Regex.Escape(entryPointModel.EntryPointType.Name) + @"(?!\w)",
-            $"partial record class {entryPointModel.EntryPointType.Name}");
-    }
 
     private static void WriteDecorator(
         ModuleEntryPointModel entryPointModel,

--- a/src/DependencyModules.SourceGenerator.Impl/DecoratorFileWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DecoratorFileWriter.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using CSharpAuthor;
 using DependencyModules.SourceGenerator.Impl.Models;
 using DependencyModules.SourceGenerator.Impl.Utilities;
@@ -37,7 +38,28 @@ public class DecoratorFileWriter {
 
         csharpFile.WriteOutput(outputContext);
 
-        return outputContext.Output();
+        return RecordAware(outputContext.Output(), entryPointModel);
+    }
+
+    /// <summary>
+    /// Rewrites the partial declaration when the module is a record.
+    /// </summary>
+    /// <remarks>
+    /// CSharpAuthor has no record class, so every writer that contributes to a module's partial has
+    /// to do this, and DependencyFileWriter and DependencyModuleWriter already did. This one did
+    /// not, so a compilation holding both a record module and any decorator failed to build with
+    /// CS0261 — the decorator file declared the module a class. It went unnoticed because a
+    /// decorator file is only emitted once something in the compilation carries [Decorator].
+    /// </remarks>
+    private static string RecordAware(string output, ModuleEntryPointModel entryPointModel) {
+        if (!entryPointModel.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.IsRecord)) {
+            return output;
+        }
+
+        return Regex.Replace(
+            output,
+            @"partial class " + Regex.Escape(entryPointModel.EntryPointType.Name) + @"(?!\w)",
+            $"partial record class {entryPointModel.EntryPointType.Name}");
     }
 
     private static void WriteDecorator(

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyFileWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyFileWriter.cs
@@ -54,12 +54,7 @@ public class DependencyFileWriter {
 
         var result = output.Output();
 
-        if (entryPointModel.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.IsRecord)) {
-            result = Regex.Replace(
-                result,
-                @"partial class " + Regex.Escape(entryPointModel.EntryPointType.Name) + @"(?!\w)",
-                $"partial record class {entryPointModel.EntryPointType.Name}");
-        }
+        result = EntryModelUtil.ApplyRecordDeclaration(result, entryPointModel);
 
         return result;
     }

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleWriter.cs
@@ -69,12 +69,7 @@ public class DependencyModuleWriter {
 
         var source = outputContext.Output();
 
-        if (entryPointModel.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.IsRecord)) {
-            source = Regex.Replace(
-                source,
-                @"partial class " + Regex.Escape(entryPointModel.EntryPointType.Name) + @"(?!\w)",
-                $"partial record class {entryPointModel.EntryPointType.Name}");
-        }
+        source = EntryModelUtil.ApplyRecordDeclaration(source, entryPointModel);
 
         context.AddSource(
             entryPointModel.EntryPointType.GetFileNameHint(

--- a/src/DependencyModules.SourceGenerator.Impl/InterceptorRegistrationWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/InterceptorRegistrationWriter.cs
@@ -1,3 +1,4 @@
+using DependencyModules.SourceGenerator.Impl.Utilities;
 using CSharpAuthor;
 using DependencyModules.SourceGenerator.Impl.Models;
 using static CSharpAuthor.SyntaxHelpers;
@@ -30,7 +31,7 @@ public class InterceptorRegistrationWriter {
 
         csharpFile.WriteOutput(outputContext);
 
-        return outputContext.Output();
+        return EntryModelUtil.ApplyRecordDeclaration(outputContext.Output(), entryPointModel);
     }
 
     private static void WriteInterceptor(

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/EntryModelUtil.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/EntryModelUtil.cs
@@ -1,10 +1,33 @@
 using System.Collections.Immutable;
 using CSharpAuthor;
+using System.Text.RegularExpressions;
 using DependencyModules.SourceGenerator.Impl.Models;
 
 namespace DependencyModules.SourceGenerator.Impl.Utilities;
 
 public class EntryModelUtil {
+    /// <summary>
+    /// Rewrites a generated partial declaration when the module is a record.
+    /// </summary>
+    /// <remarks>
+    /// CSharpAuthor has no record class, so every writer contributing to a module's partial has to
+    /// do this, and a writer that forgets breaks the build with CS0261 — but only in a compilation
+    /// that has both a record module and whatever makes that writer emit. Two writers had their own
+    /// copy and two did not; the decorator and interceptor files were each found by adding the first
+    /// [Decorator] and the first [Intercept] to a project that happened to contain a record module.
+    /// Shared so the next writer cannot get it wrong.
+    /// </remarks>
+    public static string ApplyRecordDeclaration(string output, ModuleEntryPointModel entryPointModel) {
+        if (!entryPointModel.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.IsRecord)) {
+            return output;
+        }
+
+        return Regex.Replace(
+            output,
+            @"partial class " + Regex.Escape(entryPointModel.EntryPointType.Name) + @"(?!\w)",
+            $"partial record class {entryPointModel.EntryPointType.Name}");
+    }
+
     public static string GenerateFileName(ModuleEntryPointModel entryPointModel, string uniquePortion) {
         var namespaceName = entryPointModel.EntryPointType.Namespace;
         if (string.IsNullOrEmpty(entryPointModel.EntryPointType.Namespace)) {

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -1392,6 +1392,7 @@ namespace DependencyModules.SourceGenerator.Impl.Utilities
     public class EntryModelUtil
     {
         public EntryModelUtil() { }
+        public static string ApplyRecordDeclaration(string output, DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel) { }
         [return: System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "uniqueEntryPoints",
                 "configurationModel"})]


### PR DESCRIPTION
Thirty-five integration tests for convention registration, compiled by the analyzer **through MSBuild** rather than driven in memory — plus three defects they surfaced.

The generator unit tests cannot show that the analyzer loads from an ordinary `ProjectReference`, that both analyzer packages contribute to one partial module without colliding, or — for `InAssemblyOf` — that a genuine compile-time assembly reference is what gets scanned.

## Three defects, none reachable from the unit tests

**A decorator file declared a record module a class, and so did an interceptor file.** Four writers contribute to a module's partial. Two carried their own copy of the record rewrite and two did not, so a compilation with a record module *and* a `[Decorator]` failed with `CS0261` — and separately with an `[Intercept]`. Each missing copy only breaks a compilation that has both a record module and whatever makes that writer emit, which is why finding two instances took two separate discoveries. Now `EntryModelUtil.ApplyRecordDeclaration`, called by all four, so the next writer cannot get it wrong. That one-line public API addition is the whole API snapshot diff.

**A metadata scan re-registered a package's own services.** `MetadataCandidateUtility` checked only that a type was a constructible public class, where the syntax path also excludes types carrying a service attribute. An assembly whose types carry those attributes has its own module and registers them itself, so scanning it as well registers everything twice, possibly under a different lifetime — and composing that module is what the developer should be doing instead. `[Decorator]` is excluded for the same reason it is in the compilation being built.

## What is covered

**Features** — `AsSelf` · `AsSelfWithInterfaces` including the `System.*` exclusion · `AlsoAsSelf` · `WithAttribute` · `WithName` · `RegisterAll()` selecting a type that implements nothing · `AsMatchingInterface` · `As<T>` · `WithKey` · `Using(Try)` · a type filling two roles with a lifetime each · one convention registering every closing · an open generic decorator over every convention-registered handler · `InAssemblyOf` against a real referenced assembly.

**Combinations** — a convention-registered service that is also intercepted · two decorators nesting by `Order` · a keyed registration decorated in place · records, nested types and primary constructors as candidates · an `OnlyRealm` module · module composition carrying its conventions · environment conditions on candidates in both environments · registrations not leaking between modules.

**Corners** — module-level `[Decorate]` · two modules scanning one interface, composed together · namespace filters reaching nested namespaces, the exact form refusing to, and the negative form · an open generic resolved at two closings · scoped actually scoping · disposal with the provider · an `internal` implementation as a candidate, which it is in this compilation and is not across an assembly boundary · a decorator resolving its own convention-registered dependencies · a filtered metadata scan reshaped with `AsSelf`.

## The referenced-assembly tests

`SecondarySutProject` gains three policy types and no attributes. It does not reference the conventions analyzer, so they are inert until something scans them — which is what a third-party package looks like. One is `internal`, pinning the visibility difference.

## Verification

- `dotnet build -c Release --no-incremental` — **0 warnings**
- `./scripts/coverage.sh 85` — **633 tests pass, 87.5% coverage**
- `./scripts/verify-packages.sh` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C56x6Vv6HJ6ArfqwKsuSb9