### PR TITLE
Documentation site

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,62 @@
+name: docs
+
+# Publishes the VitePress site in website/ to GitHub Pages.
+#
+# Pages has to be switched on once, by hand: Settings → Pages → Source → GitHub Actions. Until then
+# this workflow builds successfully and the deploy step fails, which is the right way round — a
+# broken site never replaces a working one.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One deployment at a time, and let a newer commit win rather than queueing behind an older one.
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - run: npm ci
+
+      # Dead internal links fail the build rather than shipping. The pages cross-reference heavily
+      # and a rename would otherwise rot links silently.
+      - run: npm run build
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,8 @@ artifacts/
 # Session working notes. Scratch for picking work up in a fresh session, not
 # project documentation — what is worth keeping belongs in docs/design.
 docs/HANDOFF.md
+
+# VitePress
+website/node_modules/
+website/.vitepress/dist/
+website/.vitepress/cache/

--- a/README.md
+++ b/README.md
@@ -269,10 +269,12 @@ serviceCollection.AddModule<ApplicationModule>();
 DependencyModules provides an xUnit extension to make testing much easier. 
 It handles the population and construction of a service provider using specified modules.
 
-```csharp
-> dotnet add package DependencyModules.xUnit
-> dotnet add package DependencyModules.xUnit.NSubstitute
+```shell
+dotnet add package DependencyModules.xUnit
+dotnet add package DependencyModules.xUnit.NSubstitute
+```
 
+```csharp
 // applies module & nsubstitute support to all tests.
 // test attributes can be applied at the assembly, class, and test method level
 [assembly: MyModule]
@@ -287,7 +289,7 @@ public class OtherServiceTests
      Assert.Equals("some mock value", test.SomeProp);
   }
 }
-
+```
 
 ## Reporting a problem
 
@@ -308,8 +310,6 @@ needed to diagnose it:
 
 Please include the log and the generated file in any [issue](https://github.com/ipjohnson/DependencyModules/issues).
 
-
-```
 ## Implementation
 
 Behind the scenes the library generates registration code that can be used with any `IServiceCollection` compatible DI container.

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -1,0 +1,121 @@
+import { defineConfig } from 'vitepress';
+
+// Published to https://ipjohnson.github.io/DependencyModules/, so every absolute path needs the
+// repository name as a base. Getting this wrong is the classic Pages failure: the site builds, the
+// landing page loads, and every asset and internal link 404s.
+const base = '/DependencyModules/';
+
+export default defineConfig({
+  title: 'DependencyModules',
+  description:
+    'Compile-time dependency injection for .NET. Attributes and conventions become registration ' +
+    'code at build time — no reflection, no assembly scanning, trimming and Native AOT safe.',
+  base,
+  lang: 'en-GB',
+  cleanUrls: true,
+
+  // A broken internal link should fail the build rather than ship. The docs cross-reference heavily
+  // and a rename would otherwise rot links silently.
+  ignoreDeadLinks: false,
+
+  head: [
+    ['link', { rel: 'icon', href: `${base}favicon.svg`, type: 'image/svg+xml' }],
+    ['meta', { name: 'theme-color', content: '#6d5bd5' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    ['meta', { property: 'og:title', content: 'DependencyModules' }],
+    [
+      'meta',
+      {
+        property: 'og:description',
+        content: 'Compile-time dependency injection for .NET. No reflection, AOT safe.',
+      },
+    ],
+  ],
+
+  themeConfig: {
+    siteTitle: 'DependencyModules',
+
+    nav: [
+      { text: 'Guide', link: '/guide/getting-started', activeMatch: '/guide/' },
+      { text: 'Reference', link: '/reference/diagnostics', activeMatch: '/reference/' },
+      {
+        text: 'NuGet',
+        items: [
+          { text: 'Runtime', link: 'https://www.nuget.org/packages/DependencyModules.Runtime/' },
+          {
+            text: 'SourceGenerator',
+            link: 'https://www.nuget.org/packages/DependencyModules.SourceGenerator/',
+          },
+          {
+            text: 'Conventions',
+            link: 'https://www.nuget.org/packages/DependencyModules.Conventions/',
+          },
+          { text: 'xUnit', link: 'https://www.nuget.org/packages/DependencyModules.xUnit/' },
+        ],
+      },
+    ],
+
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Getting started',
+          items: [
+            { text: 'Installation', link: '/guide/getting-started' },
+            { text: 'Modules', link: '/guide/modules' },
+            { text: 'Registering services', link: '/guide/services' },
+          ],
+        },
+        {
+          text: 'Registering in bulk',
+          items: [
+            { text: 'Conventions', link: '/guide/conventions' },
+            { text: 'Scanning a package', link: '/guide/scanning' },
+          ],
+        },
+        {
+          text: 'Changing behaviour',
+          items: [
+            { text: 'Decorators', link: '/guide/decorators' },
+            { text: 'Interception', link: '/guide/interception' },
+            { text: 'Environments', link: '/guide/environments' },
+          ],
+        },
+        {
+          text: 'Everything else',
+          items: [
+            { text: 'Testing', link: '/guide/testing' },
+            { text: 'Trimming and AOT', link: '/guide/aot' },
+            { text: 'Troubleshooting', link: '/guide/troubleshooting' },
+          ],
+        },
+      ],
+      '/reference/': [
+        {
+          text: 'Reference',
+          items: [
+            { text: 'Diagnostics', link: '/reference/diagnostics' },
+            { text: 'Attributes', link: '/reference/attributes' },
+            { text: 'Convention API', link: '/reference/conventions-api' },
+            { text: 'MSBuild properties', link: '/reference/msbuild' },
+          ],
+        },
+      ],
+    },
+
+    socialLinks: [{ icon: 'github', link: 'https://github.com/ipjohnson/DependencyModules' }],
+
+    search: { provider: 'local' },
+
+    editLink: {
+      pattern: 'https://github.com/ipjohnson/DependencyModules/edit/main/website/:path',
+      text: 'Edit this page on GitHub',
+    },
+
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'Copyright © Ian Johnson',
+    },
+
+    outline: [2, 3],
+  },
+});

--- a/website/guide/aot.md
+++ b/website/guide/aot.md
@@ -1,0 +1,59 @@
+# Trimming and Native AOT
+
+This is the reason the library exists in the shape it does, so it is worth being precise about what
+survives and what does not.
+
+## The problem with scanning at run time
+
+A reflection-based scanner enumerates an assembly's types when the application starts. The trimmer
+cannot follow that: it has no way to know those types are needed, so it removes them, and the scan
+finds nothing. The failure appears at startup in a published build and never in development.
+
+## What happens here instead
+
+The same work happens during the build, and each match is emitted as a literal `typeof()` into your
+assembly:
+
+```csharp
+services.AddScoped(typeof(IHandler<CreateOrder, OrderId>), typeof(CreateOrderHandler));
+```
+
+Two things follow, and the second matters more than people expect.
+
+**The trimmer roots the type**, because a `typeof()` in your code is an ordinary static reference.
+
+**The constructor survives too.** `ServiceDescriptor`'s implementation-type parameter carries
+`[DynamicallyAccessedMembers(PublicConstructors)]`. That annotation can only flow to a type the
+compiler knows about — which is exactly what a literal `typeof()` gives it, and exactly what a type
+discovered at run time does not.
+
+Neither works when the type is only discovered at run time. **The capability that breaks a
+reflection-based scanner is the capability that works here**, including for
+[types in a referenced package](/guide/scanning).
+
+## What this covers
+
+- Attribute registration
+- Conventions, including open generics and referenced-assembly scanning
+- Decorators and interception — the wrapper is generated code in your assembly
+
+## What it does not cover
+
+**Environment conditions decide behaviour, not size.** The test runs at run time, so both branches
+are compiled and every conditionally registered type stays referenced. Removing a service from a
+build is a compile-time decision and belongs to `#if`.
+
+**Open generic registration is the least AOT-friendly part of the container itself**, independent of
+this library. If you are targeting Native AOT aggressively, prefer closed registrations.
+
+**Runtime assembly discovery is not offered.** Scrutor's `FromApplicationDependencies()`,
+`FromDependencyContext()` and `FromAssemblyDependencies()` load libraries by name at run time. There
+is no compile-time answer, so those are deliberately absent rather than approximated — see
+[Scanning a package](/guide/scanning).
+
+## The generator never ships
+
+The analyzer packages contain no `lib/` folder, so they cannot reach your output, and
+`DevelopmentDependency=true` stops them flowing transitively to anything that references your
+library. Only `DependencyModules.Runtime` is a run-time dependency, and it holds interfaces,
+attributes and a small registry — no Roslyn, no reflection over your types.

--- a/website/guide/conventions.md
+++ b/website/guide/conventions.md
@@ -1,0 +1,287 @@
+# Conventions
+
+Attributes are explicit, and explicit stops being a virtue somewhere around the fortieth handler.
+Conventions let a module say *what* to register once, and the generator works out which types fit
+while it builds.
+
+```csharp
+[DependencyModule]
+public partial class DataModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IRepository>().AsScoped();
+        conventions.RegisterAll(typeof(IRequestHandler<,>)).AsTransient();
+    }
+}
+```
+
+::: tip Install
+Conventions ship in their own analyzer package, so a project that does not use them never loads the
+class-scanning providers.
+
+```shell
+dotnet add package DependencyModules.Conventions
+```
+:::
+
+## The body never runs
+
+This is the one thing worth understanding before anything else. `Conventions` is **read** at compile
+time, not executed. The generator parses the calls out of your source, resolves the matching types,
+and emits ordinary registrations. Nothing implements `IConventionDefinitions` at run time and the
+method is never called.
+
+That has two consequences.
+
+**Only the declared calls may appear in it.** A loop, a conditional, a local variable or a call to
+your own helper cannot be evaluated during a build, so they are reported as
+[DM0009](/reference/diagnostics#dm0009) rather than quietly ignored.
+
+**You get the same output as writing it by hand.** There is no convention engine at run time, no
+registration strategy to configure. `EmitCompilerGeneratedFiles` will show you `services.AddScoped(…)`
+calls, one per match.
+
+## Why the interface name appears twice
+
+```csharp
+public partial class DataModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) { }
+    // ^^^^^^^^^^^^^^^^^^ explicit implementation
+}
+```
+
+`IConventionDefinitions` is emitted `internal` into your compilation, so an implicit
+`public void Conventions(…)` is `CS0051: Inconsistent accessibility`. Explicit implementation is the
+only shape that compiles.
+
+Emitting the contract `internal` keeps it off your public API surface, and it means two assemblies
+that both use conventions do not collide on the same type names.
+
+## What matches
+
+A type matches when it **declares** the service type, or declares an interface that extends it:
+
+```csharp
+public interface IAuditedRepository : IRepository { }
+
+public class OrderRepository  : IRepository { }          // matches
+public class AuditedOrders    : IAuditedRepository { }   // matches — IAuditedRepository extends IRepository
+```
+
+An interface saying it extends another is a deliberate statement that it is substitutable for it,
+so it counts.
+
+Reaching the service type through a **base class** does not, unless you ask:
+
+```csharp
+public abstract class RepositoryBase : IRepository { }
+public class ProductRepository : RepositoryBase { }      // no match by default
+
+conventions.RegisterAll<IRepository>().IncludeBaseClasses().AsScoped();   // now it matches
+```
+
+Extending a class is a statement about implementation reuse rather than about the contract, and
+every subclass added years later would otherwise join the convention with nobody revisiting it. It
+is an opt-in because the common `CreateOrderValidator : AbstractValidator<CreateOrder>` shape needs
+it and because silently inheriting registration is worse than typing one call.
+
+::: info Attributes always win
+A type carrying `[SingletonService]`, `[ScopedService]`, `[TransientService]` or `[CrossWireService]`
+is never a convention candidate. Neither is a `[Decorator]` — a decorator implements the interface
+it decorates, and it is not a service.
+:::
+
+## Open generics
+
+`typeof(IHandler<,>)` cannot be written as a type argument, which is why there is a `Type` overload.
+Each match registers against the **closed** construction it actually implements:
+
+```csharp
+public class CreateOrderHandler : IRequestHandler<CreateOrder, OrderId> { }
+public class RenameOrderHandler : IRequestHandler<RenameOrder, OrderId> { }
+
+conventions.RegisterAll(typeof(IRequestHandler<,>)).AsTransient();
+```
+
+```csharp
+// generated
+services.AddTransient(typeof(IRequestHandler<CreateOrder, OrderId>), typeof(CreateOrderHandler));
+services.AddTransient(typeof(IRequestHandler<RenameOrder, OrderId>), typeof(RenameOrderHandler));
+```
+
+A type implementing **several** closings registers against all of them:
+
+```csharp
+public class OrderEvents
+    : INotificationHandler<OrderPlaced>, INotificationHandler<OrderShipped> { }
+```
+
+Both are registered. They are different service types, so this is not the same implementation
+appearing twice.
+
+A generic implementation that closes nothing registers as the open generic, and the container closes
+it per request:
+
+```csharp
+public class PassThroughCache<T> : ICache<T> { }   // registers ICache<> itself
+```
+
+## Narrowing what matches
+
+Filters chain, and combine with **and**. Alternatives go inside a single call.
+
+```csharp
+conventions.RegisterAll<IRepository>()
+    .InNamespaceOf<OrderMarker>()          // and in this namespace or below it
+    .WithoutName("*Legacy")                // and not named like this
+    .WithAttribute<AuditedAttribute>()     // and carrying this attribute
+    .AsScoped();
+```
+
+| Filter | Matches |
+|---|---|
+| `InNamespaceOf<TMarker>()` | the marker's namespace **and those beneath it** |
+| `InNamespaces(params string[])` | the given namespaces and those beneath them |
+| `InExactNamespaces(params string[])` | only those namespaces, not nested ones |
+| `NotInNamespaceOf<TMarker>()`, `NotInNamespaces(…)` | excludes; applied after inclusions |
+| `WithAttribute<T>()`, `WithoutAttribute<T>()` | the attribute type, resolved rather than name-matched |
+| `WithName(params string[])`, `WithoutName(…)` | name globs — see below |
+
+Namespace and name inclusions of the same kind combine with **or**; exclusions are applied afterwards
+and any one of them removes a match.
+
+### Name globs
+
+Two wildcards and no regular expressions:
+
+| Token | Matches |
+|---|---|
+| `*` | zero or more characters |
+| `?` | exactly one character |
+
+A pattern containing a dot is matched against the full `Namespace.TypeName`; otherwise against the
+bare type name. Matching is ordinal and case-sensitive, like C# identifiers.
+
+```csharp
+conventions.RegisterAll<IRepository>().WithName("*Repository", "*Store").AsScoped();
+```
+
+Name globbing is the weakest selector here and is listed last deliberately. It is the one most likely
+to match something nobody intended when a class is added years later — prefer a service type, an
+attribute, or a namespace.
+
+## Registering types that implement nothing
+
+`RegisterAll()` with no service type selects by filter alone. It is how a concrete class that
+implements no interface gets registered by convention:
+
+```csharp
+conventions.RegisterAll()
+    .InNamespaceOf<OrderMarker>()
+    .WithName("*Calculator")
+    .AsSelf()
+    .AsScoped();
+```
+
+It requires a shape — there is nothing to register the matches *as* otherwise — and at least one
+filter. Without a filter it would match every class in the compilation, which is never what anybody
+means, so it is reported rather than obeyed.
+
+## What each match is registered as
+
+| Call | Registers |
+|---|---|
+| *(default)* | the service type the convention matched |
+| `AsSelf()` | the match's own concrete type, instead of the interface |
+| `AlsoAsSelf()` | the matched service type **and** the concrete type, sharing one instance |
+| `AsSelfWithInterfaces()` | the concrete type and **every** interface it implements, sharing one instance |
+| `AsMatchingInterface()` | the interface named after the type — `Foo` as `IFoo` |
+| `As<TService>()` | one named service type, whatever the match matched through |
+
+### One instance or several
+
+This is the distinction that catches people out with every scanning library.
+
+```csharp
+conventions.RegisterAll<IFoo>().AsSingleton();          // one registration
+conventions.RegisterAll<IBar>().AsSingleton();          // another, same class
+```
+
+A class matched through two different interfaces gets **two registrations and two instances**, which
+is what Scrutor and MediatR both produce and is usually what you want for handlers.
+
+When you want one instance reachable through several service types, say so:
+
+```csharp
+conventions.RegisterAll(typeof(IValidator<>)).IncludeBaseClasses().AlsoAsSelf().AsScoped();
+```
+
+`AlsoAsSelf()` and `AsSelfWithInterfaces()` both cross-wire: resolving any of the registered service
+types gives the same instance. The difference is reach — `AlsoAsSelf()` registers only the interfaces
+the convention matched, `AsSelfWithInterfaces()` registers everything the type implements.
+
+::: warning AsSelfWithInterfaces skips System interfaces
+Interfaces declared in `System` or a namespace beginning `System.` are not expanded into. Without
+that, any type whose base implements `IDisposable` would become resolvable *as* `IDisposable`, and a
+FluentValidation validator would become resolvable as `IEnumerable<IValidationRule>`.
+
+It applies only to the expansion. A service type you named yourself is always honoured, so
+`RegisterAll<IDisposable>()` still registers `IDisposable`.
+:::
+
+## Lifetime, keys and registration strategy
+
+A lifetime is required. There is no default, because a lifetime nobody wrote down is the most
+expensive thing for a registration to get wrong — omitting one is
+[DM0009](/reference/diagnostics#dm0009).
+
+```csharp
+conventions.RegisterAll<IRepository>()
+    .AsScoped()
+    .Using(RegistrationType.Try)     // Add, Try, TryEnumerable or Replace
+    .WithKey("primary");             // literal, const or enum member
+```
+
+## When two conventions collide
+
+Two conventions in one module that would register the same implementation under the **same service
+type** is [DM0004](/reference/diagnostics#dm0004), an error. One lifetime has to win and the source
+does not say which.
+
+```csharp
+conventions.RegisterAll<IRepository>().AsScoped();
+conventions.RegisterAll<IRepository>().AsSingleton();   // DM0004
+```
+
+A type filling two *different* roles is not a collision, and registers as both:
+
+```csharp
+public class OrderEvents : INotificationHandler<OrderPlaced>, IRequestPreProcessor<ShipOrder> { }
+
+conventions.RegisterAll(typeof(INotificationHandler<>)).AsTransient();
+conventions.RegisterAll(typeof(IRequestPreProcessor<>)).AsTransient();   // fine
+```
+
+Conventions in *different* modules never collide — each registers into its own realm.
+
+## What conventions will not do
+
+Every Scrutor overload that takes a lambda — `Where(Func<Type,bool>)`,
+`AsImplementedInterfaces(predicate)`, `WithLifetime(Func<Type,ServiceLifetime>)` — has no
+compile-time equivalent. A generator cannot run your code over the types it is describing.
+
+The escape hatch is a normal method, and it composes with everything above:
+
+```csharp
+[DependencyModule]
+public partial class DataModule : IServiceCollectionConfiguration {
+    public void ConfigureServices(IServiceCollection services) {
+        // unrestricted access to IServiceCollection, at run time
+    }
+}
+```
+
+## Next
+
+- [Scanning a package](/guide/scanning) — matching types in a referenced assembly
+- [Convention API reference](/reference/conventions-api) — every call in one table
+- [Diagnostics](/reference/diagnostics) — what each DM code means

--- a/website/guide/decorators.md
+++ b/website/guide/decorators.md
@@ -1,0 +1,130 @@
+# Decorators
+
+A decorator wraps a registered service with a type you write. You get real signatures, real
+parameter names, and no generics gymnastics — which is what makes it the right tool when you want to
+do something specific to one member.
+
+```csharp
+public interface IRepository { Item Get(int id); }
+
+[SingletonService]
+public class SqlRepository : IRepository {
+    public Item Get(int id) => /* … */;
+}
+
+[Decorator]
+public class CachingRepository(IRepository inner, IMemoryCache cache) : IRepository {
+    public Item Get(int id) => cache.GetOrCreate(id, _ => inner.Get(id))!;
+}
+```
+
+Resolving `IRepository` now gives you `CachingRepository` wrapping `SqlRepository`.
+
+## How it is wired
+
+The **first constructor parameter is the wrapped instance**; every other parameter is resolved from
+the container. You never register the decorator yourself — `[Decorator]` is enough, and the
+decorator is not registered as a service in its own right.
+
+That last part matters with [conventions](/guide/conventions): a decorator implements the interface
+it decorates, so a convention scanning that interface would otherwise match the decorator too.
+`[Decorator]` takes it out of convention matching for exactly that reason.
+
+## Ordering
+
+Decorators are sorted across **every module** in an `AddModule(s)` call, not just within the module
+that declared them. Lower orders sit closer to the implementation; higher ones wrap them.
+
+```csharp
+[Decorator(Order = 10)] public class Retrying(IRepository inner) : IRepository { }
+[Decorator(Order = 20)] public class Logging(IRepository inner)  : IRepository { }
+
+// resolves as Logging(Retrying(SqlRepository))
+```
+
+By convention framework packages use 0–999 and application code 1000 and above, so an application's
+decorators wrap those contributed by the libraries it consumes.
+
+Two decorators of one service sharing an order is [DM0007](/reference/diagnostics#dm0007) — the
+nesting would be unpredictable from reading the source.
+
+## Open generics
+
+One decorator can wrap every closed registration of an open generic. This is the shape that makes
+cross-cutting behaviour over MediatR handlers or FluentValidation validators a single declaration:
+
+```csharp
+[Decorator]
+public class LoggingHandler<TRequest, TResponse>(
+    IRequestHandler<TRequest, TResponse> inner, ILogger log)
+    : IRequestHandler<TRequest, TResponse> {
+
+    public TResponse Handle(TRequest request) {
+        log.LogInformation("handling {Request}", typeof(TRequest).Name);
+        return inner.Handle(request);
+    }
+}
+```
+
+Combined with a convention, that is the whole setup:
+
+```csharp
+conventions.RegisterAll(typeof(IRequestHandler<,>)).AsScoped();
+```
+
+Every handler is registered and every handler is wrapped.
+
+## Decorating from the module
+
+When the service, the decorator, or both come from an assembly you do not control, there is nowhere
+to put `[Decorator]`. Declare it on the module instead:
+
+```csharp
+[DependencyModule]
+[Decorate(typeof(IRepository), typeof(CachingRepository), Order = 100)]
+public partial class DataModule;
+```
+
+## Ordering relative to services
+
+Decoration runs as a distinct phase **after** every module's registrations, so a decorator sees
+everything registered by every module in the call. You do not have to sequence anything, which is
+the main difference from `Decorate()` in Scrutor.
+
+The contract is worth stating precisely: a decorator sees the services registered by the modules in
+its `AddModule(s)` call. Anything the application registers afterwards is outside that scope, which
+is inherent to `IServiceCollection` — decoration rewrites descriptors, so it can only see
+descriptors that exist.
+
+## One limitation
+
+A service **registered as an open generic** — a single generic implementation serving every closing
+— cannot be decorated:
+
+```csharp
+[SingletonService]
+public class Repository<T> : IRepository<T> { }   // registers IRepository<> itself
+
+[Decorator]
+public class CachingRepository<T>(IRepository<T> inner) : IRepository<T> { }
+```
+
+```
+InvalidOperationException: 'IRepository`1' is registered as an open generic and cannot be
+decorated by 'CachingRepository`1'. …
+```
+
+Decoration replaces a registration with a factory, and the container does not allow a factory for an
+open generic service type. Register closed constructions instead.
+
+Note this is about the *registration*, not the decorator. An open generic decorator over closed
+registrations — the example further up — works and is the common case.
+
+## Decorator or interceptor?
+
+|  | Decorator | [Interception](/guide/interception) |
+|---|---|---|
+| Who writes the wrapper | you | the generator, every member |
+| Applies to | one interface | many unrelated services |
+| Member access | real signatures | uniform, `TResult` and `IArguments` |
+| Reach for it when | caching *this* method, validating *that* one | logging, timing, retry, tracing |

--- a/website/guide/environments.md
+++ b/website/guide/environments.md
@@ -1,0 +1,144 @@
+# Environments
+
+A registration can depend on the environment the application is running in.
+
+```csharp
+[SingletonService]
+[IfEnvironment("Development", "Staging")]
+public class FakeEmailSender : IEmailSender { }
+
+[SingletonService]
+[IfNotEnvironment("Development")]
+public class SmtpEmailSender : IEmailSender { }
+```
+
+Resolve `IEmailSender` and you get whichever one the environment selected.
+
+## The attributes
+
+| Attribute | Registers when |
+|---|---|
+| `[IfEnvironment(params string[])]` | the environment name matches any of them |
+| `[IfNotEnvironment(params string[])]` | it matches none of them |
+| `[IfEnvironmentValue(key)]` | the environment has any value for the key |
+| `[IfEnvironmentValue(key, value)]` | the value equals exactly |
+| `[IfNotEnvironmentValue(…)]` | the inverse of either form |
+
+Conditions of **different kinds** combine with **and**. Alternatives go inside one attribute, which
+is why `IfEnvironment` takes `params` and is not `AllowMultiple` — two of them could never both hold.
+
+```csharp
+[SingletonService]
+[IfNotEnvironment("Production")]
+[IfEnvironmentValue("FEATURE_PROFILING", "on")]
+public class RequestProfiler : IProfiler { }
+```
+
+Environment **names** compare case-insensitively, matching `IHostEnvironment.IsDevelopment()`.
+**Values** compare ordinally, because a value is data rather than a well-known label.
+
+## Where the environment comes from
+
+There is always one, and it is never null.
+
+```csharp
+services.AddModules(new ModuleEnvironment("Development"), new ApplicationModule());
+```
+
+Supply nothing and you get `ModuleEnvironment.Default`, which reads the process:
+`ASPNETCORE_ENVIRONMENT`, then `DOTNET_ENVIRONMENT`, then `"Production"`. Values come from
+environment variables, read on each call rather than captured.
+
+That means `[IfEnvironment("Development")]` works with nothing wired up beyond the variable you
+already set, and the `"Production"` default means a service gated on a non-production environment
+stays unregistered unless something says otherwise.
+
+`ModuleEnvironment.None` says this application has no environment — a real object with an empty name
+and no values, rather than a null to branch on.
+
+Whatever is used is **registered**, so `GetRequiredService<IModuleEnvironment>()` returns the same
+environment that decided the registrations.
+
+::: warning Register an instance, not a type
+The environment is read while the collection is still being populated, before any provider exists,
+so only a singleton **instance** can be used.
+
+```csharp
+services.AddSingleton<IModuleEnvironment>(new ModuleEnvironment("Staging"));   // works
+services.AddSingleton<IModuleEnvironment, MyEnvironment>();                    // throws
+```
+
+Registering by type or factory is refused with a message naming the fix, rather than silently
+falling back to the process default.
+:::
+
+An environment passed to `AddModules` **replaces** one already in the collection rather than joining
+it. The environment answers a single question and several would need a rule for which one wins. To
+layer one on another, read the existing one and combine before you call:
+
+```csharp
+var existing = services.FirstOrDefault(d => d.ServiceType == typeof(IModuleEnvironment))
+    ?.ImplementationInstance as IModuleEnvironment;
+
+services.AddModules(Combine(existing ?? ModuleEnvironment.Default, overlay), modules);
+```
+
+## Ordering
+
+A conditional registration is emitted **after** the unconditional ones in its module, so it can
+override a default:
+
+```csharp
+[SingletonService]                                  public class SmtpEmailSender : IEmailSender { }
+[SingletonService] [IfEnvironment("Development")]    public class FakeEmailSender : IEmailSender { }
+```
+
+In Development the fake wins, because the container resolves a single service from the last matching
+descriptor.
+
+Across modules, **module order decides** — a referenced module's conditional registration does not
+override the module that references it. A condition says "instead of my other registration", not
+"instead of yours".
+
+::: info Try is first-wins
+`Using(RegistrationType.Try)` is first-wins rather than last-wins, so a conditional `Try` cannot
+override an unconditional one. The override pattern wants `Add`, which is the default.
+:::
+
+## Conditions and conventions
+
+A class matched by a convention honours its conditions too. A class carrying a service attribute is
+never a convention candidate, so a condition on a convention-matched class has no other route — and
+dropping it would put a development-only service into production.
+
+## What conditions cost
+
+The test runs at run time, so **both branches are compiled and every conditionally registered type
+stays referenced**. Conditions change what is registered, not what ships. Trimming a service out of a
+build is a compile-time decision and belongs to `#if`.
+
+## Seeing it at build time
+
+Whether a condition holds is a run-time question, so there is no build error for the ordinary case.
+[DM0011](/reference/diagnostics#dm0011) reports what each conditional registration depends on, so
+the condition is visible where you are already looking.
+
+A condition that names nothing to test — `[IfEnvironment()]`, `[IfEnvironmentValue("")]` — is
+[DM0012](/reference/diagnostics#dm0012).
+
+## Programmatic access
+
+For registration that needs the environment but is not a simple condition:
+
+```csharp
+[DependencyModule]
+public partial class ApplicationModule : IEnvironmentServiceCollectionConfiguration {
+    public void ConfigureServices(IServiceCollection services, IModuleEnvironment environment) {
+        if (environment.Value("REGION") == "eu") {
+            services.AddSingleton<IStorage, EuStorage>();
+        }
+    }
+}
+```
+
+It receives the same non-null environment the attributes are evaluated against.

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -1,0 +1,91 @@
+# Getting started
+
+DependencyModules turns attributes and conventions into `IServiceCollection` registration code
+during the build. There is no container of its own — what comes out is `services.AddScoped(…)` calls
+in a file you can read.
+
+## Install
+
+```shell
+dotnet add package DependencyModules.Runtime
+dotnet add package DependencyModules.SourceGenerator
+```
+
+Requires .NET 8.0 or later. Two more packages are optional:
+
+| Package | For |
+|---|---|
+| `DependencyModules.Conventions` | [registering by convention](/guide/conventions) rather than per class |
+| `DependencyModules.xUnit` | [building a provider in tests](/guide/testing) from the modules a test names |
+
+## A first module
+
+A module is a `partial` class. The generator completes it.
+
+```csharp
+using DependencyModules.Runtime.Attributes;
+
+namespace MyApp;
+
+public interface IEmailSender { void Send(string to); }
+
+[SingletonService]
+public class SmtpEmailSender : IEmailSender {
+    public void Send(string to) { }
+}
+
+[DependencyModule]
+public partial class ApplicationModule;
+```
+
+Then load it:
+
+```csharp
+using DependencyModules.Runtime;
+
+var services = new ServiceCollection();
+
+services.AddModule<ApplicationModule>();
+
+var provider = services.BuildServiceProvider();
+var sender = provider.GetRequiredService<IEmailSender>();
+```
+
+::: tip Call AddModule once
+Modules compose through attributes rather than by calling `AddModule` inside each other. Calling it
+once at the composition root keeps the registration order predictable.
+:::
+
+## See what was generated
+
+The generated code is the ground truth, and it is worth looking at once.
+
+```xml
+<PropertyGroup>
+  <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+</PropertyGroup>
+```
+
+The files appear under `obj/`, and `ApplicationModule.Dependencies.g.cs` will contain something like:
+
+```csharp
+private static void ModuleDependencies(IServiceCollection services) {
+    services.AddSingleton(typeof(MyApp.IEmailSender), typeof(MyApp.SmtpEmailSender));
+}
+```
+
+That is all there is. No reflection, no startup scan, and a literal `typeof()` the trimmer can
+follow.
+
+::: warning Delete generated/ between runs
+If you point `CompilerGeneratedFilesOutputPath` at a folder inside your project, stale files from a
+previous build compile alongside fresh ones and produce a wall of `CS0111`/`CS0579`. Clear it when
+you change module names.
+:::
+
+## Where to go next
+
+- [Modules](/guide/modules) — composition, realms, parameters and features
+- [Registering services](/guide/services) — lifetimes, keys, factories, `As`, `Try`/`Replace`
+- [Conventions](/guide/conventions) — declare a rule instead of attributing each class
+- [Trimming and AOT](/guide/aot) — why this survives what reflection-based scanners do not

--- a/website/guide/interception.md
+++ b/website/guide/interception.md
@@ -1,0 +1,131 @@
+# Interception
+
+An interceptor runs around every call to a service. Unlike a [decorator](/guide/decorators) you do
+not write the wrapper — the generator emits a type implementing the service interface and routes
+every member through your interceptor.
+
+```csharp
+public class TimingInterceptor(ILogger log) : IInterceptor {
+    public TResult Intercept<TResult>(InvocationContext<TResult> context) {
+        var stopwatch = Stopwatch.StartNew();
+
+        try {
+            return context.Proceed();
+        } finally {
+            log.LogInformation("{Member} took {Elapsed}", context.Caller.MemberName, stopwatch.Elapsed);
+        }
+    }
+}
+
+[SingletonService]
+[Intercept(typeof(TimingInterceptor))]
+public class Repository : IRepository { }
+```
+
+Because the interface is not generic and the method is, the return type comes from the generated
+call site. Nothing is boxed and nothing is inspected at run time.
+
+::: info Only calls through the interface
+A call the implementation makes to itself does not pass through the wrapper.
+:::
+
+## Three interfaces, chosen per member
+
+A synchronous interceptor has nowhere to await, so it cannot serve a `Task`-returning member — the
+surrounding code would report completion when the task was handed back rather than when the work
+finished. Implement whichever you can serve:
+
+| Interface | For members returning |
+|---|---|
+| `IInterceptor` | a value directly, or `void` |
+| `IAsyncInterceptor` | `Task`, `Task<T>`, `ValueTask`, `ValueTask<T>` |
+| `IAsyncEnumerableInterceptor` | `IAsyncEnumerable<T>` |
+
+A type may implement any combination. **The generator picks per member**, and a member no
+interceptor can serve is forwarded untouched with no allocation.
+
+```csharp
+public class TracingInterceptor : IInterceptor, IAsyncInterceptor {
+    public TResult Intercept<TResult>(InvocationContext<TResult> context) => context.Proceed();
+
+    public async ValueTask<TResult> InterceptAsync<TResult>(AsyncInvocationContext<TResult> context) {
+        using var span = tracer.StartSpan(context.Caller.MemberName);
+
+        return await context.ProceedAsync();
+    }
+}
+```
+
+An interceptor implementing only `IAsyncInterceptor` applied to a service with both synchronous and
+asynchronous members intercepts the asynchronous ones and passes the rest straight through. That is
+deliberate: an interface is intercepted as a whole, and an interceptor has nothing to say about the
+members it cannot serve.
+
+## Awaiting is yours
+
+The generated wrapper awaits nothing on your behalf. An interceptor awaits `ProceedAsync()` itself,
+so anything after the await happens once the work has finished — and because the call is held in a
+single method body, state spanning it is an ordinary local:
+
+```csharp
+public async ValueTask<TResult> InterceptAsync<TResult>(AsyncInvocationContext<TResult> context) {
+    using var scope = _tracer.StartSpan(context.Caller.MemberName);   // spans the whole call
+
+    return await context.ProceedAsync();
+}
+```
+
+A `using` spanning the call is inexpressible with separate enter and exit hooks, which is why there
+are none.
+
+## Streams
+
+An `IAsyncEnumerable<T>` member hands its stream back immediately, so wrapping it as an ordinary
+value would measure the construction of the iterator and nothing else. A stream interceptor
+enumerates it, and so observes each item as it is produced:
+
+```csharp
+public async IAsyncEnumerable<TItem> InterceptStream<TItem>(StreamInvocationContext<TItem> context) {
+    var count = 0;
+
+    await foreach (var item in context.Proceed()) {
+        count++;
+        yield return item;
+    }
+
+    log.LogInformation("{Member} produced {Count}", context.Caller.MemberName, count);
+}
+```
+
+## What the context gives you
+
+| Member | |
+|---|---|
+| `Proceed()` / `ProceedAsync()` | run the rest of the pipeline — more than once to retry, or not at all to skip the implementation |
+| `Caller.ServiceType`, `Caller.MemberName` | what is being called |
+| `Arguments` | by index or by name, and **writable** — a write replaces what the implementation receives |
+
+Arguments cost nothing until read, because they are typed fields that box only on access.
+
+## Several interceptors
+
+```csharp
+[Intercept(typeof(TimingInterceptor), typeof(RetryInterceptor))]
+public class Repository : IRepository { }
+```
+
+They nest in declaration order. Each is resolved from the container, so an interceptor may take its
+own dependencies.
+
+## What cannot be intercepted
+
+The generator refuses rather than guessing, reporting [DM0008](/reference/diagnostics#dm0008):
+
+- `ref`, `in` and `out` parameters, and `ref struct` parameters — they cannot live in a field, and
+  async cannot take them either
+- by-reference returns
+- `init`-only setters
+- static members
+- generic implementations, which register as an open generic
+
+Custom decorators remain the answer for those.

--- a/website/guide/modules.md
+++ b/website/guide/modules.md
@@ -1,0 +1,119 @@
+# Modules
+
+A module is a `partial` class carrying `[DependencyModule]`. The generator completes the partial
+with the plumbing that applies its registrations.
+
+```csharp
+[DependencyModule]
+public partial class ApplicationModule;
+```
+
+::: warning Two rules
+A module **must** be `partial` — otherwise the generator cannot complete it, and reports
+[DM0003](/reference/diagnostics#dm0003).
+
+A module must be declared **directly in a namespace**, not nested inside another type. A nested
+module generates a separate, detached class rather than completing the partial, so its registrations
+never run. Services may be nested freely; only the module itself is restricted.
+:::
+
+## Composing modules
+
+Every module generates an attribute of the same name. Applying it to another module makes it a
+dependency.
+
+```csharp
+[DependencyModule]
+public partial class DataModule;
+
+[DependencyModule]
+[DataModule]                       // DataModule's registrations come along
+public partial class ApplicationModule;
+```
+
+Dependencies are expanded before the module that declares them, so a module's own registrations are
+applied last and win where the container is last-wins.
+
+## Loading modules
+
+```csharp
+using DependencyModules.Runtime;
+
+services.AddModule<ApplicationModule>();
+services.AddModules(new ApplicationModule(), new DiagnosticsModule());
+```
+
+`AddModules` also takes an [environment](/guide/environments), which is what conditional
+registrations are evaluated against:
+
+```csharp
+services.AddModules(new ModuleEnvironment("Development"), new ApplicationModule());
+```
+
+## Auto-generated application module
+
+For [top-level statement](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/program-structure/top-level-statements)
+applications, an `ApplicationModule` is generated for a file named `Program.cs`, so you do not need
+to declare one.
+
+```csharp
+[assembly: SomeOtherModule]
+
+var services = new ServiceCollection();
+
+// SomeOtherModule, plus every registration in this project
+services.AddModule<ApplicationModule>();
+```
+
+## Realms
+
+A realm scopes a registration to one module rather than to every module in the compilation.
+
+```csharp
+[SingletonService(Realm = typeof(DiagnosticsModule))]
+public class Profiler : IProfiler { }
+```
+
+A module declared with `OnlyRealm = true` takes **nothing** that did not name it:
+
+```csharp
+[DependencyModule(OnlyRealm = true)]
+public partial class DiagnosticsModule;
+```
+
+Convention registrations always name their declaring module as their realm, so two modules scanning
+the same interface do not leak into each other.
+
+## Parameters
+
+A module can take constructor parameters and expose them as properties, which its generated
+attribute mirrors.
+
+```csharp
+[DependencyModule]
+public partial class ApplicationModule {
+    public string? ConnectionString { get; set; }
+}
+
+[ApplicationModule(ConnectionString = "…")]
+public partial class TestModule;
+```
+
+## Programmatic registration
+
+For anything the attributes and conventions cannot express, implement
+`IServiceCollectionConfiguration`. It runs after the module's own registrations, with unrestricted
+access to the collection.
+
+```csharp
+[DependencyModule]
+public partial class ApplicationModule : IServiceCollectionConfiguration {
+    public void ConfigureServices(IServiceCollection services) {
+        services.AddHttpClient();
+    }
+}
+```
+
+There is a matching `ConfigureDecorators` that runs after every module's decorators, and an
+`IEnvironmentServiceCollectionConfiguration` that also receives the
+[environment](/guide/environments).

--- a/website/guide/scanning.md
+++ b/website/guide/scanning.md
@@ -1,0 +1,72 @@
+# Scanning a package
+
+A convention normally matches types in the project being built. `InAssemblyOf<T>()` points it at a
+**referenced assembly** instead — for registering handlers, validators or policies out of a package
+you do not control.
+
+```csharp
+conventions.RegisterAll(typeof(IHandler<,>))
+    .InAssemblyOf<SomeTypeInThatPackage>()
+    .AsScoped();
+```
+
+## It still happens at compile time
+
+The types are read as Roslyn symbols during the build, and each match is emitted as a literal
+`typeof()` into your assembly:
+
+```csharp
+services.AddScoped(typeof(IHandler<CreateOrder, OrderId>), typeof(ThePackage.CreateOrderHandler));
+```
+
+Nothing is loaded or reflected over at run time. This is the point at which reflection-based
+scanners stop working under trimming and this one keeps going — see
+[Trimming and AOT](/guide/aot).
+
+## The assembly is always named
+
+There is no "scan everything I depend on", and there should not be. Walking every reference visits
+thousands of types on every keystroke where one named assembly visits its own — measured at roughly
+700× the cost on a minimal eleven-reference compilation.
+
+Naming it with a **type** rather than a string means an assembly that is not referenced cannot be
+asked for. The mistake is unexpressible rather than diagnosable.
+
+## What is visible
+
+Only `public` types cross an assembly boundary. A scan of the project being built also sees
+`internal` ones.
+
+Nothing can report the type it cannot see, so this is a difference to know rather than one the
+generator can warn about.
+
+Types carrying `[SingletonService]` and friends are skipped, as they are in the project being built.
+An assembly whose types carry those attributes has its own module and registers them itself —
+compose that module instead of scanning it.
+
+## Filters and shapes still apply
+
+```csharp
+conventions.RegisterAll<IPolicy>()
+    .InAssemblyOf<FirstPolicy>()
+    .WithName("Retry*")
+    .AsSelf()
+    .AsSingleton();
+```
+
+## What stays out
+
+Scrutor's `FromApplicationDependencies()`, `FromDependencyContext()` and
+`FromAssemblyDependencies(Assembly)` load runtime libraries by name, including assemblies that were
+never compile-time references. There is no compile-time answer to that and no way to fake one, so it
+is not offered.
+
+Note also that a referenced project **you own** is better served by giving it its own module with
+its own conventions and composing through module attributes — explicit, ordered, and cross-assembly
+by construction. Scanning earns its keep on assemblies you cannot add a module to.
+
+## Diagnostics
+
+A match from a referenced assembly has no source to point at, so
+[DM0010](/reference/diagnostics#dm0010) and friends report at the `RegisterAll` line instead of at
+the class.

--- a/website/guide/services.md
+++ b/website/guide/services.md
@@ -1,0 +1,110 @@
+# Registering services
+
+Four attributes cover most registration. Each maps onto the `IServiceCollection` call you would
+otherwise write.
+
+| Attribute | Emits |
+|---|---|
+| `[SingletonService]` | `AddSingleton` |
+| `[ScopedService]` | `AddScoped` |
+| `[TransientService]` | `AddTransient` |
+| `[CrossWireService]` | the implementation **and** every interface it declares, sharing one instance |
+
+```csharp
+[SingletonService]
+public class SmtpEmailSender : IEmailSender { }
+```
+
+A class with no interface registers as itself. A class with interfaces registers as the first one it
+declares, unless you say otherwise with `As`.
+
+## Choosing the service type
+
+```csharp
+[SingletonService(As = typeof(IEmailSender))]
+public class SmtpEmailSender : IEmailSender, IDiagnosticSource { }
+```
+
+## Cross wiring
+
+`[CrossWireService]` is the "one instance, several front doors" registration. Resolving the concrete
+type or any of its interfaces gives the same instance.
+
+```csharp
+[CrossWireService]
+public class Cache : IReadCache, IWriteCache { }
+```
+
+Two independent registrations would give you one instance per service type, which is almost never
+what people mean.
+
+## Keys
+
+```csharp
+[SingletonService(Key = "primary")]
+public class PrimaryConnection : IConnection { }
+```
+
+```csharp
+provider.GetRequiredKeyedService<IConnection>("primary");
+```
+
+The key is written into the registration as you wrote it, so a literal, a `const` or an enum member
+all work.
+
+## Registration strategy
+
+`Using` chooses how the registration is added.
+
+| Value | Behaviour |
+|---|---|
+| `Add` *(default)* | always adds |
+| `Try` | adds only if the service type is not already registered |
+| `TryEnumerable` | adds unless this exact service/implementation pair is present |
+| `Replace` | replaces an existing registration of the service type |
+
+```csharp
+[SingletonService(Using = RegistrationType.Try)]
+public class DefaultClock : IClock { }
+```
+
+## Factories
+
+When a type cannot be constructed by the container, register a static factory method instead. The
+attribute goes on the method.
+
+```csharp
+public class SomeClass : ISomeInterface {
+    public SomeClass(IDep one, IDepTwo two, DateTime timestamp) { }
+
+    [SingletonService]
+    public static ISomeInterface Factory(IDep one, IDepTwo two) =>
+        new SomeClass(one, two, DateTime.UtcNow);
+}
+```
+
+Every parameter of the factory is resolved from the container.
+
+## Constructor selection
+
+The greediest accessible constructor is used, matching `ActivatorUtilities`. To pick a specific one,
+mark it:
+
+```csharp
+[ActivatorUtilitiesConstructor]
+public SomeClass(IDep one) { }
+```
+
+## Generated factories
+
+By default the generator emits `typeof(Implementation)` and lets the container construct it. Turning
+on factory generation emits a `new` expression instead, which removes the container's reflection
+from the hot path:
+
+```xml
+<PropertyGroup>
+  <DependencyModules_GenerateFactories>true</DependencyModules_GenerateFactories>
+</PropertyGroup>
+```
+
+See [MSBuild properties](/reference/msbuild) for the rest.

--- a/website/guide/testing.md
+++ b/website/guide/testing.md
@@ -1,0 +1,258 @@
+# Testing
+
+Testing a module means building a provider from it and asking what came out. The xUnit package does
+that for you: a test names the modules it wants, declares the services it needs as parameters, and
+gets them injected.
+
+```shell
+dotnet add package DependencyModules.xUnit
+dotnet add package DependencyModules.xUnit.NSubstitute
+```
+
+## A first test
+
+```csharp
+using DependencyModules.xUnit.Attributes;
+
+public class OrderServiceTests {
+    [ModuleTest]
+    [ApplicationModule]
+    public void PlacingAnOrderSendsConfirmation(OrderService service) {
+        service.Place(new Order());
+    }
+}
+```
+
+`[ModuleTest]` replaces `[Fact]`. The module attribute says which modules to load — it is the
+attribute the generator produced for `ApplicationModule`. Every parameter is resolved from the
+provider that results.
+
+## Where module attributes go
+
+They apply at assembly, class or method level, and they accumulate. Put the ones every test needs at
+the assembly level and stop repeating them:
+
+```csharp
+[assembly: ApplicationModule]
+[assembly: NSubstituteSupport]
+```
+
+```csharp
+public class OrderServiceTests {
+    [ModuleTest]
+    public void UsesTheAssemblyModules(OrderService service) { }
+
+    [ModuleTest]
+    [DiagnosticsModule]                 // this test also gets DiagnosticsModule
+    public void AddsOneMore(OrderService service, IProfiler profiler) { }
+}
+```
+
+## Mocking
+
+`[Mock]` on a parameter substitutes that service. The substitute is **registered in the container**,
+so anything resolved afterwards depends on the mock rather than the real implementation — which is
+the point.
+
+```csharp
+[assembly: NSubstituteSupport]
+```
+
+```csharp
+[ModuleTest]
+public void SendsToTheCustomerAddress(OrderService service, [Mock] IEmailSender sender) {
+    service.Place(new Order { Email = "a@b.com" });
+
+    sender.Received().Send("a@b.com");
+}
+```
+
+`OrderService` is constructed by the container and receives the same substitute the test holds.
+
+`[NSubstituteSupport]` is what supplies the mocking library. Without it, `[Mock]` has nothing to
+create substitutes with and the test fails with a message saying so.
+
+## Supplying values
+
+Some parameters are not services. `[InjectValues]` provides them, and mixes with resolution — a
+record can take both a service and a literal:
+
+```csharp
+public record InjectModel(IDependencyOne DependencyOne, string StringValue);
+
+[ModuleTest]
+[SutModule]
+public void InjectTestValue([InjectValues("Hello World!")] InjectModel model) {
+    Assert.NotNull(model.DependencyOne);          // from the container
+    Assert.Equal("Hello World!", model.StringValue);   // from the attribute
+}
+```
+
+## Data-driven tests
+
+`[ModuleTest]` composes with xUnit's data attributes. Data parameters come first, injected ones
+after:
+
+```csharp
+[ModuleTest]
+[InlineData("one")]
+[InlineData("two")]
+[SutModule]
+public void MultipleRows(string value, IDependencyOne one) {
+    Assert.NotNull(value);
+    Assert.NotNull(one);
+}
+```
+
+## Registering something for one test
+
+`[TestExport]` adds a registration to the test's container without touching the module. Useful for a
+stub you want the real container to construct, or for overriding one service.
+
+```csharp
+[ModuleTest]
+[ApplicationModule]
+[TestExport(typeof(IClock), Implementation = typeof(FixedClock), Lifetime = ServiceLifetime.Singleton)]
+public void UsesTheFixedClock(IOrderService service) { }
+```
+
+It applies at assembly, class or method level like the module attributes, and `Implementation`
+defaults to the service type when omitted.
+
+## Testing what a module registered
+
+The xUnit package is for testing *behaviour through* the container. For assertions about the
+registrations themselves — lifetimes, keys, how many things matched — build the collection directly
+and look at it. No test framework integration needed:
+
+```csharp
+using DependencyModules.Runtime;
+
+var services = new ServiceCollection();
+
+services.AddModules(new DataModule());
+
+var descriptor = Assert.Single(services, d => d.ServiceType == typeof(IRepository));
+
+Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+Assert.Equal(typeof(SqlRepository), descriptor.ImplementationType);
+```
+
+This is the right shape for testing a [convention](/guide/conventions), because the interesting
+question is usually *which types matched* rather than what one of them does:
+
+```csharp
+var registered = services
+    .Where(d => d.ServiceType == typeof(IRepository))
+    .Select(d => d.ImplementationType!.Name)
+    .OrderBy(name => name)
+    .ToArray();
+
+Assert.Equal(["OrderRepository", "ProductRepository"], registered);
+```
+
+::: warning One provider per assertion set
+Building a provider twice gives you two sets of singletons. If a test resolves a service from one
+provider and asserts on a singleton it captured from another, it will compare two different
+instances and the failure will look like the registration is wrong.
+
+```csharp
+var provider = services.BuildServiceProvider();   // build once
+
+var service = provider.GetRequiredService<IOrderService>();
+var log = provider.GetRequiredService<Log>();     // same provider, same singleton
+```
+:::
+
+## Testing conditional registrations
+
+Registrations gated on the [environment](/guide/environments) are decided when the modules are
+applied, so the environment has to be supplied then:
+
+```csharp
+var services = new ServiceCollection();
+
+services.AddModules(new ModuleEnvironment("Development"), new ApplicationModule());
+
+Assert.IsType<FakeEmailSender>(
+    services.BuildServiceProvider().GetRequiredService<IEmailSender>());
+```
+
+Supply nothing and the process environment is used, which defaults to `"Production"` — so a test for
+a development-only service **must** name the environment or it will silently test the wrong branch.
+
+A theory covers both sides in one place:
+
+```csharp
+[Theory]
+[InlineData("Development", typeof(FakeEmailSender))]
+[InlineData("Production", typeof(SmtpEmailSender))]
+public void SelectsBySender(string environment, Type expected) {
+    var services = new ServiceCollection();
+
+    services.AddModules(new ModuleEnvironment(environment), new ApplicationModule());
+
+    Assert.IsType(expected, services.BuildServiceProvider().GetRequiredService<IEmailSender>());
+}
+```
+
+## Testing decorators and interceptors
+
+Both change what resolving gives you, so assert on the resolved type and on the effect:
+
+```csharp
+var provider = services.BuildServiceProvider();
+
+var repository = provider.GetRequiredService<IRepository>();
+
+Assert.IsType<CachingRepository>(repository);      // the decorator is on the outside
+```
+
+For [ordering](/guide/decorators#ordering), have each decorator contribute to a string and assert the
+nesting, which is far clearer than reflecting over the chain:
+
+```csharp
+Assert.Equal("outer(inner(core))", provider.GetRequiredService<IOrdered>().Describe());
+```
+
+An [interceptor](/guide/interception) is easiest to test through something it records:
+
+```csharp
+var provider = services.BuildServiceProvider();
+var log = provider.GetRequiredService<InterceptLog>();
+
+provider.GetRequiredService<IOrders>().Count("acme");
+
+Assert.Equal(["intercepted Count"], log.Lines);
+```
+
+Note that a service resolves as a **generated wrapper**, so `Assert.IsType<Orders>(…)` fails where
+you might expect it to pass. Assert on behaviour, or on the interface.
+
+## Testing scopes
+
+```csharp
+using var first = provider.CreateScope();
+using var second = provider.CreateScope();
+
+var one = first.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+Assert.Same(one, first.ServiceProvider.GetRequiredService<IUnitOfWork>());
+Assert.NotSame(one, second.ServiceProvider.GetRequiredService<IUnitOfWork>());
+```
+
+## What to test, and what not to
+
+Testing that `[SingletonService]` produced `AddSingleton` is testing this library, not your code. The
+registrations worth asserting on are the ones where **you** made a decision the compiler cannot
+check:
+
+- a convention matched the set of types you meant — and, more usefully, did **not** match the ones
+  you did not
+- a conditional registration selects the right implementation in each environment
+- decorators nest in the order you intended
+- a service resolves at all, which catches a missing registration in a module you compose
+
+The build already tells you about the rest. A convention that matches nothing is
+[DM0005](/reference/diagnostics#dm0005), a service that cannot be constructed is
+[DM0002](/reference/diagnostics#dm0002), and both fail before a test ever runs.

--- a/website/guide/troubleshooting.md
+++ b/website/guide/troubleshooting.md
@@ -1,0 +1,69 @@
+# Troubleshooting
+
+If services are not registered the way you expect, three steps produce almost everything needed to
+diagnose it.
+
+## 1. Read the generated code
+
+The registrations the generator produced are the ground truth.
+
+```xml
+<PropertyGroup>
+  <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+</PropertyGroup>
+```
+
+The files appear under `obj/`. `YourModule.Dependencies.g.cs` holds the registrations,
+`YourModule.Module.g.cs` the module plumbing, and there are separate files for decorators and
+interceptors.
+
+::: warning Stale files
+If you redirect `CompilerGeneratedFilesOutputPath` into your project, delete the folder between runs.
+Stale files compile alongside fresh ones and produce a wall of `CS0111`/`CS0579`.
+:::
+
+## 2. Turn on the generator log
+
+It records the configuration in effect, every module and service discovered, and anything skipped
+along with the reason.
+
+```xml
+<PropertyGroup>
+  <DependencyModules_LogOutputDirectory>$(MSBuildProjectDirectory)/dmlogs</DependencyModules_LogOutputDirectory>
+</PropertyGroup>
+```
+
+## 3. Check for DM diagnostics
+
+The generator reports what it can detect at build time. See the
+[diagnostics reference](/reference/diagnostics) for what each one means and what to do about it.
+
+## Common causes
+
+**The module is not `partial`.** [DM0003](/reference/diagnostics#dm0003). The generator cannot
+complete a class it cannot extend.
+
+**The module is nested inside another type.** A nested module generates a separate, detached class
+rather than completing the partial, so its registrations never run. Declare it directly in a
+namespace.
+
+**A convention matched nothing.** [DM0005](/reference/diagnostics#dm0005) — usually a renamed
+interface or a typo in a filter.
+
+**A service was registered but resolves to the wrong implementation.** The container takes the last
+matching descriptor for a single resolve. Check the order in the generated file; conditional
+registrations are emitted after unconditional ones deliberately.
+
+**A convention picked up something unexpected.** Narrow it with a
+[filter](/guide/conventions#narrowing-what-matches), and remember that a name glob is the weakest
+selector — `*Handler` matches a decorator named `LoggingHandler` just as readily.
+
+**`AddModule` called more than once.** Modules compose through attributes; calling `AddModule` inside
+a module or several times at the root duplicates registrations.
+
+## Reporting a problem
+
+Please include the generator log and the generated file in any
+[issue](https://github.com/ipjohnson/DependencyModules/issues). Between them they answer whether a
+service was discovered at all, which realm it landed in, and what configuration was in effect —
+none of which is visible from the generated output alone.

--- a/website/index.md
+++ b/website/index.md
@@ -1,0 +1,120 @@
+---
+layout: home
+
+hero:
+  name: DependencyModules
+  text: Dependency injection, decided at compile time
+  tagline: >-
+    Attributes and conventions become ordinary registration code during the build. Nothing reflects,
+    nothing scans an assembly at startup, and the trimmer can follow every registration you declared.
+  image:
+    src: /hero.svg
+    alt: Declarations on the left becoming generated registration code on the right
+  actions:
+    - theme: brand
+      text: Get started
+      link: /guide/getting-started
+    - theme: alt
+      text: Conventions
+      link: /guide/conventions
+    - theme: alt
+      text: View on GitHub
+      link: https://github.com/ipjohnson/DependencyModules
+
+features:
+  - title: Registrations you can read
+    details: >-
+      Every registration is emitted into your assembly as plain C#. Set EmitCompilerGeneratedFiles
+      and the file under obj/ is the ground truth — no container graph to reason about, no startup
+      cost to measure.
+    link: /guide/services
+    linkText: Registering services
+
+  - title: Conventions without reflection
+    details: >-
+      Declare what to register and the generator resolves the matches during the build. Assignability,
+      namespaces, attributes and name globs — including types in a referenced package.
+    link: /guide/conventions
+    linkText: How conventions work
+
+  - title: Trimming and Native AOT safe
+    details: >-
+      Each match is emitted as a literal typeof(), which the trimmer roots and which carries the
+      constructor along with it. The capability that breaks reflection-based scanners is the one
+      that works here.
+    link: /guide/aot
+    linkText: Why it survives trimming
+
+  - title: Mistakes reported at build time
+    details: >-
+      A convention that matches nothing, a service that cannot be constructed, two conventions
+      claiming one service type — each is a DM diagnostic in the IDE rather than an exception at
+      startup.
+    link: /reference/diagnostics
+    linkText: Diagnostics reference
+
+  - title: Decorate and intercept
+    details: >-
+      Wrap a service with a decorator you write, or with a generated wrapper that routes every member
+      through an interceptor. Both compose with conventions and both are ordered globally.
+    link: /guide/decorators
+    linkText: Decorators and interception
+
+  - title: Built for testing
+    details: >-
+      The xUnit package builds a provider from the modules a test names and injects the services the
+      test asks for, with mocks substituted where you want them.
+    link: /guide/testing
+    linkText: Testing modules
+---
+
+<div class="dm-sample">
+
+## What it looks like
+
+Mark a class, and the registration is written for you.
+
+```csharp
+[SingletonService]
+public class SmtpEmailSender : IEmailSender { }
+
+[DependencyModule]
+public partial class ApplicationModule;
+```
+
+```csharp
+var services = new ServiceCollection();
+
+services.AddModule<ApplicationModule>();
+```
+
+Or declare a rule once, and let it cover everything that fits.
+
+```csharp
+[DependencyModule]
+public partial class HandlerModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll(typeof(IRequestHandler<,>)).AsScoped();
+        conventions.RegisterAll<IValidator>().InNamespaceOf<OrderMarker>().AsScoped();
+    }
+}
+```
+
+That body never runs. It is read during the build, and what comes out the other side is the same
+registration code you would have written by hand.
+
+</div>
+
+<style>
+.dm-sample {
+  max-width: 1152px;
+  margin: 0 auto;
+  padding: 0 24px 64px;
+}
+
+.dm-sample h2 {
+  border-top: 1px solid var(--vp-c-divider);
+  padding-top: 40px;
+  margin-top: 8px;
+}
+</style>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,0 +1,2537 @@
+{
+  "name": "dependencymodules-docs",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dependencymodules-docs",
+      "version": "0.0.0",
+      "devDependencies": {
+        "vitepress": "^1.6.3"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.22.0.tgz",
+      "integrity": "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.56.0.tgz",
+      "integrity": "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.56.0.tgz",
+      "integrity": "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.56.0.tgz",
+      "integrity": "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.56.0.tgz",
+      "integrity": "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.56.0.tgz",
+      "integrity": "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.56.0.tgz",
+      "integrity": "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.56.0.tgz",
+      "integrity": "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.56.0.tgz",
+      "integrity": "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.56.0.tgz",
+      "integrity": "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.56.0.tgz",
+      "integrity": "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.56.0.tgz",
+      "integrity": "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.56.0.tgz",
+      "integrity": "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.56.0.tgz",
+      "integrity": "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.93",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.93.tgz",
+      "integrity": "sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
+      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/shared": "3.5.41",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
+      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz",
+      "integrity": "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@vue/compiler-core": "3.5.41",
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/shared": "3.5.41",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.19",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
+      "integrity": "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.10"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.10",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
+      "integrity": "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.41.tgz",
+      "integrity": "sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.41.tgz",
+      "integrity": "sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.41",
+        "@vue/runtime-core": "3.5.41",
+        "@vue/shared": "3.5.41",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.41.tgz",
+      "integrity": "sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/shared": "3.5.41"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
+      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.56.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.56.0.tgz",
+      "integrity": "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.22.0",
+        "@algolia/client-abtesting": "5.56.0",
+        "@algolia/client-analytics": "5.56.0",
+        "@algolia/client-common": "5.56.0",
+        "@algolia/client-insights": "5.56.0",
+        "@algolia/client-personalization": "5.56.0",
+        "@algolia/client-query-suggestions": "5.56.0",
+        "@algolia/client-search": "5.56.0",
+        "@algolia/ingestion": "1.56.0",
+        "@algolia/monitoring": "1.56.0",
+        "@algolia/recommend": "5.56.0",
+        "@algolia/requester-browser-xhr": "5.56.0",
+        "@algolia/requester-fetch": "5.56.0",
+        "@algolia/requester-node-http": "5.56.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.41",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.41.tgz",
+      "integrity": "sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.41",
+        "@vue/compiler-sfc": "3.5.41",
+        "@vue/runtime-dom": "3.5.41",
+        "@vue/server-renderer": "3.5.41",
+        "@vue/shared": "3.5.41"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "dependencymodules-docs",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vitepress dev",
+    "build": "vitepress build",
+    "preview": "vitepress preview"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.3"
+  }
+}

--- a/website/public/favicon.svg
+++ b/website/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#6d5bd5"/>
+  <g fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round">
+    <path d="M9 10h5a6 6 0 0 1 0 12H9z"/>
+    <path d="M23 11v10"/>
+  </g>
+</svg>

--- a/website/public/hero.svg
+++ b/website/public/hero.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320" width="320" height="320" role="img" aria-label="Attributes on the left becoming generated registration code on the right">
+  <defs>
+    <linearGradient id="dmGlow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7c6bf0"/>
+      <stop offset="100%" stop-color="#4f46b8"/>
+    </linearGradient>
+    <!-- Sits behind the panels so the mark reads on both the light and dark theme without
+         needing two files. -->
+    <radialGradient id="dmHalo" cx="50%" cy="45%" r="55%">
+      <stop offset="0%" stop-color="#7c6bf0" stop-opacity="0.28"/>
+      <stop offset="100%" stop-color="#7c6bf0" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <circle cx="160" cy="150" r="150" fill="url(#dmHalo)"/>
+
+  <!-- Declarations -->
+  <g>
+    <rect x="20" y="60" width="112" height="30" rx="9" fill="url(#dmGlow)" opacity="0.92"/>
+    <rect x="32" y="71" width="66" height="8" rx="4" fill="#fff" opacity="0.85"/>
+
+    <rect x="20" y="104" width="112" height="30" rx="9" fill="url(#dmGlow)" opacity="0.72"/>
+    <rect x="32" y="115" width="82" height="8" rx="4" fill="#fff" opacity="0.85"/>
+
+    <rect x="20" y="148" width="112" height="30" rx="9" fill="url(#dmGlow)" opacity="0.52"/>
+    <rect x="32" y="159" width="54" height="8" rx="4" fill="#fff" opacity="0.85"/>
+
+    <rect x="20" y="192" width="112" height="30" rx="9" fill="url(#dmGlow)" opacity="0.34"/>
+    <rect x="32" y="203" width="74" height="8" rx="4" fill="#fff" opacity="0.85"/>
+  </g>
+
+  <!-- Compile step -->
+  <g stroke="#7c6bf0" stroke-width="3" stroke-linecap="round" fill="none">
+    <path d="M144 141h26"/>
+    <path d="M162 133l9 8-9 8"/>
+  </g>
+
+  <!-- Generated registrations -->
+  <g>
+    <rect x="184" y="52" width="118" height="178" rx="14" fill="#7c6bf0" opacity="0.10"/>
+    <rect x="184" y="52" width="118" height="178" rx="14" fill="none" stroke="#7c6bf0" stroke-opacity="0.45" stroke-width="2"/>
+
+    <g fill="#7c6bf0">
+      <rect x="200" y="76"  width="60" height="7" rx="3.5" opacity="0.95"/>
+      <rect x="200" y="94"  width="86" height="7" rx="3.5" opacity="0.55"/>
+      <rect x="212" y="112" width="62" height="7" rx="3.5" opacity="0.55"/>
+      <rect x="200" y="136" width="70" height="7" rx="3.5" opacity="0.95"/>
+      <rect x="200" y="154" width="86" height="7" rx="3.5" opacity="0.55"/>
+      <rect x="212" y="172" width="52" height="7" rx="3.5" opacity="0.55"/>
+      <rect x="200" y="196" width="64" height="7" rx="3.5" opacity="0.95"/>
+    </g>
+  </g>
+</svg>

--- a/website/reference/attributes.md
+++ b/website/reference/attributes.md
@@ -1,0 +1,82 @@
+# Attributes
+
+Every attribute lives in `DependencyModules.Runtime.Attributes`.
+
+## Modules
+
+### `[DependencyModule]`
+
+Marks a `partial` class as a module. Generates an attribute of the same name for composition.
+
+| Property | |
+|---|---|
+| `OnlyRealm` | the module takes only registrations that named it as their realm |
+| `GenerateAttribute` | set `false` to suppress the generated composition attribute |
+| `RegisterJsonSerializers` | register discovered `JsonSerializerContext` types |
+
+### `[Decorate(service, decorator)]`
+
+Declares a decorator on the module rather than on the decorator class — for when the service, the
+decorator or both come from an assembly you do not control.
+
+| Property | |
+|---|---|
+| `Order` | nesting; lower sits closer to the implementation |
+
+## Services
+
+### `[SingletonService]` · `[ScopedService]` · `[TransientService]`
+
+Registers the class, or a static factory method, with that lifetime.
+
+| Property | |
+|---|---|
+| `As` | the service type to register as |
+| `Key` | a service key |
+| `Using` | `Add`, `Try`, `TryEnumerable` or `Replace` |
+| `Realm` | scope the registration to one module |
+
+### `[CrossWireService]`
+
+Registers the implementation **and** every interface it declares, sharing one instance.
+
+Takes the same properties, plus `Lifetime`.
+
+## Decoration and interception
+
+### `[Decorator]`
+
+Marks a class as a decorator of the interface it implements. The first constructor parameter is the
+wrapped instance; the rest are resolved from the container.
+
+A `[Decorator]` is never a convention candidate — it is not a service.
+
+| Property | |
+|---|---|
+| `Order` | nesting; lower sits closer to the implementation |
+
+### `[Intercept(params Type[])]`
+
+Wraps a service so every call through its interface passes through the given interceptors, in order.
+
+| Property | |
+|---|---|
+| `Service` | the interface to intercept, when the service implements more than one |
+| `Order` | nesting relative to decorators and other interceptors |
+
+## Environment conditions
+
+All four take effect on a class that is registered by attribute or by convention. Conditions of
+different kinds combine with **and**.
+
+### `[IfEnvironment(params string[])]` · `[IfNotEnvironment(params string[])]`
+
+Compares the environment name, case-insensitively.
+
+### `[IfEnvironmentValue(key)]` · `[IfEnvironmentValue(key, value)]`
+
+Presence of the key, or an exact ordinal match on its value. `AllowMultiple`.
+
+### `[IfNotEnvironmentValue(…)]`
+
+The inverse of either form.

--- a/website/reference/conventions-api.md
+++ b/website/reference/conventions-api.md
@@ -1,0 +1,67 @@
+# Convention API
+
+Every call available inside a `Conventions` body. See [Conventions](/guide/conventions) for how they
+fit together.
+
+```csharp
+[DependencyModule]
+public partial class DataModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) {
+        conventions.RegisterAll<IRepository>().InNamespaceOf<Marker>().AsScoped();
+    }
+}
+```
+
+## Starting a convention
+
+| Call | Selects |
+|---|---|
+| `RegisterAll<TService>()` | types assignable to `TService` |
+| `RegisterAll(Type serviceType)` | the same, for an open generic — `typeof(IHandler<,>)` |
+| `RegisterAll()` | nothing by assignability; requires a filter and a shape |
+
+## Filters
+
+Chained calls, combined with **and**. Inclusions of the same kind combine with **or**; exclusions are
+applied afterwards and any one removes a match.
+
+| Call | |
+|---|---|
+| `InNamespaceOf<TMarker>()` | the marker's namespace and those beneath it |
+| `InNamespaces(params string[])` | those namespaces and those beneath them |
+| `InExactNamespaces(params string[])` | only those namespaces |
+| `NotInNamespaceOf<TMarker>()` | excludes that namespace and those beneath it |
+| `NotInNamespaces(params string[])` | excludes those namespaces |
+| `WithAttribute<TAttribute>()` | types carrying the attribute |
+| `WithoutAttribute<TAttribute>()` | types not carrying it |
+| `WithName(params string[])` | name globs — `*` and `?` |
+| `WithoutName(params string[])` | excludes matching names |
+| `IncludeBaseClasses()` | also match types reaching the service through a base class |
+| `InAssemblyOf<TMarker>()` | scan the marker's assembly instead of this project |
+
+## Shape
+
+| Call | Registers each match as |
+|---|---|
+| *(default)* | the service type the convention matched |
+| `AsSelf()` | its own concrete type, instead of the interface |
+| `AlsoAsSelf()` | the matched service type **and** the concrete type, sharing one instance |
+| `AsSelfWithInterfaces()` | the concrete type and every interface it implements, sharing one instance |
+| `AsMatchingInterface()` | the interface named after it — `Foo` as `IFoo` |
+| `As<TService>()` | one named service type |
+
+## Lifetime and strategy
+
+| Call | |
+|---|---|
+| `AsSingleton()` · `AsScoped()` · `AsTransient()` | required; there is no default |
+| `Using(RegistrationType)` | `Add`, `Try`, `TryEnumerable` or `Replace` |
+| `WithKey(object)` | a service key — literal, `const` or enum member |
+
+## What is not offered
+
+Anything taking a lambda. `Where(Func<Type,bool>)`, `AsImplementedInterfaces(predicate)`,
+`WithLifetime(Func<Type,ServiceLifetime>)` and `WithServiceKey(Func<Type,object?>)` have no
+compile-time equivalent, because a generator cannot run your code over the types it is describing.
+
+Use `IServiceCollectionConfiguration.ConfigureServices` for those.

--- a/website/reference/diagnostics.md
+++ b/website/reference/diagnostics.md
@@ -1,0 +1,127 @@
+# Diagnostics
+
+The generator reports what it can decide at build time rather than letting it fail at startup. Each
+code can be tuned or silenced through `.editorconfig`:
+
+```ini
+dotnet_diagnostic.DM0010.severity = none
+```
+
+| Code | Severity | Meaning |
+|---|---|---|
+| [DM0001](#dm0001) | Error | The generator failed |
+| [DM0002](#dm0002) | Warning | A service type cannot be constructed |
+| [DM0003](#dm0003) | Error | A module is not `partial` |
+| [DM0004](#dm0004) | Error | Two conventions register a type as the same service type |
+| [DM0005](#dm0005) | Warning | A convention matched nothing |
+| [DM0006](#dm0006) | Warning | A convention matched a type with no accessible constructor |
+| [DM0007](#dm0007) | Error | Two decorators of one service share an order |
+| [DM0008](#dm0008) | Warning | A service marked for interception cannot be wrapped |
+| [DM0009](#dm0009) | Error | A convention declaration could not be read |
+| [DM0010](#dm0010) | Info | A service is registered by convention |
+| [DM0011](#dm0011) | Info | A service is registered only when a condition holds |
+| [DM0012](#dm0012) | Warning | An environment condition names nothing to test |
+
+## DM0001 {#dm0001}
+
+**The generator failed; registrations may be missing.**
+
+Surfaced as a build error rather than discarded, because a generator that fails quietly produces a
+green build with no registrations. Please [open an issue](https://github.com/ipjohnson/DependencyModules/issues)
+with the generator log — see [Troubleshooting](/guide/troubleshooting).
+
+## DM0002 {#dm0002}
+
+**A service type cannot be constructed and was not registered.**
+
+The implementation is abstract or a static class. Registering it would throw when the provider is
+built, a long way from the declaration responsible.
+
+## DM0003 {#dm0003}
+
+**A module marked with `[DependencyModule]` is not partial.**
+
+The generator completes the module's partial declaration. Without `partial` there is nothing to
+complete.
+
+## DM0004 {#dm0004}
+
+**Two conventions in one module register a type as the same service type.**
+
+One lifetime has to win and the source does not say which.
+
+```csharp
+conventions.RegisterAll<IRepository>().AsScoped();
+conventions.RegisterAll<IRepository>().AsSingleton();   // DM0004
+```
+
+Equal lifetimes are an error too — the outcome is predictable, but the declaration is redundant, and
+silently collapsing a duplicate is the failure mode this generator avoids.
+
+A type filling two *different* roles is not ambiguous and registers as both. Conventions in
+different modules never collide, because each registers into its own realm.
+
+## DM0005 {#dm0005}
+
+**A convention matched no types.**
+
+Almost always a renamed interface or a typo in a filter. Without this it fails silently: the build is
+green and the application throws at resolve time, which is the failure Scrutor cannot report because
+its scan does not run until startup.
+
+## DM0006 {#dm0006}
+
+**A convention matched a type with no accessible constructor.**
+
+Reported rather than registered, because the container would throw when the provider is built.
+
+## DM0007 {#dm0007}
+
+**Two decorators of one service share an order.**
+
+Their nesting would not be predictable from reading the source. See
+[Decorators](/guide/decorators#ordering).
+
+## DM0008 {#dm0008}
+
+**A service marked for interception cannot be wrapped.**
+
+The member uses `ref`, `in`, `out` or a `ref struct` parameter, returns by reference, has an
+`init`-only setter, is static, or the implementation is generic. See
+[Interception](/guide/interception#what-cannot-be-intercepted).
+
+## DM0009 {#dm0009}
+
+**A convention declaration could not be read.**
+
+The `Conventions` body is read at compile time rather than executed, so only a closed set of calls
+can appear in it. A loop, a conditional, a local or a call to your own helper has no compile-time
+meaning.
+
+It also covers a convention that declared no lifetime, a `RegisterAll()` with no shape or no filter,
+and a chain the generator could not resolve.
+
+## DM0010 {#dm0010}
+
+**A service is registered by convention.**
+
+Informational, reported at the class. A class registered by convention carries no attribute saying
+so, so nothing at the declaration explains why it is in the container — this is that explanation, and
+it names the interface the match came through when it was not direct.
+
+A match from a [referenced assembly](/guide/scanning) has no class to point at, so it reports at the
+`RegisterAll` line instead.
+
+## DM0011 {#dm0011}
+
+**A service is registered only when an environment condition holds.**
+
+Informational. Whether a condition holds is a run-time question, so no build error is available — this
+puts the condition where you are already looking. See [Environments](/guide/environments).
+
+## DM0012 {#dm0012}
+
+**An environment condition names nothing to test.**
+
+`[IfEnvironment()]` and `[IfEnvironmentValue("")]` both compile. Written plain they mean the service
+never registers; written as the `IfNot` form they mean the attribute does nothing at all.

--- a/website/reference/msbuild.md
+++ b/website/reference/msbuild.md
@@ -1,0 +1,30 @@
+# MSBuild properties
+
+Set these in a `PropertyGroup` in the consuming project. They reach the generator through the
+package's `build/*.targets`.
+
+| Property | Default | |
+|---|---|---|
+| `DependencyModules_GenerateFactories` | `false` | emit a `new` expression instead of `typeof(T)`, so the container does not construct by reflection |
+| `DependencyModules_RegistrationType` | `Add` | the default registration strategy for the project |
+| `DependencyModules_AutoGenerateModule` | `true` | generate `ApplicationModule` for a top-level `Program.cs` |
+| `DependencyModules_RegisterGenerator` | `false` | register discovered `JsonSerializerContext` types |
+| `DependencyModules_ExcludeGeneratedCodeFromCoverage` | `true` | apply `[ExcludeFromCodeCoverage]` to generated members |
+| `DependencyModules_LogOutputDirectory` | *(none)* | write a generator log here — see [Troubleshooting](/guide/troubleshooting) |
+
+```xml
+<PropertyGroup>
+  <DependencyModules_GenerateFactories>true</DependencyModules_GenerateFactories>
+  <DependencyModules_LogOutputDirectory>$(MSBuildProjectDirectory)/dmlogs</DependencyModules_LogOutputDirectory>
+</PropertyGroup>
+```
+
+## Seeing the generated files
+
+Not a DependencyModules property, but the one you will reach for most:
+
+```xml
+<PropertyGroup>
+  <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+</PropertyGroup>
+```


### PR DESCRIPTION
A VitePress site under `website/`, published to GitHub Pages — plus a README bug that is live on every NuGet package page right now.

## Why

The README documented roughly half of what the library does. **Conventions, decorators, interception and environment-conditional registration had no documentation at all.** There was no diagnostics reference despite the README telling people to check for `DM####` codes, and the trimming and AOT story — the actual competitive position against Scrutor and Castle — was one sentence in the intro.

`DependencyModules.Conventions` is also about to be published with a README that never says the word "convention".

## The README bug

A code fence opened at *Unit testing & Mocking* and did not close until *Implementation*, so the entire **Reporting a problem** section renders as a C# code block — on GitHub and on all five published NuGet pages. Three paragraphs of diagnostic advice, displayed as code. Fixed, and the shell commands inside that block moved to a `shell` fence.

## Sixteen pages

| | |
|---|---|
| **Guide** | getting started · modules · registering services · conventions · scanning a package · decorators · interception · environments · testing · trimming and AOT · troubleshooting |
| **Reference** | diagnostics (DM0001–DM0012) · attributes · convention API · MSBuild properties |

Written against the code rather than from memory — the testing page in particular was written after reading `MockAttribute`, `InjectValuesAttribute`, `TestExportAttribute` and the existing integration tests, so `[InjectValues]`, `[TestExport]` and data-driven `[ModuleTest]` are documented as they actually behave.

Several pages record traps found while building these features, including two I fell into myself: building a provider twice gives you two sets of singletons (which cost an hour chasing a phantom async-interceptor bug), and an intercepted service resolves as a generated wrapper so `Assert.IsType<Orders>` fails where you would expect it to pass.

## Build

`ignoreDeadLinks: false`, so a dead internal link **fails the build** rather than shipping. The pages cross-reference heavily and a rename would otherwise rot links silently.

Local search, dark mode, and a hero illustration that works on both themes without needing two files. Verified in a browser at 1440px in light and dark.

## Deployment

`.github/workflows/docs.yaml` builds and deploys on pushes to `main` that touch `website/**`. Repository settings are already correct — Pages build type is `workflow`, the `github-pages` environment is restricted to `main`, and the site URL matches the configured base path. The workflow simply has to exist on `main`, which is what merging this does.

The workflow declares `pages: write` and `id-token: write` explicitly, which it needs because the repository default for the workflow token is `read`.

## Follow-ups, deliberately not in this PR

- The README now duplicates large parts of the site. It should be cut down to a pitch, install, a short example and a link — two copies drift within a release.
- The site presents `DependencyModules.Conventions` as available. Its install snippet will 404 until the package is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C56x6Vv6HJ6ArfqwKsuSb9