### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-08-16
+
+The first stable release. Identical in content to `1.0.0-rc9340` below — it is the same commit
+without the prerelease label, published so that `dotnet add package DependencyModules.Runtime`
+resolves without `--prerelease`, which is the single most common thing to have gone wrong for someone
+trying this library for the first time.
+
+**What stability means here.** The public API is now under [semantic
+versioning](https://semver.org/spec/v2.0.0.html): the attributes, the convention contracts, the
+runtime interfaces and the testing attributes will not break within 1.x. Two things are deliberately
+outside that promise, and both say so in their own documentation — the generator extension points
+that `DependencyModules.SourceGenerator.Impl` ships as source, which exist for frameworks building
+their own generator on this one, and the exact text of generated code, which is an implementation
+detail rather than something to compile against.
+
+Diagnostics are covered too, in the sense that a `DM####` code will not be reused for a different
+meaning. New ones may be added in a minor release, and a new warning can turn a green build red under
+`TreatWarningsAsErrors` — that is the normal cost of a diagnostic arriving, and `NoWarn` takes them
+per-project.
+
+The breaking changes gathered in the release candidates land here rather than after, which is the
+point of doing them now: `DecoratorExpansion.Expand` changed shape, and `[InjectValues]` is
+restricted to parameters. Both are described below.
+
+`net8.0` and `net10.0` are supported. `net8.0` leaves support in November 2026 and will be dropped in
+a later minor release, not a patch.
+
 ## [1.0.0-rc9340] - 2026-08-16
 
 Everything since `1.0.0-rc9230`. The theme is registrations that were silently not happening: an

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,10 +8,10 @@
     <PropertyGroup>
         <VersionPrefix>1.0.0</VersionPrefix>
         <!--
-            The release candidate label. Assembly and file versions carry no prerelease part, so
-            they stay put until the version they do carry changes.
+            Empty at 1.0.0. Set it again to cut a prerelease of the next version; assembly and file
+            versions carry no prerelease part, so they stay put until the version they do carry changes.
         -->
-        <VersionSuffix>rc9340</VersionSuffix>
+        <VersionSuffix></VersionSuffix>
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
         <FileVersion>1.0.0.0</FileVersion>
     </PropertyGroup>

--- a/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Shipped.md
+++ b/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Shipped.md
@@ -1,2 +1,25 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+## Release 1.0.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+DM0001 | DependencyModules | Error | The generator failed; registrations may be missing.
+DM0002 | DependencyModules | Warning | A service type cannot be constructed and was not registered.
+DM0003 | DependencyModules | Error | A module marked with [DependencyModule] is not partial.
+DM0004 | DependencyModules | Error | Two conventions in one module register a type as the same service type.
+DM0005 | DependencyModules | Warning | A convention matched no types.
+DM0006 | DependencyModules | Warning | A convention matched a type with no accessible constructor.
+DM0007 | DependencyModules | Error | Two decorators of one service share an order.
+DM0008 | DependencyModules | Warning | A service marked for interception cannot be wrapped.
+DM0009 | DependencyModules | Error | A convention declaration could not be read.
+DM0010 | DependencyModules | Info | A service is registered by convention.
+DM0011 | DependencyModules | Info | A service is registered only when an environment condition holds.
+DM0012 | DependencyModules | Warning | An environment condition names nothing to test.
+DM0013 | DependencyModules | Warning | A service registered as an open generic cannot be decorated.
+DM0014 | DependencyModules | Warning | A generic type cannot be cross-wired.
+DM0015 | DependencyModules | Warning | An interceptor does not apply to every member it was applied to.
+DM0016 | DependencyModules | Warning | An assembly-level module attribute's namespace is not imported.

--- a/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
+++ b/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
@@ -1,23 +1,2 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-DM0001 | DependencyModules | Error | The generator failed; registrations may be missing.
-DM0002 | DependencyModules | Warning | A service type cannot be constructed and was not registered.
-DM0003 | DependencyModules | Error | A module marked with [DependencyModule] is not partial.
-DM0004 | DependencyModules | Error | Two conventions in one module register a type as the same service type.
-DM0005 | DependencyModules | Warning | A convention matched no types.
-DM0006 | DependencyModules | Warning | A convention matched a type with no accessible constructor.
-DM0007 | DependencyModules | Error | Two decorators of one service share an order.
-DM0008 | DependencyModules | Warning | A service marked for interception cannot be wrapped.
-DM0009 | DependencyModules | Error | A convention declaration could not be read.
-DM0010 | DependencyModules | Info | A service is registered by convention.
-DM0011 | DependencyModules | Info | A service is registered only when an environment condition holds.
-DM0012 | DependencyModules | Warning | An environment condition names nothing to test.
-DM0013 | DependencyModules | Warning | A service registered as an open generic cannot be decorated.
-DM0014 | DependencyModules | Warning | A generic type cannot be cross-wired.
-DM0015 | DependencyModules | Warning | An interceptor does not apply to every member it was applied to.
-DM0016 | DependencyModules | Warning | An assembly-level module attribute's namespace is not imported.


### PR DESCRIPTION
Same content as `1.0.0-rc9340`, without the prerelease label.

The immediate reason is that `dotnet add package DependencyModules.Runtime` fails with *"There are no stable versions available"* against a feed carrying only prereleases — the first thing a new reader does, and the first thing that goes wrong. The README and docs already show the plain command, which becomes true when this ships.

## What changes

- `## [1.0.0]` in the changelog, stating what stability covers: the attributes, convention contracts, runtime interfaces and testing attributes are under semver for 1.x. Deliberately outside it, and documented as such — the generator extension points `SourceGenerator.Impl` ships as source, and the exact text of generated code.
- The `DM####` rules move from `AnalyzerReleases.Unshipped.md` to `Shipped` under Release 1.0.0.
- `VersionSuffix` emptied. The workflow takes the published version from the tag, so this only affects local builds, but an rc label in a stable tree misleads whoever reads it next.

The breaking changes gathered through the candidates land here rather than after, which is the point of doing them now: `DecoratorExpansion.Expand` changed shape, and `[InjectValues]` is restricted to parameters.

## Verification

- Full solution green on both TFMs, coverage 89.4% against the 85% gate
- `scripts/verify-packages.sh 1.0.0` passes for net8.0 and net10.0
- `1.0.0-rc9340` was published first and verified from nuget.org in a clean project with only the public feed: builds under `TreatWarningsAsErrors` and runs, including a nullable service type argument — the CS8669 case this round fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMV4J1eVscS5EBMUhhWc2x