### PR TITLE
Testing section, generator guide, and less rationale

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -66,6 +66,14 @@ export default defineConfig({
           ],
         },
         {
+          text: 'Testing',
+          items: [
+            { text: 'Testing modules', link: '/guide/testing' },
+            { text: 'Mocks and values', link: '/guide/testing-mocks' },
+            { text: 'Testing registrations', link: '/guide/testing-registrations' },
+          ],
+        },
+        {
           text: 'Registering in bulk',
           items: [
             { text: 'Conventions', link: '/guide/conventions' },
@@ -83,9 +91,9 @@ export default defineConfig({
         {
           text: 'Everything else',
           items: [
-            { text: 'Testing', link: '/guide/testing' },
             { text: 'Trimming and AOT', link: '/guide/aot' },
             { text: 'Troubleshooting', link: '/guide/troubleshooting' },
+            { text: 'Writing your own generator', link: '/guide/extending' },
           ],
         },
       ],

--- a/website/guide/aot.md
+++ b/website/guide/aot.md
@@ -1,7 +1,6 @@
 # Trimming and Native AOT
 
-This is the reason the library exists in the shape it does, so it is worth being precise about what
-survives and what does not.
+What survives trimming, and what does not.
 
 ## The problem with scanning at run time
 
@@ -18,18 +17,15 @@ assembly:
 services.AddScoped(typeof(IHandler<CreateOrder, OrderId>), typeof(CreateOrderHandler));
 ```
 
-Two things follow, and the second matters more than people expect.
+Two things follow.
 
 **The trimmer roots the type**, because a `typeof()` in your code is an ordinary static reference.
 
 **The constructor survives too.** `ServiceDescriptor`'s implementation-type parameter carries
-`[DynamicallyAccessedMembers(PublicConstructors)]`. That annotation can only flow to a type the
-compiler knows about — which is exactly what a literal `typeof()` gives it, and exactly what a type
-discovered at run time does not.
+`[DynamicallyAccessedMembers(PublicConstructors)]`, and that annotation can only flow to a type the
+compiler knows about.
 
-Neither works when the type is only discovered at run time. **The capability that breaks a
-reflection-based scanner is the capability that works here**, including for
-[types in a referenced package](/guide/scanning).
+Both hold for [types in a referenced package](/guide/scanning) as well.
 
 ## What this covers
 
@@ -46,9 +42,7 @@ build is a compile-time decision and belongs to `#if`.
 **Open generic registration is the least AOT-friendly part of the container itself**, independent of
 this library. If you are targeting Native AOT aggressively, prefer closed registrations.
 
-**Runtime assembly discovery is not offered.** Scrutor's `FromApplicationDependencies()`,
-`FromDependencyContext()` and `FromAssemblyDependencies()` load libraries by name at run time. There
-is no compile-time answer, so those are deliberately absent rather than approximated — see
+**Runtime assembly discovery is not supported**, since there is nothing to resolve at build time. See
 [Scanning a package](/guide/scanning).
 
 ## The generator never ships

--- a/website/guide/conventions.md
+++ b/website/guide/conventions.md
@@ -14,6 +14,9 @@ public partial class DataModule : IConventionModule {
 }
 ```
 
+Implement `Conventions` **explicitly**, as above. An implicit `public void Conventions(…)` does not
+compile.
+
 ::: tip Install
 Conventions ship in their own analyzer package, so a project that does not use them never loads the
 class-scanning providers.
@@ -25,36 +28,12 @@ dotnet add package DependencyModules.Conventions
 
 ## The body never runs
 
-This is the one thing worth understanding before anything else. `Conventions` is **read** at compile
-time, not executed. The generator parses the calls out of your source, resolves the matching types,
-and emits ordinary registrations. Nothing implements `IConventionDefinitions` at run time and the
-method is never called.
+`Conventions` is **read** at compile time, not executed. That means only the calls documented on this
+page may appear in it — a loop, a conditional, a local variable or a call to your own helper is
+reported as [DM0009](/reference/diagnostics#dm0009).
 
-That has two consequences.
-
-**Only the declared calls may appear in it.** A loop, a conditional, a local variable or a call to
-your own helper cannot be evaluated during a build, so they are reported as
-[DM0009](/reference/diagnostics#dm0009) rather than quietly ignored.
-
-**You get the same output as writing it by hand.** There is no convention engine at run time, no
-registration strategy to configure. `EmitCompilerGeneratedFiles` will show you `services.AddScoped(…)`
-calls, one per match.
-
-## Why the interface name appears twice
-
-```csharp
-public partial class DataModule : IConventionModule {
-    void IConventionModule.Conventions(IConventionDefinitions conventions) { }
-    // ^^^^^^^^^^^^^^^^^^ explicit implementation
-}
-```
-
-`IConventionDefinitions` is emitted `internal` into your compilation, so an implicit
-`public void Conventions(…)` is `CS0051: Inconsistent accessibility`. Explicit implementation is the
-only shape that compiles.
-
-Emitting the contract `internal` keeps it off your public API surface, and it means two assemblies
-that both use conventions do not collide on the same type names.
+What comes out is ordinary registration code, one `services.AddScoped(…)` per match. Turn on
+`EmitCompilerGeneratedFiles` to read it.
 
 ## What matches
 
@@ -79,10 +58,8 @@ public class ProductRepository : RepositoryBase { }      // no match by default
 conventions.RegisterAll<IRepository>().IncludeBaseClasses().AsScoped();   // now it matches
 ```
 
-Extending a class is a statement about implementation reuse rather than about the contract, and
-every subclass added years later would otherwise join the convention with nobody revisiting it. It
-is an opt-in because the common `CreateOrderValidator : AbstractValidator<CreateOrder>` shape needs
-it and because silently inheriting registration is worse than typing one call.
+Turn it on for the common `CreateOrderValidator : AbstractValidator<CreateOrder>` shape. Bear in mind
+that every future subclass of that base joins the convention too.
 
 ::: info Attributes always win
 A type carrying `[SingletonService]`, `[ScopedService]`, `[TransientService]` or `[CrossWireService]`
@@ -92,8 +69,8 @@ it decorates, and it is not a service.
 
 ## Open generics
 
-`typeof(IHandler<,>)` cannot be written as a type argument, which is why there is a `Type` overload.
-Each match registers against the **closed** construction it actually implements:
+An open generic cannot be written as a type argument, so use the `Type` overload. Each match
+registers against the **closed** construction it implements:
 
 ```csharp
 public class CreateOrderHandler : IRequestHandler<CreateOrder, OrderId> { }
@@ -165,9 +142,8 @@ bare type name. Matching is ordinal and case-sensitive, like C# identifiers.
 conventions.RegisterAll<IRepository>().WithName("*Repository", "*Store").AsScoped();
 ```
 
-Name globbing is the weakest selector here and is listed last deliberately. It is the one most likely
-to match something nobody intended when a class is added years later — prefer a service type, an
-attribute, or a namespace.
+Prefer a service type, an attribute or a namespace where you can. A name pattern will happily match
+a class somebody adds next year.
 
 ## Registering types that implement nothing
 
@@ -182,9 +158,8 @@ conventions.RegisterAll()
     .AsScoped();
 ```
 
-It requires a shape — there is nothing to register the matches *as* otherwise — and at least one
-filter. Without a filter it would match every class in the compilation, which is never what anybody
-means, so it is reported rather than obeyed.
+It requires a shape and at least one filter. Both are reported as
+[DM0009](/reference/diagnostics#dm0009) if missing.
 
 ## What each match is registered as
 
@@ -220,18 +195,16 @@ types gives the same instance. The difference is reach — `AlsoAsSelf()` regist
 the convention matched, `AsSelfWithInterfaces()` registers everything the type implements.
 
 ::: warning AsSelfWithInterfaces skips System interfaces
-Interfaces declared in `System` or a namespace beginning `System.` are not expanded into. Without
-that, any type whose base implements `IDisposable` would become resolvable *as* `IDisposable`, and a
-FluentValidation validator would become resolvable as `IEnumerable<IValidationRule>`.
+Interfaces in `System` or a namespace beginning `System.` are not expanded into, so a type whose base
+implements `IDisposable` does not become resolvable as `IDisposable`.
 
-It applies only to the expansion. A service type you named yourself is always honoured, so
+This applies only to the expansion. A service type you name yourself is always honoured, so
 `RegisterAll<IDisposable>()` still registers `IDisposable`.
 :::
 
 ## Lifetime, keys and registration strategy
 
-A lifetime is required. There is no default, because a lifetime nobody wrote down is the most
-expensive thing for a registration to get wrong — omitting one is
+A lifetime is required; there is no default. Omitting one is
 [DM0009](/reference/diagnostics#dm0009).
 
 ```csharp
@@ -243,9 +216,8 @@ conventions.RegisterAll<IRepository>()
 
 ## When two conventions collide
 
-Two conventions in one module that would register the same implementation under the **same service
-type** is [DM0004](/reference/diagnostics#dm0004), an error. One lifetime has to win and the source
-does not say which.
+Two conventions in one module registering the same implementation under the **same service type** is
+[DM0004](/reference/diagnostics#dm0004), an error — the lifetime would be ambiguous.
 
 ```csharp
 conventions.RegisterAll<IRepository>().AsScoped();
@@ -265,11 +237,10 @@ Conventions in *different* modules never collide — each registers into its own
 
 ## What conventions will not do
 
-Every Scrutor overload that takes a lambda — `Where(Func<Type,bool>)`,
-`AsImplementedInterfaces(predicate)`, `WithLifetime(Func<Type,ServiceLifetime>)` — has no
-compile-time equivalent. A generator cannot run your code over the types it is describing.
+Anything that would need a lambda over the matched types — a predicate, or a lifetime chosen per type
+— cannot be expressed, because the declaration is read at compile time rather than run.
 
-The escape hatch is a normal method, and it composes with everything above:
+Use `IServiceCollectionConfiguration` for those, alongside your conventions:
 
 ```csharp
 [DependencyModule]

--- a/website/guide/decorators.md
+++ b/website/guide/decorators.md
@@ -26,9 +26,9 @@ The **first constructor parameter is the wrapped instance**; every other paramet
 the container. You never register the decorator yourself — `[Decorator]` is enough, and the
 decorator is not registered as a service in its own right.
 
-That last part matters with [conventions](/guide/conventions): a decorator implements the interface
-it decorates, so a convention scanning that interface would otherwise match the decorator too.
-`[Decorator]` takes it out of convention matching for exactly that reason.
+This matters with [conventions](/guide/conventions): a decorator implements the interface it
+decorates, and `[Decorator]` keeps it out of convention matching so it is not registered as a service
+in its own right.
 
 ## Ordering
 
@@ -45,8 +45,7 @@ that declared them. Lower orders sit closer to the implementation; higher ones w
 By convention framework packages use 0–999 and application code 1000 and above, so an application's
 decorators wrap those contributed by the libraries it consumes.
 
-Two decorators of one service sharing an order is [DM0007](/reference/diagnostics#dm0007) — the
-nesting would be unpredictable from reading the source.
+Two decorators of one service sharing an order is [DM0007](/reference/diagnostics#dm0007).
 
 ## Open generics
 
@@ -88,13 +87,10 @@ public partial class DataModule;
 ## Ordering relative to services
 
 Decoration runs as a distinct phase **after** every module's registrations, so a decorator sees
-everything registered by every module in the call. You do not have to sequence anything, which is
-the main difference from `Decorate()` in Scrutor.
+everything registered by every module in the call and you do not have to sequence anything.
 
-The contract is worth stating precisely: a decorator sees the services registered by the modules in
-its `AddModule(s)` call. Anything the application registers afterwards is outside that scope, which
-is inherent to `IServiceCollection` — decoration rewrites descriptors, so it can only see
-descriptors that exist.
+A decorator sees the services registered by the modules in its `AddModule(s)` call. Anything you
+register afterwards is outside that scope.
 
 ## One limitation
 
@@ -114,11 +110,10 @@ InvalidOperationException: 'IRepository`1' is registered as an open generic and 
 decorated by 'CachingRepository`1'. …
 ```
 
-Decoration replaces a registration with a factory, and the container does not allow a factory for an
-open generic service type. Register closed constructions instead.
+Register closed constructions instead.
 
-Note this is about the *registration*, not the decorator. An open generic decorator over closed
-registrations — the example further up — works and is the common case.
+This is about the *registration*, not the decorator. An open generic decorator over closed
+registrations — the example further up — works, and is the common case.
 
 ## Decorator or interceptor?
 

--- a/website/guide/environments.md
+++ b/website/guide/environments.md
@@ -24,8 +24,8 @@ Resolve `IEmailSender` and you get whichever one the environment selected.
 | `[IfEnvironmentValue(key, value)]` | the value equals exactly |
 | `[IfNotEnvironmentValue(…)]` | the inverse of either form |
 
-Conditions of **different kinds** combine with **and**. Alternatives go inside one attribute, which
-is why `IfEnvironment` takes `params` and is not `AllowMultiple` — two of them could never both hold.
+Conditions of **different kinds** combine with **and**. Alternatives go inside one attribute, as
+`params`.
 
 ```csharp
 [SingletonService]
@@ -35,7 +35,7 @@ public class RequestProfiler : IProfiler { }
 ```
 
 Environment **names** compare case-insensitively, matching `IHostEnvironment.IsDevelopment()`.
-**Values** compare ordinally, because a value is data rather than a well-known label.
+**Values** compare ordinally.
 
 ## Where the environment comes from
 
@@ -49,12 +49,9 @@ Supply nothing and you get `ModuleEnvironment.Default`, which reads the process:
 `ASPNETCORE_ENVIRONMENT`, then `DOTNET_ENVIRONMENT`, then `"Production"`. Values come from
 environment variables, read on each call rather than captured.
 
-That means `[IfEnvironment("Development")]` works with nothing wired up beyond the variable you
-already set, and the `"Production"` default means a service gated on a non-production environment
-stays unregistered unless something says otherwise.
+So `[IfEnvironment("Development")]` works with nothing wired up beyond the variable you already set.
 
-`ModuleEnvironment.None` says this application has no environment — a real object with an empty name
-and no values, rather than a null to branch on.
+`ModuleEnvironment.None` says this application has no environment — an empty name and no values.
 
 Whatever is used is **registered**, so `GetRequiredService<IModuleEnvironment>()` returns the same
 environment that decided the registrations.
@@ -68,13 +65,11 @@ services.AddSingleton<IModuleEnvironment>(new ModuleEnvironment("Staging"));   /
 services.AddSingleton<IModuleEnvironment, MyEnvironment>();                    // throws
 ```
 
-Registering by type or factory is refused with a message naming the fix, rather than silently
-falling back to the process default.
+Registering by type or factory throws, with a message naming the fix.
 :::
 
-An environment passed to `AddModules` **replaces** one already in the collection rather than joining
-it. The environment answers a single question and several would need a rule for which one wins. To
-layer one on another, read the existing one and combine before you call:
+An environment passed to `AddModules` **replaces** one already in the collection. To layer one on
+another, read the existing one and combine before you call:
 
 ```csharp
 var existing = services.FirstOrDefault(d => d.ServiceType == typeof(IModuleEnvironment))
@@ -93,35 +88,32 @@ override a default:
 [SingletonService] [IfEnvironment("Development")]    public class FakeEmailSender : IEmailSender { }
 ```
 
-In Development the fake wins, because the container resolves a single service from the last matching
+In Development the fake wins, since the container resolves a single service from the last matching
 descriptor.
 
 Across modules, **module order decides** — a referenced module's conditional registration does not
-override the module that references it. A condition says "instead of my other registration", not
-"instead of yours".
+override the module that references it.
 
 ::: info Try is first-wins
-`Using(RegistrationType.Try)` is first-wins rather than last-wins, so a conditional `Try` cannot
-override an unconditional one. The override pattern wants `Add`, which is the default.
+A conditional `Using(RegistrationType.Try)` cannot override an unconditional registration. Use `Add`,
+the default, for the override pattern.
 :::
 
 ## Conditions and conventions
 
-A class matched by a convention honours its conditions too. A class carrying a service attribute is
-never a convention candidate, so a condition on a convention-matched class has no other route — and
-dropping it would put a development-only service into production.
+A class matched by a [convention](/guide/conventions) honours its conditions too, so a condition
+works whether the class is registered by attribute or by convention.
 
 ## What conditions cost
 
 The test runs at run time, so **both branches are compiled and every conditionally registered type
-stays referenced**. Conditions change what is registered, not what ships. Trimming a service out of a
-build is a compile-time decision and belongs to `#if`.
+stays referenced**. Conditions change what is registered, not what ships. To remove a service from a
+build, use `#if`.
 
 ## Seeing it at build time
 
-Whether a condition holds is a run-time question, so there is no build error for the ordinary case.
-[DM0011](/reference/diagnostics#dm0011) reports what each conditional registration depends on, so
-the condition is visible where you are already looking.
+[DM0011](/reference/diagnostics#dm0011) reports what each conditional registration depends on, in the
+IDE at the class.
 
 A condition that names nothing to test — `[IfEnvironment()]`, `[IfEnvironmentValue("")]` — is
 [DM0012](/reference/diagnostics#dm0012).

--- a/website/guide/extending.md
+++ b/website/guide/extending.md
@@ -1,0 +1,189 @@
+# Writing your own generator
+
+DependencyModules is built out of parts you can reuse. Module discovery, configuration reading,
+diagnostics, logging and emission all live in a shared assembly, so a package can add its own
+registration mechanism without re-implementing any of it.
+
+`DependencyModules.Conventions` is exactly that — a separate analyzer package that plugs into the
+same pipeline. This page describes how, using it as the worked example.
+
+::: warning Not a supported public API yet
+These are the extension points the conventions package uses, and they are public. They are not
+versioned as a stable API, so a minor release may move them. If you build on this, pin the generator
+package version.
+:::
+
+## What you get to reuse
+
+| | |
+|---|---|
+| Module discovery | which `[DependencyModule]` classes exist, and their realms and features |
+| Configuration | the `DependencyModules_*` MSBuild properties, already parsed |
+| `DependencyFileWriter` | turns `ServiceModel`s into registration code |
+| `FileLogger` | the diagnostic log users attach to issues |
+| Diagnostics | the `DM####` descriptors and their release tracking |
+| Model equality helpers | what keeps the incremental cache working |
+
+Producing `ServiceModel`s that look like the attribute path's means emission needs no special case —
+your mechanism and `[SingletonService]` come out the same way.
+
+## The shape
+
+Two interfaces. `BaseSourceGenerator` is the Roslyn entry point, and it asks you for the generators
+that want module models:
+
+```csharp
+[Generator]
+public class MySourceGenerator : BaseSourceGenerator {
+
+    protected override IEnumerable<IDependencyModuleSourceGenerator> AttributeSourceGenerators() {
+        yield return new MyGenerator();
+    }
+
+    // SetupRootGenerator is deliberately not overridden. DependencyModules.SourceGenerator owns the
+    // module partial; emitting it from here too would declare every module twice.
+}
+```
+
+`IDependencyModuleSourceGenerator` is one method. You receive the initialization context and a
+provider of every discovered module paired with the configuration in effect:
+
+```csharp
+public class MyGenerator : IDependencyModuleSourceGenerator {
+
+    public void SetupGenerator(
+        IncrementalGeneratorInitializationContext context,
+        IncrementalValuesProvider<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> modules) {
+
+        var candidates = context.SyntaxProvider
+            .CreateSyntaxProvider(IsCandidate, GetModel)
+            .Where(model => !model.IsIgnored)
+            .Collect();
+
+        context.RegisterSourceOutput(modules.Collect().Combine(candidates), Generate);
+    }
+}
+```
+
+For an attribute-driven mechanism, `BaseAttributeSourceGenerator<TModel>` does more of the work —
+you supply the attribute types, a transform, a comparer and an ignored sentinel:
+
+```csharp
+public class MyGenerator : BaseAttributeSourceGenerator<MyModel> {
+    protected override IEnumerable<ITypeDefinition> AttributeTypes() => [MyAttributeType];
+    protected override MyModel GenerateAttributeModel(GeneratorAttributeSyntaxContext c, CancellationToken t) => …;
+    protected override IEqualityComparer<MyModel> GetComparer() => new MyModelComparer();
+    protected override MyModel IgnoredModel => MyModel.Ignore;
+    protected override void GenerateSourceOutput(SourceProductionContext context, …) => …;
+}
+```
+
+## Emitting registrations
+
+Build `ServiceModel`s and hand them to `DependencyFileWriter`. The `uniqueId` becomes part of the
+generated method and field names, so pick something that will not collide with another generator
+contributing to the same module:
+
+```csharp
+var writer = new DependencyFileWriter(logger, coverageAttributeOnMethod: true);
+
+var output = writer.Write(entryPointModel, configurationModel, serviceModels, "MyMechanism");
+
+context.AddSource(
+    entryPointModel.EntryPointType.GetFileNameHint(configuration.RootNamespace, "MyDependencies"),
+    output);
+```
+
+::: tip coverageAttributeOnMethod
+`[ExcludeFromCodeCoverage]` is not `AllowMultiple`, and attributes on partial parts combine. Only one
+writer can own the class-level attribute, so every other file contributing to the same partial has to
+apply it per member. Pass `true` unless you are the first.
+:::
+
+## Packaging
+
+The project is an analyzer, and the packaging is unforgiving in ways that only show up once someone
+installs it. Copy the conventions project's csproj rather than working it out again.
+
+```xml
+<PropertyGroup>
+  <TargetFramework>netstandard2.0</TargetFramework>
+  <IsRoslynComponent>true</IsRoslynComponent>
+  <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+  <DevelopmentDependency>true</DevelopmentDependency>
+  <IncludeBuildOutput>false</IncludeBuildOutput>
+  <!-- Analyzer package: ships an analyzer and no lib/, which is what NU5128 flags. -->
+  <NoWarn>$(NoWarn);NU5128</NoWarn>
+</PropertyGroup>
+
+<ItemGroup>
+  <None Include="$(OutputPath)\$(AssemblyName).dll"
+        Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false"/>
+</ItemGroup>
+```
+
+Roslyn supplies the compiler assemblies at load time, so every compiler dependency must be
+`PrivateAssets="all"` or it leaks into your consumers' dependency graphs.
+
+### Reusing the shared sources
+
+The shared code is compiled **into** your analyzer rather than referenced, because an analyzer
+assembly cannot depend on another one at load time:
+
+```xml
+<ItemGroup>
+  <Compile Include="../DependencyModules.SourceGenerator.Impl/**/*.cs"
+           Exclude="../DependencyModules.SourceGenerator.Impl/obj/**/*">
+    <Link>Impl\%(RecursiveDir)/%(FileName)%(Extension)</Link>
+  </Compile>
+</ItemGroup>
+```
+
+That works because **`Impl` declares no `[Generator]` of its own**. Compiling it into a second
+analyzer assembly adds no second registration of the service, decorator or interceptor generators, so
+a project referencing both packages does not generate everything twice.
+
+If you carry the `DM####` descriptors, you need their release tracking too or the build fails RS2008:
+
+```xml
+<ItemGroup>
+  <AdditionalFiles Include="../DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Shipped.md"/>
+  <AdditionalFiles Include="../DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md"/>
+</ItemGroup>
+```
+
+## Three rules that will cost you a day each
+
+**Never put a symbol in a model.** `ISymbol` is not equatable and holds its `SyntaxTree` alive.
+A model containing one never compares equal across runs, so the incremental cache misses on every
+keystroke and pins memory. Render what you need to strings or `ITypeDefinition` during the transform.
+
+**Give every model structural equality.** A positional record compares `IReadOnlyList` members by
+reference, so two structurally identical models built on consecutive runs are unequal and everything
+downstream recomputes. `ModelEquality.ListEquals` and `ListHashCode` exist for this.
+
+**Keep the predicate syntax-only and cheap.** It runs on a great many nodes. Reject on node type
+first, and do not touch the semantic model — resolve in the transform, which runs only for what the
+predicate accepted.
+
+## Refuse rather than guess
+
+The house style is that an unsupported shape produces a `DM####` diagnostic and generates nothing.
+The failure mode should be "this library does not support X", never a `CS` error inside generated
+code, and never a silent absence.
+
+Silent failure is the recurring bug class here. When you add something, ask what happens when it does
+not work — and if the answer is "nothing is registered and the build is green", add a diagnostic.
+
+## Testing it
+
+Drive the generator in memory and then **execute what it produced**. Asserting on generated text
+passes happily while the wrong service type is registered.
+
+The pattern used throughout this repository is: compile the source with the generator, emit a real
+assembly, load it, build a provider, and resolve. See [Testing](/guide/testing) for the consumer-facing
+equivalent.
+
+One caveat if you drive two analyzers from one test project: both compile in the shared `Impl`
+sources, so referencing both as libraries puts two copies of every `Impl` type in scope and every use
+is `CS0433`. Reach the second through an `Alias` and let everything else resolve to the first.

--- a/website/guide/interception.md
+++ b/website/guide/interception.md
@@ -22,8 +22,8 @@ public class TimingInterceptor(ILogger log) : IInterceptor {
 public class Repository : IRepository { }
 ```
 
-Because the interface is not generic and the method is, the return type comes from the generated
-call site. Nothing is boxed and nothing is inspected at run time.
+The return type comes from the generated call site, so nothing is boxed and nothing is inspected at
+run time.
 
 ::: info Only calls through the interface
 A call the implementation makes to itself does not pass through the wrapper.
@@ -31,9 +31,8 @@ A call the implementation makes to itself does not pass through the wrapper.
 
 ## Three interfaces, chosen per member
 
-A synchronous interceptor has nowhere to await, so it cannot serve a `Task`-returning member — the
-surrounding code would report completion when the task was handed back rather than when the work
-finished. Implement whichever you can serve:
+A synchronous interceptor cannot serve a `Task`-returning member, because it has nowhere to await.
+Implement whichever you need:
 
 | Interface | For members returning |
 |---|---|
@@ -56,10 +55,8 @@ public class TracingInterceptor : IInterceptor, IAsyncInterceptor {
 }
 ```
 
-An interceptor implementing only `IAsyncInterceptor` applied to a service with both synchronous and
-asynchronous members intercepts the asynchronous ones and passes the rest straight through. That is
-deliberate: an interface is intercepted as a whole, and an interceptor has nothing to say about the
-members it cannot serve.
+An interceptor implementing only `IAsyncInterceptor`, applied to a service with both synchronous and
+asynchronous members, intercepts the asynchronous ones and passes the rest straight through.
 
 ## Awaiting is yours
 
@@ -75,14 +72,12 @@ public async ValueTask<TResult> InterceptAsync<TResult>(AsyncInvocationContext<T
 }
 ```
 
-A `using` spanning the call is inexpressible with separate enter and exit hooks, which is why there
-are none.
+
 
 ## Streams
 
-An `IAsyncEnumerable<T>` member hands its stream back immediately, so wrapping it as an ordinary
-value would measure the construction of the iterator and nothing else. A stream interceptor
-enumerates it, and so observes each item as it is produced:
+An `IAsyncEnumerable<T>` member hands its stream back immediately. A stream interceptor enumerates
+it, so it observes each item as it is produced:
 
 ```csharp
 public async IAsyncEnumerable<TItem> InterceptStream<TItem>(StreamInvocationContext<TItem> context) {
@@ -105,7 +100,7 @@ public async IAsyncEnumerable<TItem> InterceptStream<TItem>(StreamInvocationCont
 | `Caller.ServiceType`, `Caller.MemberName` | what is being called |
 | `Arguments` | by index or by name, and **writable** — a write replaces what the implementation receives |
 
-Arguments cost nothing until read, because they are typed fields that box only on access.
+Arguments cost nothing until you read one.
 
 ## Several interceptors
 
@@ -119,10 +114,9 @@ own dependencies.
 
 ## What cannot be intercepted
 
-The generator refuses rather than guessing, reporting [DM0008](/reference/diagnostics#dm0008):
+These are reported as [DM0008](/reference/diagnostics#dm0008) and left unwrapped:
 
-- `ref`, `in` and `out` parameters, and `ref struct` parameters — they cannot live in a field, and
-  async cannot take them either
+- `ref`, `in` and `out` parameters, and `ref struct` parameters
 - by-reference returns
 - `init`-only setters
 - static members

--- a/website/guide/scanning.md
+++ b/website/guide/scanning.md
@@ -10,39 +10,29 @@ conventions.RegisterAll(typeof(IHandler<,>))
     .AsScoped();
 ```
 
-## It still happens at compile time
-
-The types are read as Roslyn symbols during the build, and each match is emitted as a literal
-`typeof()` into your assembly:
+The types are read during the build, and each match is emitted as a literal `typeof()` into your
+assembly:
 
 ```csharp
 services.AddScoped(typeof(IHandler<CreateOrder, OrderId>), typeof(ThePackage.CreateOrderHandler));
 ```
 
-Nothing is loaded or reflected over at run time. This is the point at which reflection-based
-scanners stop working under trimming and this one keeps going — see
+Nothing is loaded or reflected over at run time, so this survives trimming — see
 [Trimming and AOT](/guide/aot).
 
-## The assembly is always named
+## Name one assembly at a time
 
-There is no "scan everything I depend on", and there should not be. Walking every reference visits
-thousands of types on every keystroke where one named assembly visits its own — measured at roughly
-700× the cost on a minimal eleven-reference compilation.
-
-Naming it with a **type** rather than a string means an assembly that is not referenced cannot be
-asked for. The mistake is unexpressible rather than diagnosable.
+There is no "scan everything I depend on". Point each convention at the assembly you want, using any
+type from it as the marker.
 
 ## What is visible
 
-Only `public` types cross an assembly boundary. A scan of the project being built also sees
-`internal` ones.
+Only `public` types cross an assembly boundary, where a scan of your own project also sees `internal`
+ones. Nothing warns about this — the generator cannot see what it cannot see.
 
-Nothing can report the type it cannot see, so this is a difference to know rather than one the
-generator can warn about.
-
-Types carrying `[SingletonService]` and friends are skipped, as they are in the project being built.
-An assembly whose types carry those attributes has its own module and registers them itself —
-compose that module instead of scanning it.
+Types carrying `[SingletonService]` and friends are skipped, as they are in your own project. An
+assembly whose types carry those attributes has its own module; compose that module rather than
+scanning it.
 
 ## Filters and shapes still apply
 
@@ -54,19 +44,18 @@ conventions.RegisterAll<IPolicy>()
     .AsSingleton();
 ```
 
-## What stays out
+## When to reach for it
 
-Scrutor's `FromApplicationDependencies()`, `FromDependencyContext()` and
-`FromAssemblyDependencies(Assembly)` load runtime libraries by name, including assemblies that were
-never compile-time references. There is no compile-time answer to that and no way to fake one, so it
-is not offered.
+Scanning is for assemblies you **do not own** — a package whose handlers or validators you want
+registered.
 
-Note also that a referenced project **you own** is better served by giving it its own module with
-its own conventions and composing through module attributes — explicit, ordered, and cross-assembly
-by construction. Scanning earns its keep on assemblies you cannot add a module to.
+For a project you own, give it its own module with its own conventions and compose through module
+attributes. That works across assemblies already, and keeps each project in charge of its own
+registrations.
+
+Discovering assemblies at run time is not supported, since there is nothing to resolve at build time.
 
 ## Diagnostics
 
 A match from a referenced assembly has no source to point at, so
-[DM0010](/reference/diagnostics#dm0010) and friends report at the `RegisterAll` line instead of at
-the class.
+[DM0010](/reference/diagnostics#dm0010) and friends report at the `RegisterAll` line.

--- a/website/guide/services.md
+++ b/website/guide/services.md
@@ -35,8 +35,7 @@ type or any of its interfaces gives the same instance.
 public class Cache : IReadCache, IWriteCache { }
 ```
 
-Two independent registrations would give you one instance per service type, which is almost never
-what people mean.
+Registering the interfaces separately would give you one instance per service type instead.
 
 ## Keys
 
@@ -97,9 +96,8 @@ public SomeClass(IDep one) { }
 
 ## Generated factories
 
-By default the generator emits `typeof(Implementation)` and lets the container construct it. Turning
-on factory generation emits a `new` expression instead, which removes the container's reflection
-from the hot path:
+By default the generator emits `typeof(Implementation)` and the container constructs it. Factory
+generation emits a `new` expression instead, removing the container's reflection from the hot path:
 
 ```xml
 <PropertyGroup>

--- a/website/guide/testing-mocks.md
+++ b/website/guide/testing-mocks.md
@@ -1,0 +1,89 @@
+# Mocks and values
+
+Not every parameter should come from the real container. Two attributes cover the rest, and a third
+lets a single test override a registration.
+
+## Mocking
+
+`[Mock]` on a parameter substitutes that service. The substitute is **registered in the container**,
+so anything resolved afterwards depends on the mock rather than the real implementation.
+
+```csharp
+[assembly: NSubstituteSupport]
+```
+
+```csharp
+[ModuleTest]
+[ApplicationModule]
+public void SendsToTheCustomerAddress(OrderService service, [Mock] IEmailSender sender) {
+    service.Place(new Order { Email = "a@b.com" });
+
+    sender.Received().Send("a@b.com");
+}
+```
+
+`OrderService` is constructed by the container and receives the same substitute the test holds. You
+do not wire anything together.
+
+`[NSubstituteSupport]` supplies the mocking library. Without it `[Mock]` fails with a message saying
+so. Like the module attributes it applies at assembly, class or method level; assembly is usually
+right.
+
+## Supplying values
+
+Some parameters are not services at all. `[InjectValues]` provides them, and it mixes with
+resolution: a record can take both a service and a literal.
+
+```csharp
+public record InjectModel(IDependencyOne DependencyOne, string StringValue);
+
+[ModuleTest]
+[SutModule]
+public void InjectTestValue([InjectValues("Hello World!")] InjectModel model) {
+    Assert.NotNull(model.DependencyOne);                // from the container
+    Assert.Equal("Hello World!", model.StringValue);    // from the attribute
+}
+```
+
+The values are matched to the constructor parameters the container cannot supply, so you only list
+the ones it could not work out for itself.
+
+## Registering something for one test
+
+`[TestExport]` adds a registration to the test's container without touching the module. Useful for a
+stub you want the real container to construct, or for overriding one service in one place.
+
+```csharp
+[ModuleTest]
+[ApplicationModule]
+[TestExport(typeof(IClock), Implementation = typeof(FixedClock), Lifetime = ServiceLifetime.Singleton)]
+public void UsesTheFixedClock(IOrderService service) { }
+```
+
+| Property | |
+|---|---|
+| *(constructor)* | the service type |
+| `Implementation` | defaults to the service type when omitted |
+| `Lifetime` | defaults to `Transient` |
+
+It applies at assembly, class or method level, so a stub every test needs can sit at the top of the
+file once.
+
+## Which one to reach for
+
+| | |
+|---|---|
+| `[Mock]` | you want to assert on the interaction — what was called, with what |
+| `[TestExport]` | you want a real object with different behaviour, constructed by the container |
+| `[InjectValues]` | the parameter is data, not a service |
+
+## A trap worth knowing
+
+An [intercepted](/guide/interception) service resolves as a **generated wrapper**, so this fails:
+
+```csharp
+Assert.IsType<Orders>(provider.GetRequiredService<IOrders>());   // it is Orders_Intercepted
+```
+
+Assert on the interface or on behaviour instead. The same applies to a
+[decorated](/guide/decorators) service, where the outermost decorator is what resolves.

--- a/website/guide/testing-registrations.md
+++ b/website/guide/testing-registrations.md
@@ -1,0 +1,123 @@
+# Testing registrations
+
+The xUnit package tests behaviour *through* the container. For assertions about the registrations
+themselves — lifetimes, keys, how many types matched — build the collection directly and look at it.
+No test framework integration is involved.
+
+```csharp
+using DependencyModules.Runtime;
+
+var services = new ServiceCollection();
+
+services.AddModules(new DataModule());
+
+var descriptor = Assert.Single(services, d => d.ServiceType == typeof(IRepository));
+
+Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
+Assert.Equal(typeof(SqlRepository), descriptor.ImplementationType);
+```
+
+## Testing a convention
+
+This is the shape that matters most, because the interesting question about a
+[convention](/guide/conventions) is usually *which types matched* rather than what one of them does.
+
+```csharp
+var registered = services
+    .Where(d => d.ServiceType == typeof(IRepository))
+    .Select(d => d.ImplementationType!.Name)
+    .OrderBy(name => name)
+    .ToArray();
+
+Assert.Equal(["OrderRepository", "ProductRepository"], registered);
+```
+
+Assert on the **whole set** rather than using `Assert.Contains` — that is what catches a convention
+quietly picking up an extra type.
+
+## Testing conditional registrations
+
+Registrations gated on the [environment](/guide/environments) are decided when the modules are
+applied, so the environment has to be supplied at that point:
+
+```csharp
+var services = new ServiceCollection();
+
+services.AddModules(new ModuleEnvironment("Development"), new ApplicationModule());
+
+Assert.IsType<FakeEmailSender>(
+    services.BuildServiceProvider().GetRequiredService<IEmailSender>());
+```
+
+::: warning Name the environment
+Supply nothing and the process environment is used, which defaults to `"Production"`. A test for a
+development-only service that forgets this tests the wrong branch.
+:::
+
+A theory covers both sides in one place:
+
+```csharp
+[Theory]
+[InlineData("Development", typeof(FakeEmailSender))]
+[InlineData("Production", typeof(SmtpEmailSender))]
+public void SelectsTheSenderByEnvironment(string environment, Type expected) {
+    var services = new ServiceCollection();
+
+    services.AddModules(new ModuleEnvironment(environment), new ApplicationModule());
+
+    Assert.IsType(expected, services.BuildServiceProvider().GetRequiredService<IEmailSender>());
+}
+```
+
+## Testing decorators
+
+Assert on the resolved type, and on the effect. For [ordering](/guide/decorators#ordering), have each
+decorator contribute to a string — far clearer than reflecting over the chain:
+
+```csharp
+Assert.Equal("outer(inner(core))", provider.GetRequiredService<IOrdered>().Describe());
+```
+
+## Testing interceptors
+
+Easiest through something the interceptor records:
+
+```csharp
+var provider = services.BuildServiceProvider();
+var log = provider.GetRequiredService<InterceptLog>();
+
+provider.GetRequiredService<IOrders>().Count("acme");
+
+Assert.Equal(["intercepted Count"], log.Lines);
+```
+
+::: danger Build one provider
+Building a provider twice gives you two independent sets of singletons. Resolving a service from one
+and asserting on a singleton captured from another compares two different instances, and the failure
+looks like the registration is broken.
+
+```csharp
+var provider = services.BuildServiceProvider();   // once
+
+var service = provider.GetRequiredService<IOrders>();
+var log = provider.GetRequiredService<InterceptLog>();   // same provider, same singleton
+```
+
+:::
+
+## Testing what a package scan found
+
+A [referenced-assembly scan](/guide/scanning) is worth pinning: a package upgrade can change what
+matches.
+
+```csharp
+var policies = provider.GetServices<IPackagePolicy>()
+    .Select(policy => policy.Name)
+    .OrderBy(name => name)
+    .ToArray();
+
+Assert.Equal(["first", "second"], policies);
+```
+
+Remember only `public` types cross an assembly boundary, so a scan finds strictly less than the same
+convention would in your own project.

--- a/website/guide/testing.md
+++ b/website/guide/testing.md
@@ -1,4 +1,4 @@
-# Testing
+# Testing modules
 
 Testing a module means building a provider from it and asking what came out. The xUnit package does
 that for you: a test names the modules it wants, declares the services it needs as parameters, and
@@ -48,46 +48,6 @@ public class OrderServiceTests {
 }
 ```
 
-## Mocking
-
-`[Mock]` on a parameter substitutes that service. The substitute is **registered in the container**,
-so anything resolved afterwards depends on the mock rather than the real implementation — which is
-the point.
-
-```csharp
-[assembly: NSubstituteSupport]
-```
-
-```csharp
-[ModuleTest]
-public void SendsToTheCustomerAddress(OrderService service, [Mock] IEmailSender sender) {
-    service.Place(new Order { Email = "a@b.com" });
-
-    sender.Received().Send("a@b.com");
-}
-```
-
-`OrderService` is constructed by the container and receives the same substitute the test holds.
-
-`[NSubstituteSupport]` is what supplies the mocking library. Without it, `[Mock]` has nothing to
-create substitutes with and the test fails with a message saying so.
-
-## Supplying values
-
-Some parameters are not services. `[InjectValues]` provides them, and mixes with resolution — a
-record can take both a service and a literal:
-
-```csharp
-public record InjectModel(IDependencyOne DependencyOne, string StringValue);
-
-[ModuleTest]
-[SutModule]
-public void InjectTestValue([InjectValues("Hello World!")] InjectModel model) {
-    Assert.NotNull(model.DependencyOne);          // from the container
-    Assert.Equal("Hello World!", model.StringValue);   // from the attribute
-}
-```
-
 ## Data-driven tests
 
 `[ModuleTest]` composes with xUnit's data attributes. Data parameters come first, injected ones
@@ -104,148 +64,29 @@ public void MultipleRows(string value, IDependencyOne one) {
 }
 ```
 
-## Registering something for one test
+## Scopes
 
-`[TestExport]` adds a registration to the test's container without touching the module. Useful for a
-stub you want the real container to construct, or for overriding one service.
+A `[ModuleTest]` gets its own provider, so singletons do not leak between tests. Within one test you
+can create scopes as usual:
 
 ```csharp
 [ModuleTest]
 [ApplicationModule]
-[TestExport(typeof(IClock), Implementation = typeof(FixedClock), Lifetime = ServiceLifetime.Singleton)]
-public void UsesTheFixedClock(IOrderService service) { }
-```
+public void ScopedServicesAreScoped(IServiceProvider provider) {
+    using var first = provider.CreateScope();
+    using var second = provider.CreateScope();
 
-It applies at assembly, class or method level like the module attributes, and `Implementation`
-defaults to the service type when omitted.
+    var one = first.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
-## Testing what a module registered
-
-The xUnit package is for testing *behaviour through* the container. For assertions about the
-registrations themselves — lifetimes, keys, how many things matched — build the collection directly
-and look at it. No test framework integration needed:
-
-```csharp
-using DependencyModules.Runtime;
-
-var services = new ServiceCollection();
-
-services.AddModules(new DataModule());
-
-var descriptor = Assert.Single(services, d => d.ServiceType == typeof(IRepository));
-
-Assert.Equal(ServiceLifetime.Scoped, descriptor.Lifetime);
-Assert.Equal(typeof(SqlRepository), descriptor.ImplementationType);
-```
-
-This is the right shape for testing a [convention](/guide/conventions), because the interesting
-question is usually *which types matched* rather than what one of them does:
-
-```csharp
-var registered = services
-    .Where(d => d.ServiceType == typeof(IRepository))
-    .Select(d => d.ImplementationType!.Name)
-    .OrderBy(name => name)
-    .ToArray();
-
-Assert.Equal(["OrderRepository", "ProductRepository"], registered);
-```
-
-::: warning One provider per assertion set
-Building a provider twice gives you two sets of singletons. If a test resolves a service from one
-provider and asserts on a singleton it captured from another, it will compare two different
-instances and the failure will look like the registration is wrong.
-
-```csharp
-var provider = services.BuildServiceProvider();   // build once
-
-var service = provider.GetRequiredService<IOrderService>();
-var log = provider.GetRequiredService<Log>();     // same provider, same singleton
-```
-:::
-
-## Testing conditional registrations
-
-Registrations gated on the [environment](/guide/environments) are decided when the modules are
-applied, so the environment has to be supplied then:
-
-```csharp
-var services = new ServiceCollection();
-
-services.AddModules(new ModuleEnvironment("Development"), new ApplicationModule());
-
-Assert.IsType<FakeEmailSender>(
-    services.BuildServiceProvider().GetRequiredService<IEmailSender>());
-```
-
-Supply nothing and the process environment is used, which defaults to `"Production"` — so a test for
-a development-only service **must** name the environment or it will silently test the wrong branch.
-
-A theory covers both sides in one place:
-
-```csharp
-[Theory]
-[InlineData("Development", typeof(FakeEmailSender))]
-[InlineData("Production", typeof(SmtpEmailSender))]
-public void SelectsBySender(string environment, Type expected) {
-    var services = new ServiceCollection();
-
-    services.AddModules(new ModuleEnvironment(environment), new ApplicationModule());
-
-    Assert.IsType(expected, services.BuildServiceProvider().GetRequiredService<IEmailSender>());
+    Assert.Same(one, first.ServiceProvider.GetRequiredService<IUnitOfWork>());
+    Assert.NotSame(one, second.ServiceProvider.GetRequiredService<IUnitOfWork>());
 }
-```
-
-## Testing decorators and interceptors
-
-Both change what resolving gives you, so assert on the resolved type and on the effect:
-
-```csharp
-var provider = services.BuildServiceProvider();
-
-var repository = provider.GetRequiredService<IRepository>();
-
-Assert.IsType<CachingRepository>(repository);      // the decorator is on the outside
-```
-
-For [ordering](/guide/decorators#ordering), have each decorator contribute to a string and assert the
-nesting, which is far clearer than reflecting over the chain:
-
-```csharp
-Assert.Equal("outer(inner(core))", provider.GetRequiredService<IOrdered>().Describe());
-```
-
-An [interceptor](/guide/interception) is easiest to test through something it records:
-
-```csharp
-var provider = services.BuildServiceProvider();
-var log = provider.GetRequiredService<InterceptLog>();
-
-provider.GetRequiredService<IOrders>().Count("acme");
-
-Assert.Equal(["intercepted Count"], log.Lines);
-```
-
-Note that a service resolves as a **generated wrapper**, so `Assert.IsType<Orders>(…)` fails where
-you might expect it to pass. Assert on behaviour, or on the interface.
-
-## Testing scopes
-
-```csharp
-using var first = provider.CreateScope();
-using var second = provider.CreateScope();
-
-var one = first.ServiceProvider.GetRequiredService<IUnitOfWork>();
-
-Assert.Same(one, first.ServiceProvider.GetRequiredService<IUnitOfWork>());
-Assert.NotSame(one, second.ServiceProvider.GetRequiredService<IUnitOfWork>());
 ```
 
 ## What to test, and what not to
 
-Testing that `[SingletonService]` produced `AddSingleton` is testing this library, not your code. The
-registrations worth asserting on are the ones where **you** made a decision the compiler cannot
-check:
+Testing that `[SingletonService]` produced `AddSingleton` is testing this library. Assert instead on
+the things the compiler cannot check for you:
 
 - a convention matched the set of types you meant — and, more usefully, did **not** match the ones
   you did not
@@ -253,6 +94,11 @@ check:
 - decorators nest in the order you intended
 - a service resolves at all, which catches a missing registration in a module you compose
 
-The build already tells you about the rest. A convention that matches nothing is
-[DM0005](/reference/diagnostics#dm0005), a service that cannot be constructed is
-[DM0002](/reference/diagnostics#dm0002), and both fail before a test ever runs.
+The build covers the rest — a convention that matches nothing is
+[DM0005](/reference/diagnostics#dm0005) and a service that cannot be constructed is
+[DM0002](/reference/diagnostics#dm0002), both before a test runs.
+
+## Next
+
+- [Mocks and values](/guide/testing-mocks) — substituting services and supplying literals
+- [Testing registrations](/guide/testing-registrations) — asserting on what a module registered

--- a/website/guide/troubleshooting.md
+++ b/website/guide/troubleshooting.md
@@ -51,12 +51,12 @@ namespace.
 interface or a typo in a filter.
 
 **A service was registered but resolves to the wrong implementation.** The container takes the last
-matching descriptor for a single resolve. Check the order in the generated file; conditional
-registrations are emitted after unconditional ones deliberately.
+matching descriptor for a single resolve. Check the order in the generated file — conditional
+registrations are emitted after unconditional ones.
 
 **A convention picked up something unexpected.** Narrow it with a
-[filter](/guide/conventions#narrowing-what-matches), and remember that a name glob is the weakest
-selector — `*Handler` matches a decorator named `LoggingHandler` just as readily.
+[filter](/guide/conventions#narrowing-what-matches). Watch name patterns in particular — `*Handler`
+matches `LoggingHandler` too.
 
 **`AddModule` called more than once.** Modules compose through attributes; calling `AddModule` inside
 a module or several times at the root duplicates registrations.
@@ -64,6 +64,5 @@ a module or several times at the root duplicates registrations.
 ## Reporting a problem
 
 Please include the generator log and the generated file in any
-[issue](https://github.com/ipjohnson/DependencyModules/issues). Between them they answer whether a
-service was discovered at all, which realm it landed in, and what configuration was in effect —
-none of which is visible from the generated output alone.
+[issue](https://github.com/ipjohnson/DependencyModules/issues). Between them they show whether a
+service was discovered, which realm it landed in, and what configuration was in effect.

--- a/website/reference/conventions-api.md
+++ b/website/reference/conventions-api.md
@@ -60,8 +60,7 @@ applied afterwards and any one removes a match.
 
 ## What is not offered
 
-Anything taking a lambda. `Where(Func<Type,bool>)`, `AsImplementedInterfaces(predicate)`,
-`WithLifetime(Func<Type,ServiceLifetime>)` and `WithServiceKey(Func<Type,object?>)` have no
-compile-time equivalent, because a generator cannot run your code over the types it is describing.
+Anything taking a lambda — a predicate over types, or a lifetime chosen per type. The declaration is
+read at compile time rather than run.
 
 Use `IServiceCollectionConfiguration.ConfigureServices` for those.

--- a/website/reference/diagnostics.md
+++ b/website/reference/diagnostics.md
@@ -1,7 +1,6 @@
 # Diagnostics
 
-The generator reports what it can decide at build time rather than letting it fail at startup. Each
-code can be tuned or silenced through `.editorconfig`:
+Each code can be tuned or silenced through `.editorconfig`:
 
 ```ini
 dotnet_diagnostic.DM0010.severity = none
@@ -26,16 +25,14 @@ dotnet_diagnostic.DM0010.severity = none
 
 **The generator failed; registrations may be missing.**
 
-Surfaced as a build error rather than discarded, because a generator that fails quietly produces a
-green build with no registrations. Please [open an issue](https://github.com/ipjohnson/DependencyModules/issues)
-with the generator log — see [Troubleshooting](/guide/troubleshooting).
+Please [open an issue](https://github.com/ipjohnson/DependencyModules/issues) with the generator log
+— see [Troubleshooting](/guide/troubleshooting).
 
 ## DM0002 {#dm0002}
 
 **A service type cannot be constructed and was not registered.**
 
-The implementation is abstract or a static class. Registering it would throw when the provider is
-built, a long way from the declaration responsible.
+The implementation is abstract or a static class, so the container could not construct it.
 
 ## DM0003 {#dm0003}
 
@@ -48,39 +45,35 @@ complete.
 
 **Two conventions in one module register a type as the same service type.**
 
-One lifetime has to win and the source does not say which.
+The lifetime would be ambiguous.
 
 ```csharp
 conventions.RegisterAll<IRepository>().AsScoped();
 conventions.RegisterAll<IRepository>().AsSingleton();   // DM0004
 ```
 
-Equal lifetimes are an error too — the outcome is predictable, but the declaration is redundant, and
-silently collapsing a duplicate is the failure mode this generator avoids.
+Equal lifetimes are an error too — the declaration is redundant.
 
-A type filling two *different* roles is not ambiguous and registers as both. Conventions in
-different modules never collide, because each registers into its own realm.
+A type filling two *different* roles is not ambiguous and registers as both. Conventions in different
+modules never collide; each registers into its own realm.
 
 ## DM0005 {#dm0005}
 
 **A convention matched no types.**
 
-Almost always a renamed interface or a typo in a filter. Without this it fails silently: the build is
-green and the application throws at resolve time, which is the failure Scrutor cannot report because
-its scan does not run until startup.
+Almost always a renamed interface or a typo in a filter.
 
 ## DM0006 {#dm0006}
 
 **A convention matched a type with no accessible constructor.**
 
-Reported rather than registered, because the container would throw when the provider is built.
+The container could not construct it.
 
 ## DM0007 {#dm0007}
 
 **Two decorators of one service share an order.**
 
-Their nesting would not be predictable from reading the source. See
-[Decorators](/guide/decorators#ordering).
+Their nesting would be ambiguous. See [Decorators](/guide/decorators#ordering).
 
 ## DM0008 {#dm0008}
 
@@ -94,20 +87,18 @@ The member uses `ref`, `in`, `out` or a `ref struct` parameter, returns by refer
 
 **A convention declaration could not be read.**
 
-The `Conventions` body is read at compile time rather than executed, so only a closed set of calls
-can appear in it. A loop, a conditional, a local or a call to your own helper has no compile-time
-meaning.
+The `Conventions` body is read at compile time, so only the documented calls can appear in it — a
+loop, a conditional, a local or a call to your own helper cannot.
 
-It also covers a convention that declared no lifetime, a `RegisterAll()` with no shape or no filter,
-and a chain the generator could not resolve.
+It also covers a convention with no lifetime, a `RegisterAll()` with no shape or no filter, and a
+chain that could not be resolved.
 
 ## DM0010 {#dm0010}
 
 **A service is registered by convention.**
 
-Informational, reported at the class. A class registered by convention carries no attribute saying
-so, so nothing at the declaration explains why it is in the container — this is that explanation, and
-it names the interface the match came through when it was not direct.
+Informational, reported at the class, naming the service type it was registered as and the interface
+the match came through when it was not direct.
 
 A match from a [referenced assembly](/guide/scanning) has no class to point at, so it reports at the
 `RegisterAll` line instead.
@@ -116,8 +107,7 @@ A match from a [referenced assembly](/guide/scanning) has no class to point at, 
 
 **A service is registered only when an environment condition holds.**
 
-Informational. Whether a condition holds is a run-time question, so no build error is available — this
-puts the condition where you are already looking. See [Environments](/guide/environments).
+Informational, reported at the class. See [Environments](/guide/environments).
 
 ## DM0012 {#dm0012}
 


### PR DESCRIPTION
Three changes to the docs site.

## Testing is its own section

It was one page under *Everything else*. It now sits between **Getting started** and **Registering in bulk**, split by what each part is for:

| Page | |
|---|---|
| Testing modules | `[ModuleTest]`, where module attributes go, data-driven tests, scopes, what is worth testing |
| Mocks and values | `[Mock]`, `[InjectValues]`, `[TestExport]`, and which to reach for |
| Testing registrations | asserting on descriptors — conventions, conditional registration, decorators, interceptors, package scans |

## Writing your own generator

New page at the end of *Everything else*, documenting the extension points `DependencyModules.Conventions` is built on: `IDependencyModuleSourceGenerator`, `BaseSourceGenerator`, `BaseAttributeSourceGenerator<T>`, emitting through `DependencyFileWriter`, and the analyzer packaging — which is unforgiving in ways that only appear after somebody installs the package.

It also carries the three rules that cost a day each: never put a symbol in a model, give every model structural equality, and keep the predicate syntax-only.

This page **keeps** its reasoning. Its readers are writing a generator, so the reasoning is the content.

## Less rationale everywhere else

The pages were explaining why the library was designed the way it is — *why the interface name appears twice*, *why an assembly is always named*, *why there is no default lifetime*, what would have happened had we chosen otherwise. That is design-doc material. A reader wants to know what to write and what will happen.

Roughly forty passages cut or rewritten to state the rule and the fix. For example:

> **Before** — There is no "scan everything I depend on", and there should not be. Walking every reference visits thousands of types on every keystroke where one named assembly visits its own — measured at roughly 700× the cost on a minimal eleven-reference compilation. Naming it with a **type** rather than a string means an assembly that is not referenced cannot be asked for. The mistake is unexpressible rather than diagnosable.

> **After** — There is no "scan everything I depend on". Point each convention at the assembly you want, using any type from it as the marker.

The "Why the interface name appears twice" section is gone entirely, replaced by one line: implement `Conventions` explicitly, an implicit `public` one does not compile.

**Kept** where it changes what a reader does: that both branches of a conditional registration still ship, that only `public` types cross an assembly boundary, and that building a provider twice gives you two sets of singletons.

## Build

Builds clean with no dead links; all four new and moved pages verified serving locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C56x6Vv6HJ6ArfqwKsuSb9