### PR TITLE
Measure the renamed and new assemblies in coverage

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -70,7 +70,7 @@ reportgenerator \
     "-targetdir:${OUT}" \
     "-reporttypes:Html;Cobertura;TextSummary;MarkdownSummaryGithub;Badges" \
     "-title:DependencyModules" \
-    "-assemblyfilters:+DependencyModules.Runtime;+DependencyModules.SourceGenerator;+DependencyModules.Conventions;+DependencyModules.xUnit;+DependencyModules.xUnit.NSubstitute" \
+    "-assemblyfilters:+DependencyModules.Runtime;+DependencyModules.SourceGenerator;+DependencyModules.Conventions;+DependencyModules.Testing;+DependencyModules.xUnit;+DependencyModules.NSubstitute;+DependencyModules.Moq;+DependencyModules.FakeItEasy" \
     "-classfilters:-CSharpAuthor.*" \
     >/dev/null
 


### PR DESCRIPTION
The coverage assembly filter still named `DependencyModules.xUnit.NSubstitute`, which no longer
exists after the mocking-package split, and never named `Testing`, `NSubstitute`, `Moq` or
`FakeItEasy`.

Those four were being built and tested but excluded from the report, so the 85% gate `release.yaml`
runs before publishing was scoring a subset of what actually ships.

With them included the total is **87.6%** and `DependencyModules.Testing` reports 94.2% rather than
not appearing at all.

Worth landing before tagging rc9210, since the release job runs this script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FasPSEiCXbFwobHLur2pnv