### PR TITLE
Fix what four applications ran into against 1.1.0, and cut 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,181 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-08-27
+
+Four applications built against the published 1.1.0 packages, by four agents who did not read each
+other's work. Every fix 1.1.0 shipped held up under runtime assertion. What did not hold up was
+everything around them — a test integration that reported a pass having run nothing, a package that
+could not resolve against the xUnit a new user installs, and three statements this project published
+that were wrong.
+
+**Upgrade note: one behaviour changes.** A `[Mock]` parameter now overrides a `[TestExport]` naming
+the same service. A test declaring both silently held the real implementation before; it holds the
+mock now. On the same method that pair is contradictory and reports `DM0021`; from a class or an
+assembly it is the default being overridden for one test, which is what having both scopes is for.
+See [Mocking frameworks](https://ipjohnson.github.io/DependencyModules/guide/testing-mocking#precedence).
+
+Three new diagnostics arrive, all warnings, so `TreatWarningsAsErrors` may turn a green build red on
+code that was quietly doing nothing. Every one of them can be silenced where it is written — which
+is itself new, and the subject of the first entry below.
+
+### Fixed
+
+- **`.editorconfig` and `#pragma warning disable` did not silence most diagnostics, and 1.1.0 said
+  they did.** A diagnostic carried its file and line but was not attached to the syntax tree, and
+  Roslyn decides both `.editorconfig` severity and `#pragma` filtering from the tree. Only `NoWarn`
+  and `WarningsAsErrors` worked.
+
+  1.1.0 shipped a *documentation correction* claiming `.editorconfig` worked, "including for the
+  error-severity codes". It worked for `DM0016` and `DM0019` and nothing else — and 1.1.0 is what
+  broke it, by relocating ten diagnostics from the project onto the declaration they are about. The
+  relocation is what put them on a location with no tree.
+
+  All three mechanisms now reach every code. Diagnostics are reported from their own source outputs,
+  which is what lets them see the compilation without re-emitting every file on every keystroke.
+
+  There was no `.editorconfig` anywhere in this repository and no test exercised any of the three
+  mechanisms, which is how a documented behaviour shipped wrong in opposite directions across two
+  releases. There is now one test per code.
+
+- **`DependencyModules.xUnit` could not resolve against the `xunit.v3` a new user installs.** The
+  dependency was declared with no upper bound, `dotnet add package xunit.v3` resolves 4.0.0, and
+  4.0.0 removed the discovery API the compiled discoverer binds to. Every test failed at discovery
+  with a `MissingMethodException` naming an xUnit internal rather than this package, and nothing
+  warned at restore or build.
+
+  Bounded to `[3.2.2, 4.0.0)`, so NuGet reports it at restore instead. `DependencyModules.NUnit` is
+  bounded to its major for the same reason, before it can do the same thing.
+
+- **`[MemberData]` under `[ModuleTest]` produced zero test cases and the run reported a pass.**
+  `[MemberData]` resolves its member against `MemberType`, which xUnit back-fills on a path this
+  integration does not take — and left null, it returns an *empty* row collection rather than
+  throwing. A project moving a row set from `[InlineData]` to `[MemberData]` lost that coverage
+  silently. `[MemberData(…, MemberType = typeof(X))]` was the shape that worked.
+
+  Returning no tests is now a failure rather than a pass, which is what xUnit's own delay-enumerated
+  theory does and what the NUnit half of this integration already did.
+
+- **`DependencyModules_GenerateFactories` undid the 1.1.0 interception fixes.** Applying an
+  interception means finding the one registration its wrapper was generated from, and a factory
+  registration cannot say what implementation it built. Under the property the filter matched
+  nothing and interception went back to wrapping every registration of the service type — an
+  unmarked sibling came back inside another class's wrapper, and interceptors ran once per
+  registration. The property the AOT guidance recommends turning on restored the bug the release
+  shipped to fix.
+
+  A service any implementation intercepts now keeps its `typeof` registration whatever the property
+  says. By service type rather than by implementation: an *unmarked* sibling built by a factory
+  cannot identify itself either, so exempting only the marked class left exactly that case broken.
+
+- **A realm-scoped service with an unrealmed `[Intercept]` was never intercepted.** The registration
+  landed only in the named module and the applicator landed everywhere except it — dead in every
+  container that could exist, reported by nothing, because each half individually followed the rule.
+  An interception naming no realm now takes the one its own class's service attribute names.
+
+  Filed twice, by different agents against different applications, as two separate defects. It is
+  one bug.
+
+- **`DM0016` and `DM0019` never fired for a module from a referenced package**, which is the case
+  both exist for. They were built only from the modules declared in the same compilation, so a
+  module arriving from a NuGet package was invisible to them — and with no local module at all, the
+  pass returned before `DM0019` was considered. The reference page printed exactly the shape that
+  did not reproduce.
+
+- **`[Intercept]` was matched by its written name**, so a namespace-qualified, `global::`-qualified
+  or aliased usage found nothing — no wrapper, no diagnostic, and a cross-cutting concern that had
+  simply stopped running. This is the defect 1.1.0 fixed for the service attributes and did not
+  carry across. Nobody filed it; it was found reading the code beside the ones that were.
+
+- **A private property on a module produced generated code that would not compile.** Module
+  parameters were chosen by "settable and not static" without ever looking at accessibility, so a
+  private property was copied onto the generated `public` attribute — `CS0122`, twice, with no
+  diagnostic explaining it. A property the attribute cannot reach is no longer a parameter, and
+  `DM0018` no longer reports one.
+
+- **Declaring `[DependencyModule] partial class ApplicationModule` in a project that already gets one
+  generated produced `CS8785` and then `CS0311` against the developer's own type.** The two models
+  had different namespaces at the point they were grouped, so consolidation never saw them as one
+  module and both were emitted under the same file name. Getting Started tells the reader to use that
+  name. They merge now.
+
+- **`InterceptorModelComparer` omitted `Realm`**, so editing only `Realm = typeof(X)` hit the
+  incremental cache and left the applicator on whichever module had it before.
+
+### Added
+
+- **`[Intercept(Lifetime = …)]`.** Interceptors were always registered as singletons, so one taking a
+  scoped dependency became a captive dependency — silent unless `ValidateScopes` is on, and
+  `GenerateFactories` switches that off. Still `TryAdd`, so an interceptor carrying its own service
+  attribute keeps that lifetime.
+
+- **`[Intercept(Members = …)]`.** Covering every member is right for auditing or retry and wrong for
+  an interface with properties, where a timing interceptor records a call per read. Takes `Methods`,
+  `Properties`, `Indexers`, `Events` or any combination. A member left out is still forwarded; it
+  just does not run through the chain.
+
+- **`[Decorator(Implementation = …)]`.** The inverse of the change 1.1.0 made to interception. A
+  decorator wraps every registration of its service by default — that is what separates it from an
+  interceptor — but a project with several implementations of one interface had no way to say "wrap
+  this one".
+
+- **`Order` on the service attributes.** Decorators and interceptors have had one since they existed.
+  Registrations did not, so several implementations of one interface arrived in the order the
+  generator emitted them, sorted by class name — renaming a class reordered a pipeline. Everything
+  defaults to `0` and the sort is stable within one order.
+
+- **`DM0020`** reports an interception no module applies, so it can never run. The case it catches is
+  a realm-only module registering the class by convention, where the realm is decided at match time
+  and an interception cannot inherit it.
+
+- **`DM0021`** reports `[Mock]` and `[TestExport]` naming one service on the same method, where the
+  parameter wins and the `[TestExport]` beside it does nothing.
+
+- **`DM0022`** reports a decorator naming an implementation in a project emitting factories, where it
+  would wrap all of them instead of one.
+
+### Documentation
+
+- **The *Composing modules* example doubled if you copied it into one project.** It declared both
+  modules together while the prose meant two assemblies, and the warning explaining the doubling sat
+  ninety lines lower under another heading. The example shows two projects now, the warning sits
+  beside it, and the remedy that did not work — "have one compose the other" — is corrected: only a
+  realm removes the doubling.
+
+- **`[Intercept]`'s `Realm` existed only in the 1.1.0 changelog.** It, per-implementation
+  interception, interceptor registration and lifetime, and the new `Members` are all on
+  [Interception](https://ipjohnson.github.io/DependencyModules/guide/interception) now. The
+  decorator-versus-interceptor table read as the opposite of the truth and has been corrected.
+
+- **A new [runtime interfaces](https://ipjohnson.github.io/DependencyModules/reference/interfaces)
+  page.** `DependencyModules.Runtime.Interfaces` appeared in samples and in the `CS0311` a colliding
+  `ApplicationModule` produces, and was named on no page.
+
+- **`IEnumerable<T>` injection and `[FromKeyedServices]` are documented**, along with the limit that
+  keyed registrations are not in the enumeration.
+
+- **`DM0016`–`DM0019` are cross-referenced from the guide pages that teach their shapes**, and the
+  Parameters section carries the module-identity paragraph `DM0018` links into.
+
+- **xUnit v3 is stated concretely**: `dotnet new xunit` gives v2, which cannot be used at all; the
+  supported range is `[3.2.2, 4.0.0)`; and the guide's own data-driven example trips `xUnit1037`.
+
+- **The `EmitCompilerGeneratedFiles` hazard is written out**, including the
+  `<Compile Remove="generated/**" />` that the redirected-output form needs.
+
+### Unversioned
+
+Two design notes record what was deliberately not built: `docs/design/dispatch-by-name.md` and
+`docs/design/runtime-module-graph.md`. Both are public surface that cannot be taken back inside 1.x,
+and both need a decision rather than a guess. Dispatch-by-name is the strongest signal the round
+produced — two applications hand-built the same per-request dictionary, neither author knowing about
+the other.
+
+Two of the round's findings were **withdrawn as correct-by-design** after review, and both came from
+behaviour the documentation did not state. Four readers of one documentation set are not four
+independent observers: where the text is silent they infer the same wrong thing. Both gaps are now
+written down.
+
 ## [1.1.0] - 2026-08-26
 
 Four registrations that silently were not what they said they were, and three new diagnostics. Every

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
         local and CI builds fall back to the values below.
     -->
     <PropertyGroup>
-        <VersionPrefix>1.1.0</VersionPrefix>
+        <VersionPrefix>1.2.0</VersionPrefix>
         <!--
             Empty at 1.0.0. Set it again to cut a prerelease of the next version; the file version
             carries no prerelease part, so it stays put until the version it does carry changes.
@@ -15,14 +15,14 @@
         <!--
             Pinned to the major for the whole of 1.x, deliberately. The assembly version is part of
             assembly identity: moving it every minor release means a library compiled against 1.0.0.0
-            no longer matches the 1.1.0.0 a consuming application resolves, and the reference only
+            no longer matches the 1.2.0.0 a consuming application resolves, and the reference only
             keeps working because the host papers over the difference. Holding it removes that
             question entirely, and costs nothing — FileVersion below carries the real version for
             anyone inspecting the binary, and the NuGet package version is what people actually
             depend on. It moves at 2.0.0.
         -->
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <FileVersion>1.1.0.0</FileVersion>
+        <FileVersion>1.2.0.0</FileVersion>
     </PropertyGroup>
 
     <!--

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ declare your own:
 public partial class ApplicationModule;
 ```
 
+Declaring one in a project that already gets a generated `ApplicationModule` merges with it rather
+than colliding — and to add a `ConfigureServices` to the generated one, declare the partial
+*without* `[DependencyModule]` and implement `IServiceCollectionConfiguration`.
+
 A module must be `partial`, and must be declared directly in a namespace rather than nested
 inside another type. Services marked with `[SingletonService]` and friends may be nested freely.
 
@@ -232,6 +236,7 @@ publishing. See the [AOT guide](https://ipjohnson.github.io/DependencyModules/gu
 | `Key = "primary"` | Keyed registration |
 | `Using = RegistrationType.Try` | `Add`, `Try`, `TryEnumerable` or `Replace` |
 | `Realm = typeof(SomeModule)` | Restrict a registration to one module |
+| `Order = 10` | Where a registration sits in `IEnumerable<T>` |
 | `[IfEnvironment("Development")]` | Register only in named environments |
 | `[Decorator]` `[Decorate]` `[Intercept]` | Wrap a service, or one you do not own |
 | A `static` method carrying a service attribute | Factory, for types the container cannot build |

--- a/docs/design/dispatch-by-name.md
+++ b/docs/design/dispatch-by-name.md
@@ -1,0 +1,107 @@
+# Dispatch by name
+
+Two of the four applications in the 1.1.0 field round hand-built the same thing: a dictionary from a
+string to a handler, rebuilt on every request. Neither author knew the other was doing it. That is
+the strongest signal in the round's feature table, and it is unaddressed in 1.2.0 because the answer
+is a design choice rather than a missing property.
+
+## What they were trying to write
+
+A JSON-RPC server routes `"tools/call"` to a handler. A plugin host routes a step name to a
+transform. In both cases the set of handlers is known at compile time, the key is a string on each
+handler, and the lookup happens per request.
+
+```csharp
+// what agent 08 wrote, once per request
+var handlers = provider.GetServices<IRequestHandler>()
+    .ToDictionary(handler => handler.Method);
+
+return handlers[request.Method].HandleAsync(request);
+```
+
+## Why the existing surface does not cover it
+
+**Keyed services are the obvious answer and do not work here.** A keyed registration is reachable by
+`GetRequiredKeyedService<T>(key)`, which is the right shape — but the keys have to come from
+somewhere, and a convention applies one literal to every match:
+
+```csharp
+conventions.RegisterAll<IRequestHandler>().WithKey("handler").AsSingleton();  // one key, every match
+```
+
+There is no way to say "the key is a constant on each matched type". Writing them out by hand is the
+thing conventions exist to avoid, and it puts the routing table somewhere other than the handler.
+
+**And keyed registrations cannot be enumerated.** `GetServices<T>()` returns only the unkeyed ones,
+so a host cannot ask "what can I route to?" — which it needs for a `tools/list` response, a
+diagnostics page, or a startup check that two handlers have not claimed one name. Both applications
+needed exactly that.
+
+So the workaround is to register unkeyed, enumerate, and build the dictionary — paying a dictionary
+build per request unless the author also knows to cache it, and losing the compile-time check that
+would have caught a duplicate.
+
+## The shape of an answer
+
+Three candidates, in increasing order of what they ask of the library.
+
+### A. A key derived per match
+
+Let a convention compute the key from the matched type rather than take a literal:
+
+```csharp
+conventions.RegisterAll<IRequestHandler>()
+    .WithKeyFrom(nameof(IRequestHandler.Method))
+    .AsSingleton();
+```
+
+The generator would read a `const string` or a literal-returning property from each matched type and
+emit one keyed registration per handler with that value.
+
+*For:* small, fits the existing convention grammar, and the key stays on the handler.
+*Against:* only works for a key the generator can read at compile time — a `const`, or a property
+with a constant body. A key computed at runtime is out of reach, and the failure would have to be a
+diagnostic rather than a fallback. It also does nothing about enumeration.
+
+### B. Enumerable keyed services
+
+Emit, alongside the keyed registrations, a registration of the map itself:
+
+```csharp
+public interface IKeyedRegistry<TService> : IReadOnlyDictionary<object, TService>;
+```
+
+`IKeyedRegistry<IRequestHandler>` is then injectable, built once, and answers both questions — route
+to one, or list them all.
+
+*For:* removes the per-request dictionary build, and makes the routing table a first-class thing a
+diagnostics endpoint can read.
+*Against:* new public surface, and a decision about whether the registry resolves eagerly (holding
+every handler for the container's life) or lazily through the provider.
+
+### C. Both
+
+A is what puts the key on the handler; B is what makes the set usable. Each is useful alone, and
+together they are the feature the two applications were reaching for.
+
+## What has to be decided before this is written
+
+1. **Where does the key come from?** A `const` on the type, an attribute on the type, or a lambda in
+   the convention that the generator evaluates. Each has a different failure mode when the generator
+   cannot read it, and each needs its own diagnostic.
+2. **Does the registry resolve eagerly or lazily?** Eager is simpler and wrong for scoped handlers;
+   lazy needs the provider and pushes lifetime questions into the registry.
+3. **What happens when two handlers claim one key?** This is the check the hand-built dictionary
+   silently lost — `ToDictionary` throws at first use, in a request rather than at build. A
+   compile-time diagnostic is available here and is most of the value.
+4. **Does this replace `WithKey` or sit beside it?** A literal key is still right for a small fixed
+   set, so probably beside.
+
+## Not doing it in 1.2.0
+
+The release already carries three new attribute properties, three new diagnostics and a precedence
+change. Dispatch-by-name is the largest item in the round's feature table and the one where guessing
+the shape wrong is most expensive — it is public surface that cannot be taken back inside 1.x.
+
+Recorded here rather than deferred silently, because two independent authors reaching for the same
+missing thing is the clearest evidence the round produced.

--- a/docs/design/runtime-module-graph.md
+++ b/docs/design/runtime-module-graph.md
@@ -1,0 +1,88 @@
+# A run-time view of the composed module graph
+
+The generator knows, at compile time, exactly which modules a composition loads and what each one
+registers. None of that is reachable at run time. The plugin-host application in the 1.1.0 field
+round wanted it and invented an `IPluginDescriptor` convention every plugin author has to remember
+to implement — a hand-maintained copy of something the generator already had.
+
+## What was wanted
+
+- **What is loaded?** A host listing its plugins, a diagnostics endpoint, a startup banner.
+- **Where did this registration come from?** Answering "why is `IFoo` the wrong implementation" means
+  knowing which module registered it, which today means reading generated code.
+- **Did the module I expect actually load?** The failure DM0019 exists for is an assembly attribute
+  nobody read. A host that could ask would not need the diagnostic to catch it.
+
+## What already exists
+
+`DependencyRegistry<TModule>` holds the applied modules while the container is being built, and
+`IDependencyModule` is the shape each one implements. The information is present during
+`LoadModules`; nothing survives into the built provider.
+
+The generated code also already knows the shape — `InternalGetModules` names each composed module,
+and the dependency methods name each registration.
+
+## The shape of an answer
+
+### A. Register the module list
+
+The smallest useful thing: `LoadModules` registers what it loaded.
+
+```csharp
+public interface IModuleGraph {
+    IReadOnlyList<Type> Modules { get; }
+    bool Contains<TModule>() where TModule : IDependencyModule;
+}
+```
+
+*For:* a few lines, no generator change, and it answers "what is loaded?" and "did it load?" — the
+two questions with the sharpest failure modes today.
+*Against:* says nothing about registrations, so "which module registered `IFoo`?" is unanswered.
+
+### B. The full graph, emitted
+
+The generator emits, per module, the service types it registers, and the runtime assembles them:
+
+```csharp
+public interface IModuleGraph {
+    IReadOnlyList<ModuleNode> Modules { get; }
+}
+
+public record ModuleNode(Type ModuleType, IReadOnlyList<Type> Services, IReadOnlyList<Type> Composes);
+```
+
+*For:* answers everything above, and makes a "why is this registration here" diagnostic page
+possible without reading generated code.
+*Against:* real new surface — every registration shape has to be represented, including conditional
+ones whose presence is a run-time question, and generic ones whose closure is per-registration. Cost
+in generated code size and startup for every project, to serve a case most do not have.
+
+### C. Opt in
+
+B, behind `DependencyModules_EmitModuleGraph`, so a project that wants it pays for it.
+
+*For:* keeps the cost off projects that do not need it, and matches how `GenerateFactories` is
+handled.
+*Against:* a fourth MSBuild property, and a library whose behaviour differs by build configuration —
+which is exactly the shape that made `GenerateFactories` × interception hard to find.
+
+## What has to be decided before this is written
+
+1. **Which of the three questions is in scope?** A answers two of them for almost nothing. B answers
+   all three at real cost. That is the decision; the rest follows.
+2. **Conditional registrations.** `[IfEnvironment]` makes a registration's presence a run-time fact.
+   The graph either reports what was *declared* or what was *applied*, and those differ. The second
+   is more useful and needs the runtime, not the generator, to build it.
+3. **Trimming and AOT.** A graph of `Type` objects is the kind of thing that keeps metadata alive.
+   Whatever ships has to be measured against the 2.6 MB the round recorded, not assumed to be free.
+4. **Is this public API or a diagnostic aid?** If it is for humans reading a page, it can be a string
+   rendering and stay outside the semver promise. If it is for code to route on, it is API for 1.x.
+
+## Not doing it in 1.2.0
+
+Option A is genuinely small and could ship on its own. It is held back with B and C because shipping
+`IModuleGraph` with two of three questions answered fixes the name — and the fuller version then
+either breaks it or arrives as a second, differently-named thing.
+
+Worth noting what the workaround cost: an interface every plugin author has to remember, with no
+diagnostic when they forget. That is the failure mode this library is otherwise built to remove.

--- a/integ-tests/SutProject.Tests/DataTests/MemberDataTests.cs
+++ b/integ-tests/SutProject.Tests/DataTests/MemberDataTests.cs
@@ -1,0 +1,85 @@
+using DependencyModules.xUnit.Attributes;
+using Xunit;
+
+namespace SutProject.Tests.DataTests;
+
+/// <summary>
+/// The row sources that are not [InlineData], run end to end through [ModuleTest].
+///
+/// These shipped broken: [MemberData] resolves its member off ITypeAwareDataAttribute.MemberType,
+/// which xUnit back-fills on a path this integration does not take, and left null it yields an
+/// empty row collection instead of throwing. Every one of these methods produced zero test cases
+/// and the suite reported a pass — which is precisely why asserting inside them was not enough and
+/// this file needs to exist. A regression here is only visible as the suite getting smaller, so
+/// the unit-level counterpart in ModuleTestCaseDataTests asserts on the number of cases created.
+/// </summary>
+public class MemberDataTests {
+
+    public static TheoryData<string> Rows => new("one", "two");
+
+    public static IEnumerable<object[]> RawRows() {
+        yield return ["one"];
+        yield return ["two"];
+    }
+
+    public static IEnumerable<TheoryDataRow<string>> TypedRows() {
+        yield return new TheoryDataRow<string>("one");
+        yield return new TheoryDataRow<string>("two");
+    }
+
+    // xUnit1037 counts the row's arguments against the method's parameters and finds them short.
+    // Under [ModuleTest] that is the feature — the trailing parameters come from the container.
+#pragma warning disable xUnit1037
+
+    [ModuleTest]
+    [MemberData(nameof(Rows))]
+    [SutModule]
+    public void TheoryDataRowsAreSupplied(string value, IDependencyOne one) {
+        Assert.NotNull(value);
+        Assert.NotNull(one);
+    }
+
+    [ModuleTest]
+    [MemberData(nameof(RawRows))]
+    [SutModule]
+    public void ObjectArrayRowsAreSupplied(string value, IDependencyOne one) {
+        Assert.NotNull(value);
+        Assert.NotNull(one);
+    }
+
+    [ModuleTest]
+    [MemberData(nameof(TypedRows))]
+    [SutModule]
+    public void TheoryDataRowRowsAreSupplied(string value, IDependencyOne one) {
+        Assert.NotNull(value);
+        Assert.NotNull(one);
+    }
+
+    /// <summary>
+    /// The shape that kept working, kept as a control: an explicit MemberType needs no back-fill.
+    /// </summary>
+    [ModuleTest]
+    [MemberData(nameof(Rows), MemberType = typeof(MemberDataTests))]
+    [SutModule]
+    public void ExplicitMemberTypeRowsAreSupplied(string value, IDependencyOne one) {
+        Assert.NotNull(value);
+        Assert.NotNull(one);
+    }
+
+    [ModuleTest]
+    [ClassData(typeof(ClassRows))]
+    [SutModule]
+    public void ClassDataRowsAreSupplied(string value, IDependencyOne one) {
+        Assert.NotNull(value);
+        Assert.NotNull(one);
+    }
+
+#pragma warning restore xUnit1037
+}
+
+public class ClassRows : TheoryData<string> {
+    public ClassRows() {
+        Add("one");
+        Add("two");
+    }
+}

--- a/integ-tests/SutProject.Tests/Moq/MoqAttributeTests.cs
+++ b/integ-tests/SutProject.Tests/Moq/MoqAttributeTests.cs
@@ -1,6 +1,9 @@
 using DependencyModules.Moq;
 using DependencyModules.Testing.Attributes;
+using DependencyModules.Testing.Attributes.Interfaces;
+using DependencyModules.Testing.Impl;
 using DependencyModules.xUnit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
@@ -139,6 +142,51 @@ public class MoqAttributeTests {
         ISingletonService instance, Mock<ISingletonService> mock) {
         Assert.IsType<ExportedSingletonService>(instance);
         Assert.NotSame(mock.Object, instance);
+    }
+
+    /// <summary>
+    /// [Mock] and [TestExport] naming one service is a contradiction, and it used to resolve
+    /// silently in [TestExport]'s favour - for the [Mock] parameter too. The test held the real
+    /// implementation while believing it held a double, and the first arrange line threw a
+    /// mocking-library error naming neither attribute.
+    ///
+    /// Both behaviours are deliberate on their own, so neither moved: [Mock] registers during setup
+    /// so the subject is built against the double, then resolves from the container so the test
+    /// holds the same instance; [TestExport] registers in a later pass and is meant to win. Asking
+    /// for both is the mistake, and it is reported as one.
+    ///
+    /// Declared through the resolver rather than as a [ModuleTest] with the conflicting signature,
+    /// because a test that carries the shape cannot also survive to assert on it.
+    /// </summary>
+    [Fact]
+    public async Task MockAndTestExportOfOneServiceIsRefused() {
+        var services = new ServiceCollection();
+        var context = new ConflictContext(
+            typeof(ConflictSample).GetMethod(nameof(ConflictSample.Conflicting))!);
+        var resolver = new TestParameterResolver(context);
+
+        resolver.SetupServiceCollection(services);
+
+        // What [TestExport] does: register the named implementation in the pass that runs after the
+        // parameter attributes have had theirs.
+        services.AddSingleton<ISingletonService, ExportedSingletonService>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => resolver.ResolveArgumentsAsync(services.BuildServiceProvider(), []));
+
+        Assert.Contains("[Mock]", exception.Message);
+        Assert.Contains("[TestExport]", exception.Message);
+        Assert.Contains(nameof(ExportedSingletonService), exception.Message);
+    }
+
+    [MoqSupport]
+    public static class ConflictSample {
+        public static void Conflicting([Mock] ISingletonService service) { }
+    }
+
+    private class ConflictContext(System.Reflection.MethodInfo method) : ITestMethodContext {
+        public System.Reflection.MethodInfo Method { get; } = method;
+        public IReadOnlyList<Attribute> Attributes { get; } = [];
     }
 
     public class ExportedSingletonService : ISingletonService {

--- a/integ-tests/SutProject.Tests/Moq/MoqAttributeTests.cs
+++ b/integ-tests/SutProject.Tests/Moq/MoqAttributeTests.cs
@@ -1,9 +1,6 @@
 using DependencyModules.Moq;
 using DependencyModules.Testing.Attributes;
-using DependencyModules.Testing.Attributes.Interfaces;
-using DependencyModules.Testing.Impl;
 using DependencyModules.xUnit.Attributes;
-using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 
@@ -145,48 +142,21 @@ public class MoqAttributeTests {
     }
 
     /// <summary>
-    /// [Mock] and [TestExport] naming one service is a contradiction, and it used to resolve
-    /// silently in [TestExport]'s favour - for the [Mock] parameter too. The test held the real
-    /// implementation while believing it held a double, and the first arrange line threw a
-    /// mocking-library error naming neither attribute.
+    /// A parameter attribute does not override one on the method, the class or the assembly.
+    /// [Mock] is parameter-only and [TestExport] is not, so naming a real implementation displaces
+    /// the double for the [Mock] parameter too — it holds what the service under test holds, which
+    /// is the point of [Mock] registering rather than merely supplying an argument.
     ///
-    /// Both behaviours are deliberate on their own, so neither moved: [Mock] registers during setup
-    /// so the subject is built against the double, then resolves from the container so the test
-    /// holds the same instance; [TestExport] registers in a later pass and is meant to win. Asking
-    /// for both is the mistake, and it is reported as one.
-    ///
-    /// Declared through the resolver rather than as a [ModuleTest] with the conflicting signature,
-    /// because a test that carries the shape cannot also survive to assert on it.
+    /// Pinned because it reads like a bug and is not. The field report filed it as one: the
+    /// parameter says [Mock] and the object is real. What it is, is two documented rules composing
+    /// — parameter attributes register in the earlier pass, setup attributes in the later one, and
+    /// later wins.
     /// </summary>
-    [Fact]
-    public async Task MockAndTestExportOfOneServiceIsRefused() {
-        var services = new ServiceCollection();
-        var context = new ConflictContext(
-            typeof(ConflictSample).GetMethod(nameof(ConflictSample.Conflicting))!);
-        var resolver = new TestParameterResolver(context);
-
-        resolver.SetupServiceCollection(services);
-
-        // What [TestExport] does: register the named implementation in the pass that runs after the
-        // parameter attributes have had theirs.
-        services.AddSingleton<ISingletonService, ExportedSingletonService>();
-
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => resolver.ResolveArgumentsAsync(services.BuildServiceProvider(), []));
-
-        Assert.Contains("[Mock]", exception.Message);
-        Assert.Contains("[TestExport]", exception.Message);
-        Assert.Contains(nameof(ExportedSingletonService), exception.Message);
-    }
-
-    [MoqSupport]
-    public static class ConflictSample {
-        public static void Conflicting([Mock] ISingletonService service) { }
-    }
-
-    private class ConflictContext(System.Reflection.MethodInfo method) : ITestMethodContext {
-        public System.Reflection.MethodInfo Method { get; } = method;
-        public IReadOnlyList<Attribute> Attributes { get; } = [];
+    [ModuleTest]
+    [SutModule]
+    [TestExport(typeof(ISingletonService), Implementation = typeof(ExportedSingletonService))]
+    public void TestExportDisplacesAMockOnTheParameterToo([Mock] ISingletonService service) {
+        Assert.IsType<ExportedSingletonService>(service);
     }
 
     public class ExportedSingletonService : ISingletonService {

--- a/integ-tests/SutProject.Tests/Moq/MoqAttributeTests.cs
+++ b/integ-tests/SutProject.Tests/Moq/MoqAttributeTests.cs
@@ -142,24 +142,62 @@ public class MoqAttributeTests {
     }
 
     /// <summary>
-    /// A parameter attribute does not override one on the method, the class or the assembly.
-    /// [Mock] is parameter-only and [TestExport] is not, so naming a real implementation displaces
-    /// the double for the [Mock] parameter too — it holds what the service under test holds, which
-    /// is the point of [Mock] registering rather than merely supplying an argument.
+    /// A [Mock] on a parameter overrides a [TestExport] naming the same service. [TestExport]
+    /// applies to a method, a class or an assembly; [Mock] names one argument, and that is the
+    /// narrowest thing a test can say — the wider scope sets the default and this one test opts out.
     ///
-    /// Pinned because it reads like a bug and is not. The field report filed it as one: the
-    /// parameter says [Mock] and the object is real. What it is, is two documented rules composing
-    /// — parameter attributes register in the earlier pass, setup attributes in the later one, and
-    /// later wins.
+    /// On the same method the pair is contradictory rather than useful, and DM0021 says so at build
+    /// time. It still resolves this way, so the diagnostic is a warning about a pointless
+    /// declaration rather than an error about an ambiguous one.
     /// </summary>
+#pragma warning disable DM0021
     [ModuleTest]
     [SutModule]
     [TestExport(typeof(ISingletonService), Implementation = typeof(ExportedSingletonService))]
-    public void TestExportDisplacesAMockOnTheParameterToo([Mock] ISingletonService service) {
-        Assert.IsType<ExportedSingletonService>(service);
+    public void AMockOnAParameterBeatsATestExportOnTheMethod([Mock] ISingletonService service) {
+        Assert.IsNotType<ExportedSingletonService>(service);
+
+        global::Moq.Mock.Get(service).Setup(x => x.GetName()).Returns("mocked");
+
+        Assert.Equal("mocked", service.GetName());
     }
+#pragma warning restore DM0021
 
     public class ExportedSingletonService : ISingletonService {
         public string GetName() => "exported";
     }
+}
+
+/// <summary>
+/// The shape a parameter-level override exists for: the class names a real implementation as the
+/// default for every test in it, and one test mocks it anyway.
+///
+/// Its own fixture on purpose — a class-level [TestExport] is a default for the whole class, so
+/// putting it on the fixture above would have changed every test there, which is the point of it.
+/// </summary>
+[MoqSupport]
+[TestExport(typeof(IScopedService), Implementation = typeof(ClassLevelTestExportTests.ExportedScopedService))]
+public class ClassLevelTestExportTests {
+
+    /// <summary>The default, taken by any test that does not say otherwise.</summary>
+    [ModuleTest]
+    [SutModule]
+    public void WithoutAMockTheClassDefaultApplies(IScopedService service) {
+        Assert.IsType<ExportedScopedService>(service);
+    }
+
+    /// <summary>
+    /// And the one test that says otherwise. No diagnostic: naming a default and overriding it for
+    /// one case is what the two scopes are for, unlike declaring both on the same method.
+    /// </summary>
+    [ModuleTest]
+    [SutModule]
+    public void AMockOnAParameterBeatsIt([Mock] IScopedService service) {
+        Assert.IsNotType<ExportedScopedService>(service);
+
+        // Reachable as a mock, which is the point - the parameter is the double, not the export.
+        Assert.NotNull(global::Moq.Mock.Get(service));
+    }
+
+    public class ExportedScopedService : IScopedService { }
 }

--- a/src/DependencyModules.Moq/MoqSupportAttribute.cs
+++ b/src/DependencyModules.Moq/MoqSupportAttribute.cs
@@ -43,11 +43,14 @@ public class MoqSupportAttribute : Attribute, IMockSupportAttribute, ITestServic
     /// resolves the <c>T</c> and gets that same mock's object. Neither has to know about the other,
     /// and the test wires nothing together itself.
     ///
-    /// Runs after the value providers behind <c>[Mock]</c> and before any other setup attribute, and
-    /// registrations are last-one-wins. So this settles any disagreement with <c>[Mock]</c> — which
-    /// is what lets <c>[Mock] IFoo</c> and <c>Mock&lt;IFoo&gt;</c> sit on one test and resolve to a
-    /// matched pair rather than to two unrelated mocks — while a <c>[TestExport]</c> naming a real
-    /// implementation of the same service still overrides both.
+    /// Runs before any other setup attribute, so a <c>[TestExport]</c> naming a real implementation
+    /// of the same service still overrides what is registered here — asking for a mock object is not
+    /// the same as declaring the service mocked.
+    ///
+    /// The value providers behind <c>[Mock]</c> run after this whole pass, so that <c>[Mock]</c>
+    /// does beat a <c>[TestExport]</c>. They stand aside for a type named here, which is what lets
+    /// <c>[Mock] IFoo</c> and <c>Mock&lt;IFoo&gt;</c> sit on one test and resolve to a matched pair
+    /// rather than to two unrelated mocks.
     /// </remarks>
     /// <param name="testMethod">The test the container is being built for.</param>
     /// <param name="serviceCollection">The collection backing the test's container.</param>
@@ -92,6 +95,30 @@ public class MoqSupportAttribute : Attribute, IMockSupportAttribute, ITestServic
         }
 
         return CreateMock(type).Object;
+    }
+
+    /// <summary>
+    /// True for a type this attribute registers itself: a <c>Mock&lt;T&gt;</c> the test asked for,
+    /// or the <c>T</c> behind it.
+    /// </summary>
+    /// <remarks>
+    /// Which is what keeps <c>[Mock] IFoo</c> and <c>Mock&lt;IFoo&gt;</c> on one test resolving to a
+    /// matched pair. [Mock] registers after the setup attributes now, so that it beats a
+    /// [TestExport] naming the same service — and without this it would also beat the pairing here,
+    /// leaving the test configuring one mock while the container handed out another.
+    /// </remarks>
+    public bool RegistersService(ITestMethodContext testMethod, Type serviceType) {
+        foreach (var parameter in testMethod.Method.GetParameters()) {
+            if (!TryGetMockedType(parameter.ParameterType, out var mockedType)) {
+                continue;
+            }
+
+            if (parameter.ParameterType == serviceType || mockedType == serviceType) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static MoqLib.Mock CreateMock(Type type) =>

--- a/src/DependencyModules.NUnit/DependencyModules.NUnit.csproj
+++ b/src/DependencyModules.NUnit/DependencyModules.NUnit.csproj
@@ -25,8 +25,14 @@
           so unlike the xUnit integration there is no narrower reference to take. The types used
           here — ITestBuilder, IWrapSetUpTearDown, TestCommand — are NUnit's documented extension
           points and live in NUnit.Framework.Interfaces and NUnit.Framework.Internal.
+
+          Upper-bounded for the same reason the xUnit integration is: these are extension points, a
+          major version is where they are free to change shape, and an unbounded reference lets NuGet
+          unify a consumer's newer major into a compiled memberref that no longer exists. That failed
+          silently for xUnit 4.0.0 with a MissingMethodException naming an xUnit internal. No NUnit
+          major has done it yet; the bound is so that one cannot.
         -->
-        <PackageReference Include="NUnit" Version="4.2.2"/>
+        <PackageReference Include="NUnit" Version="[4.2.2,5.0.0)"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/DependencyModules.NUnit/Impl/ModuleTestCommand.cs
+++ b/src/DependencyModules.NUnit/Impl/ModuleTestCommand.cs
@@ -43,9 +43,11 @@ public class ModuleTestCommand(TestCommand innerCommand) : DelegatingTestCommand
 
         SetupModules(serviceCollection, method, knownAttributes);
 
-        resolver.SetupServiceCollection(serviceCollection);
-
         SetupServiceSetupAttributes(moduleContext, serviceCollection, knownAttributes);
+
+        // Last, for the reason the xUnit host records at the same point: a [Mock] on a parameter
+        // beats a [TestExport] naming the same service.
+        resolver.SetupServiceCollection(serviceCollection);
 
         var serviceProvider = BuildServiceProvider(moduleContext, serviceCollection, knownAttributes);
 

--- a/src/DependencyModules.Runtime/Attributes/BaseServiceAttribute.cs
+++ b/src/DependencyModules.Runtime/Attributes/BaseServiceAttribute.cs
@@ -123,6 +123,29 @@ public abstract class BaseServiceAttribute : Attribute, IServiceRegistrationAttr
     /// or runtime modules.
     /// </summary>
     public Type? Realm { get; set; }
+
+    /// <summary>
+    /// Where this registration sits among the others for the same service, lowest first. Zero by
+    /// default.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Decides the sequence a dependency on <c>IEnumerable&lt;T&gt;</c> arrives in, which matters
+    /// for anything read as a pipeline — validators, handlers, filters. Without it the sequence was
+    /// the order the generator emitted, sorted by class name, so renaming a class reordered a
+    /// pipeline and nothing said so.
+    /// </para>
+    /// <para>
+    /// It decides a single resolve too: the container returns the last registration of a service, so
+    /// the highest order wins a plain <c>GetService&lt;T&gt;()</c>.
+    /// </para>
+    /// <para>
+    /// Sorting is stable within one order and everything is zero by default, so a project that names
+    /// no orders is unaffected. Negative values sort ahead of that majority, which is what
+    /// "before everything else" looks like in a codebase that has never used this.
+    /// </para>
+    /// </remarks>
+    public int Order { get; set; }
     
     /// <inheritdoc />
     [Browsable(false)]

--- a/src/DependencyModules.Runtime/Attributes/DecoratorAttribute.cs
+++ b/src/DependencyModules.Runtime/Attributes/DecoratorAttribute.cs
@@ -40,4 +40,24 @@ public class DecoratorAttribute : Attribute {
     /// registration attributes.
     /// </summary>
     public Type? Realm { get; set; }
+
+    /// <summary>
+    /// Restricts the decorator to one implementation of the service, rather than every registration
+    /// of it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Wrapping every registration is the default and is what separates a decorator from an
+    /// interceptor: the decorator is written against the interface and does not care which class is
+    /// behind it. Naming an implementation is for the case where that is not true — several
+    /// implementations of one interface, and the behaviour belongs to one of them.
+    /// </para>
+    /// <para>
+    /// A registration built from a factory cannot say what implementation it came from, so naming
+    /// one here is not honoured for those — the same limit interception has, and the reason an
+    /// intercepted service keeps its <c>typeof</c> registration under
+    /// <c>DependencyModules_GenerateFactories</c>.
+    /// </para>
+    /// </remarks>
+    public Type? Implementation { get; set; }
 }

--- a/src/DependencyModules.Runtime/Attributes/InterceptAttribute.cs
+++ b/src/DependencyModules.Runtime/Attributes/InterceptAttribute.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+
 namespace DependencyModules.Runtime.Attributes;
 
 /// <summary>
@@ -46,4 +48,18 @@ public class InterceptAttribute(params Type[] interceptors) : Attribute {
     /// module built to be isolated wrapped services it had never heard of.
     /// </remarks>
     public Type? Realm { get; set; }
+
+    /// <summary>
+    /// The lifetime the interceptors named here are registered with. Singleton by default.
+    /// </summary>
+    /// <remarks>
+    /// The generator registers each interceptor as itself, and until now always as a singleton — so
+    /// an interceptor taking a scoped dependency became a captive dependency, holding it for the
+    /// life of the container. Nothing said so unless <c>ValidateScopes</c> was on, and
+    /// <c>DependencyModules_GenerateFactories</c> turns that off for the whole project.
+    ///
+    /// The registration is still <c>TryAdd</c>, so an interceptor carrying its own service
+    /// attribute keeps that lifetime and this is ignored for it.
+    /// </remarks>
+    public ServiceLifetime Lifetime { get; set; } = ServiceLifetime.Singleton;
 }

--- a/src/DependencyModules.Runtime/Attributes/InterceptAttribute.cs
+++ b/src/DependencyModules.Runtime/Attributes/InterceptAttribute.cs
@@ -62,4 +62,14 @@ public class InterceptAttribute(params Type[] interceptors) : Attribute {
     /// attribute keeps that lifetime and this is ignored for it.
     /// </remarks>
     public ServiceLifetime Lifetime { get; set; } = ServiceLifetime.Singleton;
+
+    /// <summary>
+    /// Which kinds of member the interceptors are placed around. Everything by default.
+    /// </summary>
+    /// <remarks>
+    /// A member left out is still forwarded — the wrapper implements the whole interface either way
+    /// — it simply does not run through the interceptor chain. See
+    /// <see cref="InterceptedMembers"/> for why the default is everything and when it is wrong.
+    /// </remarks>
+    public InterceptedMembers Members { get; set; } = InterceptedMembers.All;
 }

--- a/src/DependencyModules.Runtime/Attributes/InterceptedMembers.cs
+++ b/src/DependencyModules.Runtime/Attributes/InterceptedMembers.cs
@@ -1,0 +1,39 @@
+namespace DependencyModules.Runtime.Attributes;
+
+/// <summary>
+/// Which kinds of member an interception is placed around.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Interception covers the whole interface by default, which is the right default — an interceptor
+/// written for auditing or retry has no way to know which members matter, and leaving one out
+/// silently is the failure this library works hardest to avoid.
+/// </para>
+/// <para>
+/// It is the wrong default for a service whose interface carries properties. A timing or logging
+/// interceptor placed around a property getter records a call per read, which is noise rather than
+/// signal, and the workaround was to key metrics by member name and filter afterwards. Naming the
+/// kinds to cover says it at the declaration instead.
+/// </para>
+/// <para>
+/// A member left out is still forwarded — the wrapper implements the whole interface either way.
+/// It just does not run through the interceptor chain.
+/// </para>
+/// </remarks>
+[Flags]
+public enum InterceptedMembers {
+    /// <summary>Ordinary methods.</summary>
+    Methods = 1,
+
+    /// <summary>Property getters and setters.</summary>
+    Properties = 2,
+
+    /// <summary>Indexer getters and setters.</summary>
+    Indexers = 4,
+
+    /// <summary>Event add and remove accessors.</summary>
+    Events = 8,
+
+    /// <summary>Everything the interface declares. The default.</summary>
+    All = Methods | Properties | Indexers | Events
+}

--- a/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Shipped.md
+++ b/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Shipped.md
@@ -33,3 +33,13 @@ Rule ID | Category | Severity | Notes
 DM0017 | DependencyModules | Error | A dependency module is declared inside another type.
 DM0018 | DependencyModules | Warning | A module with settable properties relies on generated equality.
 DM0019 | DependencyModules | Error | An assembly-level module attribute is outside the entry point file.
+
+## Release 1.2.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+DM0020 | DependencyModules | Warning | An interception is applied by no module, so it never runs.
+DM0021 | DependencyModules | Warning | [Mock] and [TestExport] name one service on the same test method.
+DM0022 | DependencyModules | Warning | A decorator names an implementation while factories are generated.

--- a/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
+++ b/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
@@ -6,3 +6,4 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 DM0020 | DependencyModules | Warning | An interception is applied by no module, so it never runs.
+DM0021 | DependencyModules | Warning | [Mock] and [TestExport] name one service on the same test method.

--- a/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
+++ b/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 DM0020 | DependencyModules | Warning | An interception is applied by no module, so it never runs.
 DM0021 | DependencyModules | Warning | [Mock] and [TestExport] name one service on the same test method.
+DM0022 | DependencyModules | Warning | A decorator names an implementation while factories are generated.

--- a/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
+++ b/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,8 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+DM0020 | DependencyModules | Warning | An interception is applied by no module, so it never runs.

--- a/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
+++ b/src/DependencyModules.SourceGenerator.Impl/AnalyzerReleases.Unshipped.md
@@ -1,10 +1,2 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-DM0020 | DependencyModules | Warning | An interception is applied by no module, so it never runs.
-DM0021 | DependencyModules | Warning | [Mock] and [TestExport] name one service on the same test method.
-DM0022 | DependencyModules | Warning | A decorator names an implementation while factories are generated.

--- a/src/DependencyModules.SourceGenerator.Impl/BaseAttributeSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/BaseAttributeSourceGenerator.cs
@@ -23,10 +23,19 @@ public abstract class BaseAttributeSourceGenerator<T> : IDependencyModuleSourceG
             return;
         }
 
-        context.RegisterSourceOutput(
-            incrementalValueProvider.Collect().Combine(CollectModels(context, attributeTypes)),
-            WrapGenerateSourceOutput
-        );
+        // One provider, two outputs. Sharing it means the transform runs once; registering
+        // CollectModels twice would do the same discovery work twice over.
+        var models = incrementalValueProvider.Collect().Combine(CollectModels(context, attributeTypes));
+
+        context.RegisterSourceOutput(models, WrapGenerateSourceOutput);
+
+        // Diagnostics separately, with the compilation combined in. A diagnostic needs the syntax
+        // tree its location came from before Roslyn will let .editorconfig or #pragma silence it,
+        // and only the compilation can turn a file path back into a tree. Combining the compilation
+        // into the emitting output instead would re-emit every file on every keystroke, since the
+        // compilation changes with each one; this output emits nothing, so re-running it is a walk
+        // over models that are already cached.
+        context.RegisterSourceOutput(models.Combine(context.CompilationProvider), WrapReportDiagnostics);
     }
 
     /// <summary>
@@ -56,6 +65,37 @@ public abstract class BaseAttributeSourceGenerator<T> : IDependencyModuleSourceG
                         $"{exception.GetType().Name}: {exception.Message}")));
         }
     }
+
+    private void WrapReportDiagnostics(SourceProductionContext context,
+        ((ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Left, ImmutableArray<T> Right) Left,
+            Compilation Right) data) {
+        var config = data.Left.Left.FirstOrDefault().Right;
+
+        if (config != null) {
+            FileLogger.Wrap(
+                LoggerName,
+                config,
+                logger => ReportDiagnostics(context, data.Left, new SyntaxTreeLookup(data.Right), logger),
+                exception => context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        DependencyModuleDiagnostics.GeneratorFailure,
+                        Location.None,
+                        $"{exception.GetType().Name}: {exception.Message}")));
+        }
+    }
+
+    /// <summary>
+    /// Reports this generator's diagnostics. Emits nothing.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="GenerateSourceOutput"/> so that the diagnostics can see the
+    /// compilation and the emission does not have to. A generator with nothing to report leaves it
+    /// alone; the conditions belong beside the ones emission uses to skip a model, not duplicated.
+    /// </remarks>
+    protected virtual void ReportDiagnostics(SourceProductionContext context,
+        (ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Left, ImmutableArray<T> Right) data,
+        SyntaxTreeLookup lookup,
+        FileLogger logger) { }
 
     protected virtual string LoggerName => GetType().Name;
 

--- a/src/DependencyModules.SourceGenerator.Impl/BaseSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/BaseSourceGenerator.cs
@@ -143,7 +143,7 @@ public abstract class BaseSourceGenerator : IIncrementalGenerator {
             return;
         }
 
-        context.RegisterSourceOutput(valuesProvider, new DependencyModuleWriter(true).GenerateSource);
+        DependencyModuleWriter.Register(context, valuesProvider, generateAttribute: true);
     }
 
     /// <summary>

--- a/src/DependencyModules.SourceGenerator.Impl/BaseSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/BaseSourceGenerator.cs
@@ -299,30 +299,6 @@ public abstract class BaseSourceGenerator : IIncrementalGenerator {
         );
     }
 
-    private List<PropertyInfoModel> GetProperties(GeneratorSyntaxContext context) {
-        var propertyList = new List<PropertyInfoModel>();
-
-        foreach (var propertyDeclarationSyntax in
-                 context.Node.DescendantNodes().OfType<PropertyDeclarationSyntax>().ToList()) {
-            var setter =
-                propertyDeclarationSyntax.AccessorList?.Accessors.FirstOrDefault(
-                    x => x.IsKind(SyntaxKind.SetAccessorDeclaration));
-
-            var propertyType =
-                propertyDeclarationSyntax.Type.GetTypeDefinition(context);
-
-            if (propertyType != null) {
-                propertyList.Add(new PropertyInfoModel(propertyType,
-                    propertyDeclarationSyntax.Identifier.ToString(),
-                    setter == null,
-                    propertyDeclarationSyntax.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword))
-                ));
-            }
-        }
-
-        return propertyList;
-    }
-
     private bool GetEqualsFlag(GeneratorSyntaxContext context) {
         return context.Node.DescendantNodes().OfType<MethodDeclarationSyntax>().Any(m => m.Identifier.ToString().Equals("Equals"));
     }

--- a/src/DependencyModules.SourceGenerator.Impl/DecoratorFileWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DecoratorFileWriter.cs
@@ -139,6 +139,20 @@ public class DecoratorFileWriter {
             CodeOutputComponent.Get($"({ProviderParameterName}, {InnerParameterName})"),
             construct);
 
+        // The four-argument overload when an implementation is named, which is the one interception
+        // already uses: it skips a descriptor whose origin is a different type, so the decorator
+        // reaches one registration rather than every registration of the service.
+        if (decorator.Implementation != null) {
+            return SyntaxHelpers.InvokeGeneric(
+                KnownTypes.DependencyModules.Helpers.DecoratorHelper,
+                "Decorate",
+                new[] { serviceType },
+                CodeOutputComponent.Get(servicesName),
+                TypeOf(decoratorType),
+                lambda,
+                TypeOf(decorator.Implementation));
+        }
+
         return SyntaxHelpers.InvokeGeneric(
             KnownTypes.DependencyModules.Helpers.DecoratorHelper,
             "Decorate",

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyFileWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyFileWriter.cs
@@ -39,6 +39,8 @@ public class DependencyFileWriter {
             };
         }
 
+        _interceptedServiceTypes = InterceptedServiceTypes(serviceModels);
+
         _logger.Info($"Generating Dependencies for {entryPointModel.EntryPointType.Namespace}.{entryPointModel.EntryPointType.Namespace}");
 
         var csharpFile = new CSharpFileDefinition(entryPointModel.EntryPointType.Namespace);
@@ -279,8 +281,7 @@ public class DependencyFileWriter {
                 parameters.Add(serviceModel.FactoryOutput);
             }
             else if (serviceModel is { Constructor: not null, ImplementationType: not GenericTypeDefinition } &&
-                     entryPointModel.GenerateFactories.GetValueOrDefault(
-                         configurationModel.GenerateFactories)) {
+                     ShouldGenerateFactory(serviceModel, entryPointModel, configurationModel)) {
                 parameters.Add(GenerateNewFactory(serviceModel, registrationModel));
             }
             else {
@@ -316,6 +317,61 @@ public class DependencyFileWriter {
                 serviceDescriptor
             ));
     }
+
+    /// <summary>
+    /// Whether this registration is emitted as a factory rather than as <c>typeof(Impl)</c>.
+    /// </summary>
+    /// <remarks>
+    /// An intercepted implementation is always emitted as <c>typeof</c>, whatever
+    /// <c>DependencyModules_GenerateFactories</c> says. Interception rewrites the one registration
+    /// its wrapper was generated from, and it finds that registration by asking each descriptor
+    /// which implementation it was built from - which a factory descriptor cannot answer. Under the
+    /// property every descriptor was factory-built, the filter matched nothing, and interception
+    /// reverted to wrapping every registration of the service type: an unmarked sibling coming back
+    /// inside another class's wrapper, and interceptors running once per registration.
+    ///
+    /// The exemption costs that one service the property's benefit. It costs nothing else: the
+    /// wrapper is still emitted as a literal <c>new</c>, and <c>typeof</c> is what every
+    /// registration looks like with the property off, which is the shape Native AOT already runs.
+    /// </remarks>
+    private bool ShouldGenerateFactory(
+        ServiceModel serviceModel,
+        ModuleEntryPointModel entryPointModel,
+        DependencyModuleConfigurationModel configurationModel) =>
+        !IsInterceptedServiceType(serviceModel) &&
+        entryPointModel.GenerateFactories.GetValueOrDefault(configurationModel.GenerateFactories);
+
+    /// <summary>
+    /// Whether any registration of this service is one interception has to be able to pick out.
+    /// </summary>
+    /// <remarks>
+    /// The exemption is by service type rather than by implementation, and it has to be. Applying
+    /// interception means walking every descriptor of the service type and rewriting the one whose
+    /// implementation matches - so an *unmarked* sibling built by a factory is as much of a problem
+    /// as the marked one: it cannot say what it was built from either, so it cannot be told apart
+    /// from the registration being wrapped, and it came back wearing another class's wrapper.
+    /// </remarks>
+    private bool IsInterceptedServiceType(ServiceModel serviceModel) =>
+        serviceModel.Registrations.Any(
+            registration => _interceptedServiceTypes.Contains(registration.ServiceType));
+
+    private static HashSet<ITypeDefinition> InterceptedServiceTypes(IEnumerable<ServiceModel> serviceModels) {
+        var types = new HashSet<ITypeDefinition>();
+
+        foreach (var serviceModel in serviceModels) {
+            if (!serviceModel.Features.HasFlag(RegistrationFeature.Intercepted)) {
+                continue;
+            }
+
+            foreach (var registration in serviceModel.Registrations) {
+                types.Add(registration.ServiceType);
+            }
+        }
+
+        return types;
+    }
+
+    private HashSet<ITypeDefinition> _interceptedServiceTypes = new();
 
     private static object GenerateNewFactory(ServiceModel serviceModel, ServiceRegistrationModel registrationModel) {
         var parameter =
@@ -358,8 +414,7 @@ public class DependencyFileWriter {
                 parameters.Add(factoryOutput ?? TypeOf(serviceModel.ImplementationType));
             }
             else if (serviceModel is { Constructor: not null, ImplementationType: not GenericTypeDefinition } &&
-                     entryPointModel.GenerateFactories.GetValueOrDefault(
-                         configurationModel.GenerateFactories)) {
+                     ShouldGenerateFactory(serviceModel, entryPointModel, configurationModel)) {
                 parameters.Add(GenerateNewFactory(serviceModel, registrationModel));
             }
             else {
@@ -396,7 +451,7 @@ public class DependencyFileWriter {
             ));
     }
 
-    private static void HandleTryAndAddRegistrationTypes(DependencyModuleConfigurationModel configurationModel, ModuleEntryPointModel entryPointModel, ClassDefinition classDefinition, StringBuilder stringBuilder,
+    private void HandleTryAndAddRegistrationTypes(DependencyModuleConfigurationModel configurationModel, ModuleEntryPointModel entryPointModel, ClassDefinition classDefinition, StringBuilder stringBuilder,
         RegistrationType registrationType,
         ServiceRegistrationModel registrationModel,
         ServiceModel serviceModel,
@@ -446,8 +501,7 @@ public class DependencyFileWriter {
                 parameters.Add(factoryOutput ?? TypeOf(serviceModel.ImplementationType));
             }
             else if (serviceModel is { Constructor: not null, ImplementationType: not GenericTypeDefinition } &&
-                     entryPointModel.GenerateFactories.GetValueOrDefault(
-                         configurationModel.GenerateFactories)) {
+                     ShouldGenerateFactory(serviceModel, entryPointModel, configurationModel)) {
                 parameters.Add(GenerateNewFactory(serviceModel, registrationModel));
             }
             else {

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyFileWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyFileWriter.cs
@@ -656,14 +656,45 @@ public class DependencyFileWriter {
             var byStrategy = ActsOnExistingRegistration(x, configurationModel)
                 .CompareTo(ActsOnExistingRegistration(y, configurationModel));
 
+            if (byStrategy != 0) {
+                return byStrategy;
+            }
+
+            // Order last of the deciding keys, so naming one cannot move a registration ahead of a
+            // condition or ahead of the Replace it depends on - both of which are about whether a
+            // registration works at all, where Order is only about where it lands among its peers.
+            var byOrder = OrderOf(x).CompareTo(OrderOf(y));
+
             // Name is the tie-break rather than the only key, so the order stays total and the
             // output stays deterministic under List.Sort, which is not stable.
-            return byStrategy != 0
-                ? byStrategy
+            return byOrder != 0
+                ? byOrder
                 : string.Compare(x.ImplementationType.Name, y.ImplementationType.Name, StringComparison.Ordinal);
         });
 
         return list;
+    }
+
+    /// <summary>
+    /// The order a service registers at: the lowest any of its registrations names.
+    /// </summary>
+    /// <remarks>
+    /// A class can carry several service attributes and so produce several registrations, each free
+    /// to name its own order. They are emitted together, so the model needs one number, and the
+    /// lowest is the one that matches what naming an order means — "put this early".
+    /// </remarks>
+    private static int OrderOf(ServiceModel serviceModel) {
+        var order = 0;
+        var first = true;
+
+        foreach (var registration in serviceModel.Registrations) {
+            if (first || registration.Order < order) {
+                order = registration.Order;
+                first = false;
+            }
+        }
+
+        return order;
     }
 
     private static bool IsConditional(ServiceModel serviceModel) =>

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
@@ -94,6 +94,32 @@ public static class DependencyModuleDiagnostics {
     /// no entry point to be in the wrong file relative to.
     /// </remarks>
     /// <summary>
+    /// Raised for a <c>[Mock]</c> parameter and a <c>[TestExport]</c> on the same method, both
+    /// naming one service.
+    /// </summary>
+    /// <remarks>
+    /// A parameter attribute is the narrowest thing a test can say, so <c>[Mock]</c> wins and the
+    /// <c>[TestExport]</c> beside it does nothing. That is worth reporting rather than resolving
+    /// quietly: the two say opposite things about one service, written at the same place, and only
+    /// one of them can have been meant.
+    ///
+    /// Only on the same method. A <c>[TestExport]</c> on the class or the assembly is a default for
+    /// everything under it, and a parameter overriding that for one test is the point of having
+    /// both scopes — nothing to report there.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor MockAndTestExportOnOneMethod = new(
+        id: "DM0021",
+        title: "[Mock] and [TestExport] name one service on the same method",
+        messageFormat:
+        "'{0}' carries [TestExport] for '{1}' and a [Mock] parameter naming the same service. The " +
+        "parameter wins, so the [TestExport] does nothing. Move the [TestExport] to the class or " +
+        "the assembly if it is the default this test is overriding, or drop whichever of the two " +
+        "was not meant.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
     /// Raised for an interception no module applies, so it can never run.
     /// </summary>
     /// <remarks>

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
@@ -94,6 +94,32 @@ public static class DependencyModuleDiagnostics {
     /// no entry point to be in the wrong file relative to.
     /// </remarks>
     /// <summary>
+    /// Raised for a decorator naming an implementation in a project emitting factories.
+    /// </summary>
+    /// <remarks>
+    /// Reaching one registration of a service means asking each descriptor what implementation it
+    /// was built from, and a factory descriptor cannot answer.
+    /// <c>DependencyModules_GenerateFactories</c> makes every registration factory-built, so the
+    /// decorator would wrap all of them — which is the opposite of what naming one asked for.
+    ///
+    /// An intercepted service is exempted from the property automatically, because the interception
+    /// is declared on the class being registered and the writer emitting that registration can see
+    /// it. A decorator is declared on the decorator, so the registration it targets is written by a
+    /// pass that never learns about it. Reported rather than silently doing the wrong thing.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor DecoratorImplementationNeedsTypeRegistration = new(
+        id: "DM0022",
+        title: "Decorator names an implementation while factories are generated",
+        messageFormat:
+        "'{0}' decorates only '{1}', but DependencyModules_GenerateFactories is on for this project " +
+        "and a factory registration cannot say what implementation it built — so the decorator would " +
+        "wrap every registration of '{2}' instead of one. Turn the property off for this project, or " +
+        "drop Implementation and decorate them all.",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    /// <summary>
     /// Raised for a <c>[Mock]</c> parameter and a <c>[TestExport]</c> on the same method, both
     /// naming one service.
     /// </summary>

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleDiagnostics.cs
@@ -93,6 +93,32 @@ public static class DependencyModuleDiagnostics {
     /// when nothing generated an <c>ApplicationModule</c> — a class library or a test project has
     /// no entry point to be in the wrong file relative to.
     /// </remarks>
+    /// <summary>
+    /// Raised for an interception no module applies, so it can never run.
+    /// </summary>
+    /// <remarks>
+    /// Registrations and interceptions are placed by the same rule — named a realm, it belongs to
+    /// that module; named none, it belongs to every module that is not realm-only — and the two can
+    /// still land in different places. An interception on a class a realm-only module registers by
+    /// convention is the case: the registration is stamped with that module's realm at match time,
+    /// while the interception, naming no realm, is offered only to modules that are not realm-only.
+    ///
+    /// This reports the shape that cannot work in any configuration, rather than the one that
+    /// merely looks odd: no module in the compilation applies this interception, so the wrapper is
+    /// generated and never used. Naming a realm on <c>[Intercept]</c> is the fix.
+    /// </remarks>
+    public static readonly DiagnosticDescriptor InterceptionAppliedByNoModule = new(
+        id: "DM0020",
+        title: "Interception is applied by no module",
+        messageFormat:
+        "'{0}' is marked for interception, but no module in this compilation applies it, so the " +
+        "interceptors never run. This happens when the registration and the interception land in " +
+        "different realms — a realm-only module registering '{0}' by convention, for instance, while " +
+        "the interception names no realm. Name the module on [Intercept(Realm = typeof(...))].",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
     public static readonly DiagnosticDescriptor AssemblyModuleAttributeNotComposed = new(
         id: "DM0019",
         title: "Assembly-level module attribute is not composed",

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleWriter.cs
@@ -16,6 +16,29 @@ public class DependencyModuleWriter {
         _generateAttribute = generateAttribute;
     }
 
+    /// <summary>
+    /// Registers the module writer and the diagnostics about a module's declaration.
+    /// </summary>
+    /// <remarks>
+    /// Together, because they are two halves of one thing and only the second can see the
+    /// compilation. Emission stays on the models alone so it is not re-run per keystroke;
+    /// the diagnostics combine the compilation, which they need in order to report against a syntax
+    /// tree rather than a bare file path — without one, neither <c>.editorconfig</c> nor
+    /// <c>#pragma warning disable</c> can silence them.
+    /// </remarks>
+    public static void Register(
+        IncrementalGeneratorInitializationContext context,
+        IncrementalValueProvider<ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)>> valuesProvider,
+        bool generateAttribute) {
+
+        context.RegisterSourceOutput(
+            valuesProvider, new DependencyModuleWriter(generateAttribute).GenerateSource);
+
+        context.RegisterSourceOutput(
+            valuesProvider.Combine(context.CompilationProvider),
+            ModuleEntryPointDiagnostics.Report);
+    }
+
     public void GenerateSource(SourceProductionContext context, 
         ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> allEntryPoints) {
 
@@ -68,47 +91,14 @@ public class DependencyModuleWriter {
         ModuleEntryPointModel entryPointModel, 
         DependencyModuleConfigurationModel configurationModel) {
 
-        // Generating into a non-partial type produces CS0260 against the developer's own
-        // declaration, which describes the symptom rather than the fix. Report it directly and
-        // generate nothing, so the only error they see is the actionable one.
-        if (entryPointModel.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.NotPartial)) {
-            context.ReportDiagnostic(
-                Diagnostic.Create(
-                    DependencyModuleDiagnostics.ModuleMustBePartial,
-                    entryPointModel.Location.ToLocationOrNone(),
-                    entryPointModel.EntryPointType.Name));
-
+        // Both of these are reported by ModuleEntryPointDiagnostics, which owns the conditions.
+        // Generating anyway is what makes them worth stopping for: a non-partial module produces
+        // CS0260 against the developer's own declaration, and a nested one emits a same-named type
+        // at namespace level that compiles and registers nothing. Either way the actionable message
+        // would arrive buried under errors describing the symptom.
+        if (ModuleEntryPointDiagnostics.IsNotPartial(entryPointModel) ||
+            ModuleEntryPointDiagnostics.IsNestedInType(entryPointModel)) {
             return;
-        }
-
-        // Generating anyway would emit a same-named type at namespace level, which compiles and
-        // registers nothing — the failure this is here to replace.
-        if (entryPointModel.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.NestedInType)) {
-            context.ReportDiagnostic(
-                Diagnostic.Create(
-                    DependencyModuleDiagnostics.ModuleCannotBeNested,
-                    entryPointModel.Location.ToLocationOrNone(),
-                    entryPointModel.EntryPointType.Name));
-
-            return;
-        }
-
-        // Exactly what ModuleAttributeWriter carries across to the generated attribute, which is
-        // what IsModuleParameter is for — the test used to be written out here as well and drifted
-        // from the other two. A read-only property is not a parameter — a module implementing an
-        // interface with `public string Value => "A";` has nothing anyone can configure, and asking
-        // it to declare Equals would be noise about a decision it never faces. Neither is one the
-        // attribute cannot reach.
-        //
-        // Only when the generator is supplying equality, too: a module that declares its own Equals
-        // has already answered the question this asks about.
-        if (entryPointModel.PropertyInfoModels.Any(p => p.IsModuleParameter) &&
-            entryPointModel.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.ShouldImplementEquals)) {
-            context.ReportDiagnostic(
-                Diagnostic.Create(
-                    DependencyModuleDiagnostics.ModuleWithPropertiesShouldImplementEquals,
-                    entryPointModel.Location.ToLocationOrNone(),
-                    entryPointModel.EntryPointType.Name));
         }
 
         entryPointModel = EntryModelUtil.EnsureNamespace(entryPointModel,configurationModel);

--- a/src/DependencyModules.SourceGenerator.Impl/DependencyModuleWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/DependencyModuleWriter.cs
@@ -93,14 +93,16 @@ public class DependencyModuleWriter {
             return;
         }
 
-        // Settable and non-static, matching exactly what ModuleAttributeWriter carries across from
-        // the generated attribute. A read-only property is not a parameter — a module implementing
-        // an interface with `public string Value => "A";` has nothing anyone can configure, and
-        // asking it to declare Equals would be noise about a decision it never faces.
+        // Exactly what ModuleAttributeWriter carries across to the generated attribute, which is
+        // what IsModuleParameter is for — the test used to be written out here as well and drifted
+        // from the other two. A read-only property is not a parameter — a module implementing an
+        // interface with `public string Value => "A";` has nothing anyone can configure, and asking
+        // it to declare Equals would be noise about a decision it never faces. Neither is one the
+        // attribute cannot reach.
         //
         // Only when the generator is supplying equality, too: a module that declares its own Equals
         // has already answered the question this asks about.
-        if (entryPointModel.PropertyInfoModels.Any(p => !p.IsReadOnly && !p.IsStatic) &&
+        if (entryPointModel.PropertyInfoModels.Any(p => p.IsModuleParameter) &&
             entryPointModel.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.ShouldImplementEquals)) {
             context.ReportDiagnostic(
                 Diagnostic.Create(

--- a/src/DependencyModules.SourceGenerator.Impl/InterceptorFileWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/InterceptorFileWriter.cs
@@ -696,6 +696,11 @@ public class InterceptorFileWriter {
     /// Whether any of the service's interceptors can be placed around this member.
     /// </summary>
     private static bool IsIntercepted(InterceptorModel model, InterceptedMemberModel member) {
+        // Left out by [Intercept].Members. Still forwarded below, just not through the chain.
+        if (member.Excluded) {
+            return false;
+        }
+
         foreach (var interceptor in model.Interceptors) {
             if (interceptor.CanServe(member.Kind)) {
                 return true;

--- a/src/DependencyModules.SourceGenerator.Impl/InterceptorRegistrationWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/InterceptorRegistrationWriter.cs
@@ -90,7 +90,7 @@ public class InterceptorRegistrationWriter {
             method.AddIndentedStatement(
                 new StaticInvokeStatement(
                     KnownTypes.Microsoft.DependencyInjection.ServiceCollectionDescriptorExtensions,
-                    "TryAddSingleton",
+                    TryAddMethodFor(interceptor.Lifestyle),
                     new List<IOutputComponent> {
                         CodeOutputComponent.Get(services.Name),
                         TypeOf(interceptor.Type)
@@ -177,4 +177,19 @@ public class InterceptorRegistrationWriter {
             Indented = false
         };
     }
+
+    /// <summary>
+    /// The TryAdd overload for an interceptor's declared lifetime.
+    /// </summary>
+    /// <remarks>
+    /// Still TryAdd whichever it is, so an interceptor carrying its own service attribute keeps the
+    /// lifetime that attribute gave it - services are applied before decorators, so that
+    /// registration is already in the collection by the time this runs.
+    /// </remarks>
+    private static string TryAddMethodFor(ServiceLifestyle lifestyle) =>
+        lifestyle switch {
+            ServiceLifestyle.Scoped => "TryAddScoped",
+            ServiceLifestyle.Transient => "TryAddTransient",
+            _ => "TryAddSingleton"
+        };
 }

--- a/src/DependencyModules.SourceGenerator.Impl/KnownTypes.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/KnownTypes.cs
@@ -72,6 +72,21 @@ public static class KnownTypes {
 
         }
 
+        /// <summary>
+        /// The testing attributes. Not needed to generate anything — the test integrations read
+        /// these at run time — but DM0021 is about two of them written together, and that is a
+        /// question only a compiler can answer before the test runs.
+        /// </summary>
+        public static class Testing {
+            public const string Namespace = "DependencyModules.Testing.Attributes";
+
+            public static readonly ITypeDefinition MockAttribute =
+                TypeDefinition.Get(TypeDefinitionEnum.ClassDefinition, Namespace, "MockAttribute");
+
+            public static readonly ITypeDefinition TestExportAttribute =
+                TypeDefinition.Get(TypeDefinitionEnum.ClassDefinition, Namespace, "TestExportAttribute");
+        }
+
         public static class Interfaces {
             public const string Namespace = "DependencyModules.Runtime.Interfaces";
 

--- a/src/DependencyModules.SourceGenerator.Impl/Models/DecoratorModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/DecoratorModel.cs
@@ -45,6 +45,12 @@ public record DecoratorModel(
     bool TypeParametersMatchService = true,
 
     /// <summary>
+    /// The one implementation this decorator wraps, or null to wrap every registration of the
+    /// service — which is the default and what a decorator declared against an interface means.
+    /// </summary>
+    ITypeDefinition? Implementation = null,
+
+    /// <summary>
     /// Where the decorator was declared, so DM0007 and DM0013 can point at it rather than at the
     /// project. Null for a decorator declared through [Decorate] on a module, which names two types
     /// and has no declaration of its own to point at.
@@ -116,6 +122,9 @@ public class DecoratorModelComparer : IEqualityComparer<DecoratorModel> {
                x.ServiceType.Equals(y.ServiceType) &&
                x.DecoratorType.Equals(y.DecoratorType) &&
                Equals(x.Realm, y.Realm) &&
+               // Decides which registration is wrapped, so leaving it out would serve the previous
+               // emission when only Implementation changed.
+               Equals(x.Implementation, y.Implementation) &&
                x.InnerParameterIndex == y.InnerParameterIndex &&
                x.TypeParametersMatchService == y.TypeParametersMatchService &&
                Equals(x.Constructor, y.Constructor) &&
@@ -135,6 +144,7 @@ public class DecoratorModelComparer : IEqualityComparer<DecoratorModel> {
             hash = hash * 31 + obj.DecoratorType.GetHashCode();
             hash = hash * 31 + obj.Order;
             hash = hash * 31 + (obj.Realm?.GetHashCode() ?? 0);
+            hash = hash * 31 + (obj.Implementation?.GetHashCode() ?? 0);
             hash = hash * 31 + obj.InnerParameterIndex;
             hash = hash * 31 + (obj.Constructor?.GetHashCode() ?? 0);
             hash = hash * 31 + ModelEquality.ListHashCode(obj.Conditions);

--- a/src/DependencyModules.SourceGenerator.Impl/Models/DiagnosticReporter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/DiagnosticReporter.cs
@@ -1,0 +1,64 @@
+using System;
+using Microsoft.CodeAnalysis;
+
+namespace DependencyModules.SourceGenerator.Impl.Models;
+
+/// <summary>
+/// Where a diagnostic goes, and how its location is rebuilt on the way.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The two travel together on purpose. A <see cref="LocationModel"/> can be turned into a location
+/// with or without the syntax tree it came from, and only the version with the tree can be silenced
+/// by <c>.editorconfig</c> or <c>#pragma warning disable</c> — so a reporting site that is handed a
+/// bare sink is a site that can quietly produce a diagnostic nobody can turn off. Handing both over
+/// as one thing removes the choice.
+/// </para>
+/// <para>
+/// <see cref="Silent"/> exists because analysis that reports is also analysis that produces
+/// something else worth having. The convention matcher is run twice — once to emit registrations,
+/// once to report on them — and the emitting pass wants none of the diagnostics. Asking
+/// <see cref="IsSilent"/> first lets a caller skip building a message it is about to discard.
+/// </para>
+/// </remarks>
+public sealed class DiagnosticReporter {
+    private readonly Action<Diagnostic>? _sink;
+    private readonly SyntaxTreeLookup _lookup;
+
+    /// <summary>A reporter that discards everything.</summary>
+    public static readonly DiagnosticReporter Silent = new(null, SyntaxTreeLookup.None);
+
+    public DiagnosticReporter(Action<Diagnostic>? sink, SyntaxTreeLookup lookup) {
+        _sink = sink;
+        _lookup = lookup;
+    }
+
+    /// <summary>True when nothing is listening, so there is no point composing a message.</summary>
+    public bool IsSilent => _sink == null;
+
+    public void Report(DiagnosticDescriptor descriptor, LocationModel? location, params object?[] messageArgs) {
+        if (_sink == null) {
+            return;
+        }
+
+        _sink(Diagnostic.Create(
+            descriptor,
+            location?.ToLocationOrNone(_lookup) ?? Location.None,
+            messageArgs));
+    }
+
+    /// <summary>
+    /// Reports at a location that is already resolved — one read straight from syntax rather than
+    /// carried through a model.
+    /// </summary>
+    public void Report(DiagnosticDescriptor descriptor, Location location, params object?[] messageArgs) {
+        _sink?.Invoke(Diagnostic.Create(descriptor, location, messageArgs));
+    }
+
+    /// <summary>
+    /// Rebuilds a location the way this reporter would, for a caller that has to hand one to
+    /// something else.
+    /// </summary>
+    public Location LocationFor(LocationModel? location) =>
+        location?.ToLocationOrNone(_lookup) ?? Location.None;
+}

--- a/src/DependencyModules.SourceGenerator.Impl/Models/InterceptedMemberKinds.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/InterceptedMemberKinds.cs
@@ -1,0 +1,19 @@
+namespace DependencyModules.SourceGenerator.Impl.Models;
+
+/// <summary>
+/// The generator's mirror of <c>DependencyModules.Runtime.Attributes.InterceptedMembers</c>.
+/// </summary>
+/// <remarks>
+/// Mirrored rather than referenced. The generator targets netstandard2.0 and does not reference the
+/// runtime package — every other attribute it reads is described the same way, as a name and a
+/// namespace rather than as a type.
+/// </remarks>
+[Flags]
+public enum InterceptedMemberKinds {
+    None = 0,
+    Methods = 1,
+    Properties = 2,
+    Indexers = 4,
+    Events = 8,
+    All = Methods | Properties | Indexers | Events
+}

--- a/src/DependencyModules.SourceGenerator.Impl/Models/InterceptorModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/InterceptorModel.cs
@@ -398,6 +398,11 @@ public class InterceptorModelComparer : IEqualityComparer<InterceptorModel> {
         return x.Order == y.Order &&
                x.ServiceType.Equals(y.ServiceType) &&
                x.ImplementationType.Equals(y.ImplementationType) &&
+               // Realm decides which module emits the applicator, so leaving it out meant editing
+               // only `Realm = typeof(X)` compared equal to the model before the edit, hit the
+               // cache and re-emitted nothing. DecoratorModelComparer and ServiceModelComparer both
+               // compare theirs; this was the odd one out.
+               Equals(x.Realm, y.Realm) &&
                Equals(x.Refusal, y.Refusal) &&
                ModelEquality.ListEquals(x.Interceptors, y.Interceptors) &&
                ModelEquality.ListEquals(x.Members, y.Members) &&
@@ -411,6 +416,7 @@ public class InterceptorModelComparer : IEqualityComparer<InterceptorModel> {
 
             hash = hash * 31 + obj.ImplementationType.GetHashCode();
             hash = hash * 31 + obj.Order;
+            hash = hash * 31 + (obj.Realm?.GetHashCode() ?? 0);
             hash = hash * 31 + (obj.Refusal?.GetHashCode() ?? 0);
             hash = hash * 31 + ModelEquality.ListHashCode(obj.Interceptors);
             hash = hash * 31 + ModelEquality.ListHashCode(obj.Members);

--- a/src/DependencyModules.SourceGenerator.Impl/Models/InterceptorModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/InterceptorModel.cs
@@ -149,7 +149,15 @@ public record TypeParameterModel(
 /// itself would defeat the incremental cache. Which interfaces a type implements is what decides
 /// whether it can serve a given member, and that decision is made once here rather than per member.
 /// </remarks>
-public record InterceptorTypeModel(ITypeDefinition Type, bool Sync, bool Async, bool Stream) {
+public record InterceptorTypeModel(
+    ITypeDefinition Type,
+    bool Sync,
+    bool Async,
+    bool Stream,
+    /// <summary>
+    /// The lifetime this interceptor is registered with, from the [Intercept] that named it.
+    /// </summary>
+    ServiceLifestyle Lifestyle = ServiceLifestyle.Singleton) {
 
     /// <summary>
     /// Whether this interceptor can be placed around a member of the given kind.

--- a/src/DependencyModules.SourceGenerator.Impl/Models/InterceptorModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/InterceptorModel.cs
@@ -203,7 +203,13 @@ public record InterceptedMemberModel(
     ITypeDefinition ResultType,
     IReadOnlyList<InterceptedParameterModel> Parameters,
     IReadOnlyList<TypeParameterModel> TypeParameters,
-    ReturnShape ReturnShape) {
+    ReturnShape ReturnShape,
+
+    /// <summary>
+    /// The declaration left out by <c>[Intercept].Members</c>. Still forwarded — the wrapper
+    /// implements the whole interface — but not through the interceptor chain.
+    /// </summary>
+    bool Excluded = false) {
 
     /// <summary>
     /// The interceptor interface this member has to be routed through.

--- a/src/DependencyModules.SourceGenerator.Impl/Models/LocationModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/LocationModel.cs
@@ -26,6 +26,13 @@ public record LocationModel(
     /// <summary>
     /// Rebuilds a reportable location. Safe to call only outside the incremental pipeline.
     /// </summary>
+    /// <remarks>
+    /// This is the external-file overload of <see cref="Location.Create(string, TextSpan, LinePositionSpan)"/>,
+    /// so the result reports the right file, line and column but has no <c>SourceTree</c>. Roslyn
+    /// keys <c>.editorconfig</c> severity and <c>#pragma warning</c> off the tree, so a diagnostic
+    /// reported here can only be silenced with <c>NoWarn</c>. Prefer
+    /// <see cref="ToLocation(SyntaxTreeLookup)"/>, which attaches the tree when it can find it.
+    /// </remarks>
     public Location ToLocation() =>
         Location.Create(
             FilePath,
@@ -33,6 +40,30 @@ public record LocationModel(
             new LinePositionSpan(
                 new LinePosition(StartLine, StartCharacter),
                 new LinePosition(EndLine, EndCharacter)));
+
+    /// <summary>
+    /// Rebuilds a reportable location against the syntax tree it came from, so that
+    /// <c>.editorconfig</c> and <c>#pragma warning disable</c> can reach the diagnostic.
+    /// </summary>
+    /// <remarks>
+    /// Falls back to the tree-less form when the file is not in the compilation, or when the span
+    /// no longer fits inside it. The second case is real rather than defensive: a model's location
+    /// is deliberately left out of the incremental comparers — it moves whenever anything above the
+    /// declaration is edited, and including it regenerated every model on a comment keystroke — so
+    /// a replayed model can carry a span from a previous version of the file. Out of bounds,
+    /// <c>Location.Create</c> throws, and a generator that throws reports nothing at all.
+    /// </remarks>
+    public Location ToLocation(SyntaxTreeLookup lookup) {
+        var tree = lookup.Find(FilePath);
+
+        if (tree == null) {
+            return ToLocation();
+        }
+
+        var span = new TextSpan(SpanStart, SpanLength);
+
+        return span.End <= tree.Length ? Location.Create(tree, span) : ToLocation();
+    }
 
     public static LocationModel From(SyntaxNode node) => From(NarrowToName(node));
 
@@ -79,4 +110,8 @@ public record LocationModel(
     public static readonly LocationModel None = new("", 0, 0, 0, 0, 0, 0);
 
     public Location ToLocationOrNone() => this == None ? Location.None : ToLocation();
+
+    /// <inheritdoc cref="ToLocationOrNone()"/>
+    public Location ToLocationOrNone(SyntaxTreeLookup lookup) =>
+        this == None ? Location.None : ToLocation(lookup);
 }

--- a/src/DependencyModules.SourceGenerator.Impl/Models/PropertyInfoModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/PropertyInfoModel.cs
@@ -2,4 +2,31 @@ using CSharpAuthor;
 
 namespace DependencyModules.SourceGenerator.Impl.Models;
 
-public record PropertyInfoModel(ITypeDefinition PropertyType, string PropertyName, bool IsReadOnly, bool IsStatic);
+/// <summary>
+/// A property declared on a module, and whether it is one of that module's parameters.
+/// </summary>
+/// <param name="IsReadOnly">No set accessor. Nothing to configure, so not a parameter.</param>
+/// <param name="IsStatic">Belongs to the type rather than the instance, so not a parameter.</param>
+/// <param name="IsVisibleToAttribute">
+/// Reachable from another type in the same assembly, which is where the generated attribute sits.
+/// <c>public</c>, <c>internal</c> and <c>protected internal</c> are; <c>private</c>,
+/// <c>protected</c>, <c>private protected</c> and an unmodified declaration are not.
+/// </param>
+public record PropertyInfoModel(
+    ITypeDefinition PropertyType,
+    string PropertyName,
+    bool IsReadOnly,
+    bool IsStatic,
+    bool IsVisibleToAttribute) {
+
+    /// <summary>
+    /// Whether this property is carried across to the generated attribute as a module parameter.
+    /// </summary>
+    /// <remarks>
+    /// One predicate rather than the same three-part condition written at each site. It was written
+    /// three times — the DM0018 report, the attribute's property list and the attribute's copy-back
+    /// — and the accessibility term was missing from all three, which is how a private property came
+    /// to be emitted onto a public attribute as <c>CS0122</c> in generated code.
+    /// </remarks>
+    public bool IsModuleParameter => !IsReadOnly && !IsStatic && IsVisibleToAttribute;
+}

--- a/src/DependencyModules.SourceGenerator.Impl/Models/ServiceModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/ServiceModel.cs
@@ -30,6 +30,25 @@ public enum RegistrationFeature {
     /// The implementation is a static class, which likewise cannot be constructed.
     /// </summary>
     StaticImplementation = 4,
+
+    /// <summary>
+    /// The implementation carries <c>[Intercept]</c>, so its registration has to stay identifiable
+    /// as its own.
+    /// </summary>
+    /// <remarks>
+    /// Interception is applied by rewriting the one registration the wrapper was generated from,
+    /// and finding it means asking a descriptor which implementation it was built from. A factory
+    /// descriptor cannot answer, so under <c>DependencyModules_GenerateFactories</c> the filter
+    /// matched nothing and interception went back to wrapping every registration of the service
+    /// type - the exact behaviour 1.1.0 shipped to fix, restored by the property the AOT guidance
+    /// recommends turning on.
+    ///
+    /// So an intercepted implementation keeps its <c>typeof</c> registration whatever the property
+    /// says. It costs that one service the property's benefit and nothing else: the wrapper around
+    /// it is still emitted as a literal <c>new</c>, and a <c>typeof</c> registration is the default
+    /// shape everywhere else, trimmer-annotated and already proven under Native AOT.
+    /// </remarks>
+    Intercepted = 8,
 }
 
 public record ServiceFactoryModel(

--- a/src/DependencyModules.SourceGenerator.Impl/Models/ServiceModel.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/ServiceModel.cs
@@ -80,7 +80,14 @@ public record ServiceRegistrationModel(
     ITypeDefinition? Realm = null,
     object? Key = null,
     bool? CrossWire = false,
-    IReadOnlyList<string>? Namespaces = null);
+    IReadOnlyList<string>? Namespaces = null,
+
+    /// <summary>
+    /// Where this registration sits among the others for the same service, lowest first. Decides the
+    /// sequence an <c>IEnumerable&lt;T&gt;</c> dependency sees, and therefore which one a single
+    /// resolve returns.
+    /// </summary>
+    int Order = 0);
 
 public delegate IOutputComponent? FactoryOutputDelegate(
     ServiceModel serviceModel, ServiceRegistrationModel registrationModel);

--- a/src/DependencyModules.SourceGenerator.Impl/Models/SyntaxTreeLookup.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Models/SyntaxTreeLookup.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace DependencyModules.SourceGenerator.Impl.Models;
+
+/// <summary>
+/// Finds the syntax tree a file path belongs to, so a <see cref="LocationModel"/> can be turned
+/// back into a location Roslyn will let the developer silence.
+/// </summary>
+/// <remarks>
+/// Built where diagnostics are reported and thrown away again, rather than cached. Holding one
+/// across the incremental pipeline would pin every tree in the compilation, which is the whole
+/// reason <see cref="LocationModel"/> carries primitives instead of a location; and a cached one
+/// would answer with trees from a compilation that no longer exists, which is worse than answering
+/// with nothing. The map is built on first use, so a run that reports no diagnostics — the ordinary
+/// case — never walks the trees at all.
+/// </remarks>
+public sealed class SyntaxTreeLookup {
+    private readonly Compilation? _compilation;
+    private Dictionary<string, SyntaxTree>? _byPath;
+
+    /// <summary>A lookup that finds nothing, for callers with no compilation to hand.</summary>
+    public static readonly SyntaxTreeLookup None = new(null);
+
+    public SyntaxTreeLookup(Compilation? compilation) {
+        _compilation = compilation;
+    }
+
+    public SyntaxTree? Find(string filePath) {
+        if (_compilation == null || string.IsNullOrEmpty(filePath)) {
+            return null;
+        }
+
+        if (_byPath == null) {
+            _byPath = new Dictionary<string, SyntaxTree>();
+
+            foreach (var tree in _compilation.SyntaxTrees) {
+                // First wins. Two trees can share a path — a linked file compiled into more than
+                // one target — and either answers the question a location asks.
+                if (!string.IsNullOrEmpty(tree.FilePath) && !_byPath.ContainsKey(tree.FilePath)) {
+                    _byPath.Add(tree.FilePath, tree);
+                }
+            }
+        }
+
+        return _byPath.TryGetValue(filePath, out var found) ? found : null;
+    }
+}

--- a/src/DependencyModules.SourceGenerator.Impl/ModuleAttributeWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/ModuleAttributeWriter.cs
@@ -19,7 +19,7 @@ public class ModuleAttributeWriter : BaseAttributeWriter<ModuleEntryPointModel> 
                     attributeClass.Fields.Select(f => f.Instance).OfType<object>().ToArray())).ToVar("newModule");
 
         foreach (var propertyInfoModel in model.PropertyInfoModels) {
-            if (propertyInfoModel.IsReadOnly || propertyInfoModel.IsStatic) {
+            if (!propertyInfoModel.IsModuleParameter) {
                 continue;
             }
             

--- a/src/DependencyModules.SourceGenerator.Impl/ModuleEntryPointDiagnostics.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/ModuleEntryPointDiagnostics.cs
@@ -1,0 +1,107 @@
+using System.Collections.Immutable;
+using System.Linq;
+using DependencyModules.SourceGenerator.Impl.Models;
+using DependencyModules.SourceGenerator.Impl.Utilities;
+using Microsoft.CodeAnalysis;
+
+namespace DependencyModules.SourceGenerator.Impl;
+
+/// <summary>
+/// The diagnostics about a module's own declaration — DM0003, DM0017 and DM0018.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reported from their own source output rather than from the writer that emits the module, so that
+/// the compilation can be combined in. A location needs the syntax tree it came from before Roslyn
+/// will let <c>.editorconfig</c> or <c>#pragma warning disable</c> touch the diagnostic, and the
+/// tree can only be found by asking the compilation for it.
+/// </para>
+/// <para>
+/// The split is what makes that affordable. The compilation changes on every keystroke, so
+/// combining it into the writer would re-emit every module every time — measured, and the reason
+/// module decorators and the metadata scan resolve the compilation in a Select and pass the result
+/// on by value. This output emits nothing. It walks models that are already cached, tests three
+/// conditions, and reports; re-running it costs a loop.
+/// </para>
+/// <para>
+/// The conditions live here rather than being written out at both ends. The writer still has to
+/// know when to stop — generating for a non-partial or nested module produces errors against the
+/// developer's own code instead of the one that names the fix — but it asks the same predicates
+/// rather than repeating them.
+/// </para>
+/// </remarks>
+public static class ModuleEntryPointDiagnostics {
+
+    /// <summary>
+    /// Generating into a non-partial type produces CS0260 against the developer's own declaration,
+    /// which describes the symptom rather than the fix.
+    /// </summary>
+    public static bool IsNotPartial(ModuleEntryPointModel model) =>
+        model.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.NotPartial);
+
+    /// <summary>
+    /// Generating for a nested module emits a same-named type at namespace level, which compiles
+    /// and registers nothing — the failure DM0017 exists to replace.
+    /// </summary>
+    public static bool IsNestedInType(ModuleEntryPointModel model) =>
+        model.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.NestedInType);
+
+    /// <summary>
+    /// A module carrying parameters that leaves equality to the generator. Modules de-duplicate by
+    /// type, so two instances holding different values are the same module by that rule and the
+    /// second is discarded silently.
+    /// </summary>
+    /// <remarks>
+    /// Only when the generator is supplying equality: a module that declares its own <c>Equals</c>
+    /// has already answered the question this asks about.
+    /// </remarks>
+    public static bool ReliesOnGeneratedEquality(ModuleEntryPointModel model) =>
+        model.PropertyInfoModels.Any(p => p.IsModuleParameter) &&
+        model.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.ShouldImplementEquals);
+
+    public static void Report(
+        SourceProductionContext context,
+        (ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Models,
+            Compilation Compilation) input) {
+
+        if (input.Models.Length == 0) {
+            return;
+        }
+
+        // The same consolidation the writer runs. Two partial declarations of one module are one
+        // module, and reporting per declaration would report twice.
+        var (entryPointList, _) = EntryModelUtil.ConsolidateEntryPointModels(input.Models);
+
+        var lookup = new SyntaxTreeLookup(input.Compilation);
+
+        foreach (var entryPointModel in entryPointList) {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            if (IsNotPartial(entryPointModel)) {
+                Report(context, DependencyModuleDiagnostics.ModuleMustBePartial, entryPointModel, lookup);
+                continue;
+            }
+
+            if (IsNestedInType(entryPointModel)) {
+                Report(context, DependencyModuleDiagnostics.ModuleCannotBeNested, entryPointModel, lookup);
+                continue;
+            }
+
+            if (ReliesOnGeneratedEquality(entryPointModel)) {
+                Report(context, DependencyModuleDiagnostics.ModuleWithPropertiesShouldImplementEquals,
+                    entryPointModel, lookup);
+            }
+        }
+    }
+
+    private static void Report(
+        SourceProductionContext context,
+        DiagnosticDescriptor descriptor,
+        ModuleEntryPointModel entryPointModel,
+        SyntaxTreeLookup lookup) =>
+        context.ReportDiagnostic(
+            Diagnostic.Create(
+                descriptor,
+                entryPointModel.Location.ToLocationOrNone(lookup),
+                entryPointModel.EntryPointType.Name));
+}

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/AttributeModelHelper.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/AttributeModelHelper.cs
@@ -56,16 +56,46 @@ public static class AttributeModelHelper {
                     propertyList.Add(new PropertyInfoModel(propertyType,
                         propertyDeclarationSyntax.Identifier.ToString(),
                         setter == null,
-                        propertyDeclarationSyntax.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword))
+                        propertyDeclarationSyntax.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword)),
+                        IsVisibleToAttribute(propertyDeclarationSyntax.Modifiers)
                     ));
                 }
             }
         }
 
         return new AttributeClassInfo(
-            ServiceModelUtility.GetConstructorInfo(context, context.Node, cancellationToken) ?? 
+            ServiceModelUtility.GetConstructorInfo(context, context.Node, cancellationToken) ??
             new ConstructorInfoModel(Array.Empty<ParameterInfoModel>()),
             propertyList);
+    }
+
+    /// <summary>
+    /// Whether a property with these modifiers can be read and written from another type in the
+    /// same assembly — which is what the generated attribute is.
+    /// </summary>
+    /// <remarks>
+    /// Read from syntax rather than from the symbol, because everything else in this transform is
+    /// and because the modifiers say it outright. The cases that matter:
+    /// <c>protected internal</c> means protected *or* internal, so it is reachable;
+    /// <c>private protected</c> means protected *and* internal, so it is not. A property with no
+    /// access modifier at all is private by default, which is the case most likely to be written by
+    /// accident and was the one that produced generated code that would not compile.
+    /// </remarks>
+    private static bool IsVisibleToAttribute(SyntaxTokenList modifiers) {
+        var isPrivate = modifiers.Any(m => m.IsKind(SyntaxKind.PrivateKeyword));
+        var isProtected = modifiers.Any(m => m.IsKind(SyntaxKind.ProtectedKeyword));
+        var isInternal = modifiers.Any(m => m.IsKind(SyntaxKind.InternalKeyword));
+        var isPublic = modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword));
+
+        if (isPrivate) {
+            return false;
+        }
+
+        if (isProtected) {
+            return isInternal;
+        }
+
+        return isPublic || isInternal;
     }
 
     public static IEnumerable<AttributeModel> GetAttributes(

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/BaseAttributeWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/BaseAttributeWriter.cs
@@ -47,7 +47,7 @@ public abstract class BaseAttributeWriter<T> where T : IClassModel {
 
     protected virtual void CreateProperties(IConstructContainer container, ClassDefinition attributeClass, T model) {
         foreach (var propertyInfoModel in model.PropertyInfoModels) {
-            if (propertyInfoModel.IsReadOnly || propertyInfoModel.IsStatic) {
+            if (!propertyInfoModel.IsModuleParameter) {
                 continue;
             }
 

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/DecoratorModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/DecoratorModelUtility.cs
@@ -33,6 +33,7 @@ public static class DecoratorModelUtility {
         var order = 0;
         ITypeDefinition? realm = null;
         ITypeDefinition? explicitService = null;
+        ITypeDefinition? implementation = null;
 
         if (attribute.ArgumentList != null) {
             foreach (var argument in attribute.ArgumentList.Arguments) {
@@ -47,6 +48,9 @@ public static class DecoratorModelUtility {
                         break;
                     case "Realm":
                         realm = GetTypeOfArgument(argument, context);
+                        break;
+                    case "Implementation":
+                        implementation = GetTypeOfArgument(argument, context);
                         break;
                 }
             }
@@ -84,6 +88,7 @@ public static class DecoratorModelUtility {
             constructor,
             IndexOfInnerParameter(constructor, written),
             TypeParametersMatchService(typeDeclarationSyntax, written),
+            implementation,
             LocationModel.From(typeDeclarationSyntax));
     }
 

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/EntryModelUtil.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/EntryModelUtil.cs
@@ -141,8 +141,18 @@ public class EntryModelUtil {
         if (!configurationModel.AutoGenerateEntry) {
             entryPointModels = entryPointModels.Where(m => !m.ModuleFeatures.HasFlag(ModuleEntryPointFeatures.AutoGenerateModule));
         }
-        
-        var groupingEnumerable = 
+
+        // Before grouping, not after. A generated module is created with no namespace and given the
+        // RootNamespace later, so grouping it as written put ".ApplicationModule" and
+        // "TheRootNamespace.ApplicationModule" in separate groups — two models of the same module,
+        // each believing it was the only one. Both were emitted, and by then their file names had
+        // converged (GetFileNameHint strips the RootNamespace), so the second AddSource threw
+        // inside the generator: CS8785, a warning, followed by CS0311 against the developer's own
+        // type. Naming them the same way the file name does is what lets the grouping below see
+        // they are one module and keep the declared one.
+        entryPointModels = entryPointModels.Select(m => EnsureNamespace(m, configurationModel));
+
+        var groupingEnumerable =
             entryPointModels.GroupBy(m => m.EntryPointType.Namespace + "." + m.EntryPointType.GetShortName());
 
         foreach (var grouping in groupingEnumerable) {

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/ITypeDefinitionExtensions.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/ITypeDefinitionExtensions.cs
@@ -22,19 +22,34 @@ public static class ITypeDefinitionExtensions {
                 generic.TypeArguments.Select(_ => (ITypeDefinition)TypeDefinition.Get("", "")).ToArray())
             : type;
 
+    /// <summary>
+    /// The hint name a generated file is added under. Must differ for types that differ, because a
+    /// repeat is an exception inside the generator rather than a diagnostic — it surfaces as CS8785,
+    /// a warning, and then as errors against the developer's own code.
+    /// </summary>
+    /// <remarks>
+    /// The RootNamespace prefix is dropped so the common case reads as <c>Thing.Module.g.cs</c>
+    /// rather than repeating the project's namespace in every file. That leaves one pair of distinct
+    /// types sharing a name: a type in the root namespace, whose prefix is stripped to nothing, and
+    /// a type in the global namespace, which had none to begin with. They are different types and
+    /// need different files, so the global namespace is named rather than left blank.
+    /// </remarks>
     public static string GetFileNameHint(this ITypeDefinition typeDefinition, string rootNamespace, string uniquePart) {
         var nameString = typeDefinition.Namespace;
-        
+
         if (nameString == rootNamespace ||
             nameString.StartsWith(rootNamespace + ".")) {
             nameString = nameString.Substring(rootNamespace.Length);
             nameString = nameString.TrimStart('.');
         }
+        else if (string.IsNullOrWhiteSpace(nameString)) {
+            nameString = "global";
+        }
 
         if (!string.IsNullOrWhiteSpace(nameString)) {
             nameString += ".";
         }
-        
+
         return $"{nameString}{typeDefinition.Name}.{uniquePart}.g.cs";
     }
 }

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/InterceptorModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/InterceptorModelUtility.cs
@@ -56,6 +56,7 @@ public static class InterceptorModelUtility {
         var order = 0;
         INamedTypeSymbol? explicitService = null;
         INamedTypeSymbol? realm = null;
+        var memberKinds = InterceptedMemberKinds.All;
 
         // Every [Intercept], not the first. The attribute is AllowMultiple, so stacking them is a
         // supported way to write what one attribute can also express as a params list — and reading
@@ -63,6 +64,8 @@ public static class InterceptorModelUtility {
         foreach (var attribute in attributes) {
             ReadAttribute(
                 attribute, context, cancellationToken, interceptorSymbols, ref order, ref explicitService, ref realm);
+
+            memberKinds &= ReadMemberKinds(attribute);
         }
 
         if (interceptorSymbols.Count == 0) {
@@ -83,6 +86,8 @@ public static class InterceptorModelUtility {
             return InterceptorModel.Refused(
                 $"'{serviceSymbol.Name}' declares nothing to intercept");
         }
+
+        members = ApplyMemberKinds(members, declarations, memberKinds);
 
         var interceptors = new List<InterceptorTypeModel>();
 
@@ -174,6 +179,96 @@ public static class InterceptorModelUtility {
         KnownTypes.DependencyModules.Attributes.TransientServiceAttribute,
         KnownTypes.DependencyModules.Attributes.CrossWireServiceAttribute
     };
+
+    /// <summary>
+    /// The kinds of member <c>[Intercept]</c> names, as flags. Everything when it names none.
+    /// </summary>
+    /// <remarks>
+    /// Read as written rather than resolved, for the reason the lifetime is: the alternative is
+    /// referencing an enum this generator does not. Splitting on the or-operator and taking the last
+    /// segment of each part handles `Methods`, `InterceptedMembers.Methods` and any qualification of
+    /// either.
+    /// </remarks>
+    private static InterceptedMemberKinds ReadMemberKinds(AttributeSyntax attribute) {
+        foreach (var argument in attribute.ArgumentList?.Arguments ??
+                                 default(SeparatedSyntaxList<AttributeArgumentSyntax>)) {
+            if (argument.NameEquals?.Name.ToString() != "Members") {
+                continue;
+            }
+
+            var kinds = InterceptedMemberKinds.None;
+
+            foreach (var part in argument.Expression.ToString().Split('|')) {
+                var member = part.Substring(part.LastIndexOf('.') + 1).Trim();
+
+                switch (member) {
+                    case "Methods": kinds |= InterceptedMemberKinds.Methods; break;
+                    case "Properties": kinds |= InterceptedMemberKinds.Properties; break;
+                    case "Indexers": kinds |= InterceptedMemberKinds.Indexers; break;
+                    case "Events": kinds |= InterceptedMemberKinds.Events; break;
+                    case "All": kinds |= InterceptedMemberKinds.All; break;
+                }
+            }
+
+            return kinds == InterceptedMemberKinds.None ? InterceptedMemberKinds.All : kinds;
+        }
+
+        return InterceptedMemberKinds.All;
+    }
+
+    /// <summary>
+    /// Marks the members whose declaration kind was left out.
+    /// </summary>
+    /// <remarks>
+    /// Applied after reading rather than while reading, because the kind belongs to the declaration
+    /// and the reader produces members and declarations side by side - a property contributes one
+    /// declaration and up to two members. Marking rather than removing keeps every index the
+    /// declarations hold pointing at the same member.
+    /// </remarks>
+    private static IReadOnlyList<InterceptedMemberModel> ApplyMemberKinds(
+        IReadOnlyList<InterceptedMemberModel> members,
+        IReadOnlyList<InterceptedDeclarationModel> declarations,
+        InterceptedMemberKinds kinds) {
+
+        if (kinds == InterceptedMemberKinds.All) {
+            return members;
+        }
+
+        var excluded = new HashSet<int>();
+
+        foreach (var declaration in declarations) {
+            if (KindOf(declaration.Kind) is var kind && (kinds & kind) != 0) {
+                continue;
+            }
+
+            excluded.Add(declaration.First);
+
+            if (declaration.Second >= 0) {
+                excluded.Add(declaration.Second);
+            }
+        }
+
+        if (excluded.Count == 0) {
+            return members;
+        }
+
+        var result = new List<InterceptedMemberModel>(members.Count);
+
+        for (var index = 0; index < members.Count; index++) {
+            result.Add(excluded.Contains(index) ? members[index] with { Excluded = true } : members[index]);
+        }
+
+        return result;
+    }
+
+    private static InterceptedMemberKinds KindOf(DeclarationKind kind) =>
+        kind switch {
+            DeclarationKind.Method => InterceptedMemberKinds.Methods,
+            DeclarationKind.Property => InterceptedMemberKinds.Properties,
+            DeclarationKind.Indexer => InterceptedMemberKinds.Indexers,
+            DeclarationKind.Event => InterceptedMemberKinds.Events,
+            _ => InterceptedMemberKinds.All
+        };
 
     private static InterceptorModel Refuse(string? reason, SyntaxTransformContext context) =>
         reason == null

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/InterceptorModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/InterceptorModelUtility.cs
@@ -104,9 +104,76 @@ public static class InterceptorModelUtility {
             declarations,
             order,
             TypeParameters: TypeParameterModels(implementationSymbol),
-            Realm: realm?.GetTypeDefinition(),
+            Realm: (realm?.GetTypeDefinition() ??
+                    RegistrationRealm(typeDeclarationSyntax, context, cancellationToken)),
             Location: LocationModel.From(context.Node));
     }
+
+    /// <summary>
+    /// The realm this class's own registration names, for an interception that names none.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// An interception is about one implementation - that is what per-implementation interception
+    /// means - so it belongs wherever that implementation's registration belongs. Without this,
+    /// a realm-scoped service with an unrealmed [Intercept] put the registration in the named
+    /// module and the applicator in every module except it: dead in every container that could
+    /// exist, and reported by nothing, because each half was individually following the rule.
+    /// </para>
+    /// <para>
+    /// Only consulted when [Intercept] names no realm of its own. An explicit Realm is the
+    /// developer's answer and stays the answer.
+    /// </para>
+    /// <para>
+    /// Read from the declaration rather than from the service model, because the two are built by
+    /// different providers and this one has only the syntax it was handed. That also bounds what
+    /// this can see: a class registered by a convention carries no service attribute, so its realm
+    /// is decided at match time and is not visible from here.
+    /// </para>
+    /// </remarks>
+    private static ITypeDefinition? RegistrationRealm(
+        TypeDeclarationSyntax typeDeclarationSyntax,
+        SyntaxTransformContext context,
+        CancellationToken cancellationToken) {
+
+        foreach (var attributeList in typeDeclarationSyntax.AttributeLists) {
+            foreach (var attribute in attributeList.Attributes) {
+                if (!IsServiceAttribute(attribute, context, cancellationToken)) {
+                    continue;
+                }
+
+                foreach (var argument in attribute.ArgumentList?.Arguments ??
+                                         default(SeparatedSyntaxList<AttributeArgumentSyntax>)) {
+                    if (argument.NameEquals?.Name.ToString() == "Realm" &&
+                        argument.Expression is TypeOfExpressionSyntax realmTypeOf) {
+                        return ResolveType(realmTypeOf, context, cancellationToken)?.GetTypeDefinition();
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsServiceAttribute(
+        AttributeSyntax attribute, SyntaxTransformContext context, CancellationToken cancellationToken) {
+
+        foreach (var serviceAttribute in ServiceAttributeTypes) {
+            if (AttributeTypeMatcher.Matches(
+                    context.SemanticModel, attribute, serviceAttribute, cancellationToken)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static readonly ITypeDefinition[] ServiceAttributeTypes = {
+        KnownTypes.DependencyModules.Attributes.SingletonServiceAttribute,
+        KnownTypes.DependencyModules.Attributes.ScopedServiceAttribute,
+        KnownTypes.DependencyModules.Attributes.TransientServiceAttribute,
+        KnownTypes.DependencyModules.Attributes.CrossWireServiceAttribute
+    };
 
     private static InterceptorModel Refuse(string? reason, SyntaxTransformContext context) =>
         reason == null

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/InterceptorModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/InterceptorModelUtility.cs
@@ -52,7 +52,7 @@ public static class InterceptorModelUtility {
         // Constraints come along with the parameters. The wrapper is declared over the same ones and
         // repeats their constraints, without which it could not reference what it wraps.
 
-        var interceptorSymbols = new List<INamedTypeSymbol>();
+        var interceptorSymbols = new List<(INamedTypeSymbol Symbol, ServiceLifestyle Lifestyle)>();
         var order = 0;
         INamedTypeSymbol? explicitService = null;
         INamedTypeSymbol? realm = null;
@@ -86,8 +86,8 @@ public static class InterceptorModelUtility {
 
         var interceptors = new List<InterceptorTypeModel>();
 
-        foreach (var interceptorSymbol in interceptorSymbols) {
-            interceptors.Add(ReadInterceptorType(interceptorSymbol));
+        foreach (var (interceptorSymbol, lifestyle) in interceptorSymbols) {
+            interceptors.Add(ReadInterceptorType(interceptorSymbol, lifestyle));
         }
 
         // Nothing here can be placed around anything, so the wrapper would forward every call
@@ -183,7 +183,8 @@ public static class InterceptorModelUtility {
     /// <summary>
     /// The interfaces an interceptor implements, which decide the members it can be placed around.
     /// </summary>
-    private static InterceptorTypeModel ReadInterceptorType(INamedTypeSymbol symbol) {
+    private static InterceptorTypeModel ReadInterceptorType(
+        INamedTypeSymbol symbol, ServiceLifestyle lifestyle) {
         var sync = false;
         var async = false;
         var stream = false;
@@ -206,7 +207,7 @@ public static class InterceptorModelUtility {
             }
         }
 
-        return new InterceptorTypeModel(symbol.GetTypeDefinition(), sync, async, stream);
+        return new InterceptorTypeModel(symbol.GetTypeDefinition(), sync, async, stream, lifestyle);
     }
 
     /// <summary>
@@ -236,7 +237,7 @@ public static class InterceptorModelUtility {
         AttributeSyntax attribute,
         SyntaxTransformContext context,
         CancellationToken cancellationToken,
-        List<INamedTypeSymbol> interceptors,
+        List<(INamedTypeSymbol Symbol, ServiceLifestyle Lifestyle)> interceptors,
         ref int order,
         ref INamedTypeSymbol? explicitService,
         ref INamedTypeSymbol? realm) {
@@ -244,6 +245,11 @@ public static class InterceptorModelUtility {
         if (attribute.ArgumentList == null) {
             return;
         }
+
+        // Read first, applied below. Lifetime is a named argument and may be written after the
+        // interceptors it applies to, so collecting them in one pass would attach whatever the
+        // lifetime happened to be at that point in the argument list.
+        var lifestyle = ReadLifetime(attribute);
 
         foreach (var argument in attribute.ArgumentList.Arguments) {
             var name = argument.NameEquals?.Name.ToString();
@@ -253,7 +259,7 @@ public static class InterceptorModelUtility {
                     var symbol = ResolveType(typeOf, context, cancellationToken);
 
                     if (symbol != null) {
-                        interceptors.Add(symbol);
+                        interceptors.Add((symbol, lifestyle));
                     }
                 }
 
@@ -278,6 +284,39 @@ public static class InterceptorModelUtility {
                     break;
             }
         }
+    }
+
+    /// <summary>
+    /// The lifetime one [Intercept] names for the interceptors it lists, Singleton when it names
+    /// none.
+    /// </summary>
+    /// <remarks>
+    /// Read from the written name rather than resolved, because the alternative is a constant of an
+    /// enum this generator does not reference. Every legal spelling ends in the member name, so the
+    /// last segment is the answer for `Scoped`, `ServiceLifetime.Scoped` and any qualification of
+    /// it alike.
+    /// </remarks>
+    private static ServiceLifestyle ReadLifetime(AttributeSyntax attribute) {
+        foreach (var argument in attribute.ArgumentList?.Arguments ??
+                                 default(SeparatedSyntaxList<AttributeArgumentSyntax>)) {
+            if (argument.NameEquals?.Name.ToString() != "Lifetime") {
+                continue;
+            }
+
+            var written = argument.Expression.ToString();
+            var member = written.Substring(written.LastIndexOf('.') + 1).Trim();
+
+            switch (member) {
+                case "Scoped":
+                    return ServiceLifestyle.Scoped;
+                case "Transient":
+                    return ServiceLifestyle.Transient;
+                case "Singleton":
+                    return ServiceLifestyle.Singleton;
+            }
+        }
+
+        return ServiceLifestyle.Singleton;
     }
 
     private static INamedTypeSymbol? ResolveType(

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/InterceptorModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/InterceptorModelUtility.cs
@@ -31,7 +31,7 @@ public static class InterceptorModelUtility {
             return InterceptorModel.Ignore;
         }
 
-        var attributes = FindAttributes(typeDeclarationSyntax);
+        var attributes = FindAttributes(typeDeclarationSyntax, context.SemanticModel, cancellationToken);
 
         if (attributes.Count == 0) {
             return InterceptorModel.Ignore;
@@ -310,14 +310,33 @@ public static class InterceptorModelUtility {
         return TypeDefinition.Get(namespaceName, name);
     }
 
-    private static List<AttributeSyntax> FindAttributes(TypeDeclarationSyntax typeDeclarationSyntax) {
+    /// <summary>
+    /// The <c>[Intercept]</c> usages on a declaration, resolved rather than string-matched.
+    /// </summary>
+    /// <remarks>
+    /// This used to compare <c>attribute.Name.ToString()</c> against "Intercept" and
+    /// "InterceptAttribute", so a qualified name, a <c>global::</c> prefix or a using alias found
+    /// nothing — no wrapper, no diagnostic, and a cross-cutting concern that stopped running on a
+    /// green build. It is the same mistake the service attributes carried until 1.1.0, and the same
+    /// fix: ask the semantic model what the usage binds to.
+    ///
+    /// The declaration is reached through <c>ForAttributeWithMetadataName</c>, which resolves the
+    /// attribute properly, so only this second pass ever lost it — the node was always found.
+    /// </remarks>
+    private static List<AttributeSyntax> FindAttributes(
+        TypeDeclarationSyntax typeDeclarationSyntax,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken) {
+
         var attributes = new List<AttributeSyntax>();
 
         foreach (var attributeList in typeDeclarationSyntax.AttributeLists) {
             foreach (var attribute in attributeList.Attributes) {
-                var name = attribute.Name.ToString();
-
-                if (name is "Intercept" or "InterceptAttribute") {
+                if (AttributeTypeMatcher.Matches(
+                        semanticModel,
+                        attribute,
+                        KnownTypes.DependencyModules.Attributes.InterceptAttribute,
+                        cancellationToken)) {
                     attributes.Add(attribute);
                 }
             }

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
@@ -148,8 +148,10 @@ public class ServiceModelUtility {
     /// Flags describing why the container could never construct this type, so the generator can
     /// report it instead of emitting a registration that fails when the provider is built.
     /// </summary>
-    private static RegistrationFeature GetConstructionFeatures(SyntaxNode node) {
-        if (node is not TypeDeclarationSyntax typeDeclarationSyntax) {
+    private static RegistrationFeature GetConstructionFeatures(
+        SyntaxTransformContext context, CancellationToken cancellationToken) {
+
+        if (context.Node is not TypeDeclarationSyntax typeDeclarationSyntax) {
             return RegistrationFeature.None;
         }
 
@@ -162,7 +164,40 @@ public class ServiceModelUtility {
             features |= RegistrationFeature.AbstractImplementation;
         }
 
+        if (IsIntercepted(typeDeclarationSyntax, context, cancellationToken)) {
+            features |= RegistrationFeature.Intercepted;
+        }
+
         return features;
+    }
+
+    /// <summary>
+    /// Whether the declaration carries <c>[Intercept]</c>.
+    /// </summary>
+    /// <remarks>
+    /// Read here rather than taken from the interceptor models, because the two are built by
+    /// separate providers that cannot see each other — the same reason the interception reads its
+    /// realm from the service attribute rather than the other way round. Both facts are written on
+    /// one declaration, which is the only place either transform can find the other.
+    /// </remarks>
+    private static bool IsIntercepted(
+        TypeDeclarationSyntax typeDeclarationSyntax,
+        SyntaxTransformContext context,
+        CancellationToken cancellationToken) {
+
+        foreach (var attributeList in typeDeclarationSyntax.AttributeLists) {
+            foreach (var attribute in attributeList.Attributes) {
+                if (AttributeTypeMatcher.Matches(
+                        context.SemanticModel,
+                        attribute,
+                        KnownTypes.DependencyModules.Attributes.InterceptAttribute,
+                        cancellationToken)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private static ServiceModel? GetClassDeclarationServiceModel(SyntaxTransformContext context, CancellationToken cancellationToken) {
@@ -206,7 +241,7 @@ public class ServiceModelUtility {
             null,
             factoryOutput,
             registrations,
-            GetConstructionFeatures(context.Node),
+            GetConstructionFeatures(context, cancellationToken),
             EnvironmentConditionUtility.GetConditions(context, context.Node, cancellationToken),
             LocationModel.From(context.Node));
     }

--- a/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/Utilities/ServiceModelUtility.cs
@@ -400,6 +400,7 @@ public class ServiceModelUtility {
         ITypeDefinition? realm = null;
         object? key = null;
         ServiceLifestyle lifestyle = ServiceLifestyle.Singleton;
+        var order = 0;
         var namespaces = new List<string>();
 
         if (attributeSyntax.ArgumentList != null) {
@@ -430,6 +431,12 @@ public class ServiceModelUtility {
                                 realm = realmType.Type.GetTypeDefinition(context);
                             }
                             break;
+
+                        case "Order":
+                            if (int.TryParse(argumentSyntax.Expression.ToString(), out var parsedOrder)) {
+                                order = parsedOrder;
+                            }
+                            break;
                     }
                 }
             }
@@ -447,7 +454,8 @@ public class ServiceModelUtility {
                         realm,
                         key,
                         true,
-                        namespaces
+                        namespaces,
+                        order
                     );
                 }
             }
@@ -487,6 +495,7 @@ public class ServiceModelUtility {
         // semantic model to decide that this attribute matched at all; the caller simply passes on
         // which one it was rather than discarding the answer.
         var lifestyle = LifestyleOf(attributeType);
+        var order = 0;
 
         ITypeDefinition? registration = null;
         RegistrationType? registrationType = null;
@@ -528,6 +537,12 @@ public class ServiceModelUtility {
                                 realm = realmType.Type.GetTypeDefinition(context);
                             }
                             break;
+
+                        case "Order":
+                            if (int.TryParse(argumentSyntax.Expression.ToString(), out var parsedOrder)) {
+                                order = parsedOrder;
+                            }
+                            break;
                     }
                 }
             }
@@ -540,7 +555,8 @@ public class ServiceModelUtility {
             realm,
             key,
             false,
-            namespaces
+            namespaces,
+            order
         );
     }
 

--- a/src/DependencyModules.SourceGenerator/AssemblyModuleAttributeDiagnostics.cs
+++ b/src/DependencyModules.SourceGenerator/AssemblyModuleAttributeDiagnostics.cs
@@ -140,12 +140,18 @@ internal static class AssemblyModuleAttributeDiagnostics {
 
     internal static void Report(
         SourceProductionContext context,
-        (ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Modules,
-            ImmutableArray<UnitModel> Units) input) {
+        ((ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Modules,
+            ImmutableArray<UnitModel> Units) Left, Compilation Right) data) {
+
+        var input = data.Left;
 
         if (input.Units.IsDefaultOrEmpty || input.Modules.IsDefaultOrEmpty) {
             return;
         }
+
+        // Modules from referenced assemblies are the case both these codes exist for, and neither
+        // could see them: everything below was built from the modules declared here.
+        var referenced = new ReferencedModuleLookup(data.Right);
 
         // A module in the global namespace needs no import, and an auto-generated ApplicationModule
         // is never written by hand at the assembly level, so neither can produce this mistake.
@@ -160,10 +166,6 @@ internal static class AssemblyModuleAttributeDiagnostics {
             }
 
             modulesByName[module.EntryPointType.Name] = moduleNamespace;
-        }
-
-        if (modulesByName.Count == 0) {
-            return;
         }
 
         // The file the generated ApplicationModule was built from, which is the only file whose
@@ -192,11 +194,18 @@ internal static class AssemblyModuleAttributeDiagnostics {
                 context.CancellationToken.ThrowIfCancellationRequested();
 
                 // Written as [assembly: Foo] or [assembly: FooAttribute]; both name module Foo.
-                if (!modulesByName.TryGetValue(usage.Name, out var moduleNamespace) &&
-                    !(usage.Name.EndsWith("Attribute", StringComparison.Ordinal) &&
-                      modulesByName.TryGetValue(
-                          usage.Name.Substring(0, usage.Name.Length - "Attribute".Length),
-                          out moduleNamespace))) {
+                var moduleNamespace = LocalModuleNamespace(modulesByName, usage.Name);
+
+                // Declared here, or shipped by something this project references. The imported
+                // lookup comes first because it is the cheap one and the one a building project
+                // takes; the exhaustive walk is only worth doing for a name that resolved to
+                // nothing, which is a build that is already red.
+                moduleNamespace ??= referenced.FindImported(
+                    usage.Name, unit.FileUsings.Concat(globalUsings));
+
+                moduleNamespace ??= referenced.FindAnywhere(usage.Name);
+
+                if (moduleNamespace == null) {
                     continue;
                 }
 
@@ -224,5 +233,18 @@ internal static class AssemblyModuleAttributeDiagnostics {
                 }
             }
         }
+    }
+
+    /// <summary>The namespace of a module declared in this compilation, or null.</summary>
+    private static string? LocalModuleNamespace(Dictionary<string, string> modulesByName, string name) {
+        if (modulesByName.TryGetValue(name, out var found)) {
+            return found;
+        }
+
+        return name.EndsWith("Attribute", StringComparison.Ordinal) &&
+               modulesByName.TryGetValue(
+                   name.Substring(0, name.Length - "Attribute".Length), out found)
+            ? found
+            : null;
     }
 }

--- a/src/DependencyModules.SourceGenerator/Conventions/ConventionGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/Conventions/ConventionGenerator.cs
@@ -156,15 +156,31 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
                 new EquatableList<ConventionCandidateModel>(
                     MetadataCandidateUtility.Collect(pair.Left, pair.Right, cancellation)));
 
-        context.RegisterSourceOutput(
-            incrementalValueProvider.Collect()
-                .Combine(conventionModules)
-                .Combine(candidates)
-                .Combine(metadataCandidates)
-                .Combine(decorators)
-                .Combine(attributeServices)
-                .Combine(moduleDecorators),
-            GenerateSourceOutput);
+        var everything = incrementalValueProvider.Collect()
+            .Combine(conventionModules)
+            .Combine(candidates)
+            .Combine(metadataCandidates)
+            .Combine(decorators)
+            .Combine(attributeServices)
+            .Combine(moduleDecorators);
+
+        context.RegisterSourceOutput(everything, GenerateSourceOutput);
+
+        // Diagnostics separately, with the compilation combined in, because a location needs the
+        // syntax tree it came from before .editorconfig or #pragma can silence it and only the
+        // compilation can find that tree.
+        //
+        // The compilation ModuleDecorators already carries cannot serve this. It rides inside a
+        // value compared on its resolved decorations alone, precisely so an edit that changes no
+        // declaration propagates nothing - which means that when nothing changed, the compilation
+        // held there is the one from a previous run. Good enough for asking whether a decorator's
+        // constraints admit a type; not good enough to hand Roslyn a tree that is no longer in the
+        // compilation it is filtering against.
+        //
+        // The cost is that matching runs twice, once per output. The emitting pass is silent, so
+        // nothing composes a diagnostic message it is about to discard, and this pass writes no
+        // source.
+        context.RegisterSourceOutput(everything.Combine(context.CompilationProvider), ReportDiagnostics);
     }
 
     private void GenerateSourceOutput(
@@ -202,9 +218,51 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
             configuration,
             logger => Generate(
                 context, entryPoints, conventionModules, candidates, decorators, attributeServices,
-                moduleDecorators, logger),
+                moduleDecorators, DiagnosticReporter.Silent, emit: true, logger),
             // Surfaced as a build error rather than discarded, matching the attribute generators. A
             // generator that fails quietly produces a green build with no registrations.
+            exception => context.ReportDiagnostic(
+                Diagnostic.Create(
+                    DependencyModuleDiagnostics.GeneratorFailure,
+                    Location.None,
+                    $"{exception.GetType().Name}: {exception.Message}")));
+    }
+
+    /// <summary>
+    /// Everything the convention pass has to say, reported against real syntax trees. Emits nothing.
+    /// </summary>
+    private void ReportDiagnostics(
+        SourceProductionContext context,
+        (((((((ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Left,
+            ImmutableArray<ConventionModuleModel> Right) Left,
+            ImmutableArray<ConventionCandidateModel> Right) Left,
+            EquatableList<ConventionCandidateModel> Right) Left,
+            ImmutableArray<DecoratorModel> Right) Left,
+            ImmutableArray<ServiceModel> Right) Left,
+            ModuleDecorators Right) Left,
+            Compilation Right) data) {
+
+        var models = data.Left;
+        var entryPoints = models.Left.Left.Left.Left.Left.Left;
+
+        if (entryPoints.Length == 0) {
+            return;
+        }
+
+        var candidates = models.Left.Left.Left.Left.Right.Length == 0
+            ? (IReadOnlyList<ConventionCandidateModel>)models.Left.Left.Left.Right
+            : models.Left.Left.Left.Left.Right.Concat(models.Left.Left.Left.Right).ToArray();
+
+        var configuration = entryPoints.First().Right;
+        var report = new DiagnosticReporter(context.ReportDiagnostic, new SyntaxTreeLookup(data.Right));
+
+        FileLogger.Wrap(
+            LoggerName,
+            configuration,
+            logger => Generate(
+                context, entryPoints, models.Left.Left.Left.Left.Left.Right, candidates,
+                models.Left.Left.Right, models.Left.Right, models.Right,
+                report, emit: false, logger),
             exception => context.ReportDiagnostic(
                 Diagnostic.Create(
                     DependencyModuleDiagnostics.GeneratorFailure,
@@ -220,6 +278,8 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
         ImmutableArray<DecoratorModel> decorators,
         ImmutableArray<ServiceModel> attributeServices,
         ModuleDecorators moduleDecorators,
+        DiagnosticReporter report,
+        bool emit,
         FileLogger logger) {
 
         var (entryPointList, configurationModel) = EntryModelUtil.ConsolidateEntryPointModels(entryPoints);
@@ -246,10 +306,10 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
 
             GenerateForModule(
                 context, entryPointModel, configurationModel, conventionModule, candidates, decorators,
-                attributeServices, moduleDecorators, logger);
+                attributeServices, moduleDecorators, report, emit, logger);
         }
 
-        ReportUnclaimedModules(context, conventionModules, claimed, logger);
+        ReportUnclaimedModules(report, conventionModules, claimed, logger);
     }
 
     private void GenerateForModule(
@@ -261,6 +321,8 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
         ImmutableArray<DecoratorModel> decorators,
         ImmutableArray<ServiceModel> attributeServices,
         ModuleDecorators moduleDecorators,
+        DiagnosticReporter report,
+        bool emit,
         FileLogger logger) {
 
         var withNamespace = EntryModelUtil.EnsureNamespace(entryPointModel, configurationModel);
@@ -268,15 +330,16 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
         var serviceModels = conventionModule == null
             ? Array.Empty<ServiceModel>()
             : ConventionMatcher.Match(
-                withNamespace, conventionModule, candidates, context.ReportDiagnostic, logger);
+                withNamespace, conventionModule, candidates, report, logger);
 
         // Every registration this compilation makes, however it was declared. This is the whole
         // point of the single stage: a generic decorator is expanded once, against all of them.
         WriteDecorators(
             context, withNamespace, configurationModel,
-            ServiceTypes(attributeServices, serviceModels), decorators, moduleDecorators, logger);
+            ServiceTypes(attributeServices, serviceModels), decorators, moduleDecorators,
+            report, emit, logger);
 
-        if (serviceModels.Count == 0) {
+        if (serviceModels.Count == 0 || !emit) {
             return;
         }
 
@@ -344,9 +407,11 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
         IReadOnlyList<ITypeDefinition> registeredServiceTypes,
         ImmutableArray<DecoratorModel> declared,
         ModuleDecorators moduleDecorators,
+        DiagnosticReporter report,
+        bool emit,
         FileLogger logger) {
 
-        var decorators = CollectDecorators(context, entryPointModel, declared, moduleDecorators, logger);
+        var decorators = CollectDecorators(report, entryPointModel, declared, moduleDecorators, logger);
 
         if (decorators.Count == 0) {
             return;
@@ -360,9 +425,9 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
                 DecoratorConstraintChecker.CanClose(
                     moduleDecorators.Compilation, decoratorType, closedService));
 
-        ReportOpenGenericDecoration(context, refusedForOpenGenericRegistration, logger);
+        ReportOpenGenericDecoration(report, refusedForOpenGenericRegistration, logger);
 
-        if (expanded.Count == 0) {
+        if (expanded.Count == 0 || !emit) {
             return;
         }
 
@@ -381,7 +446,7 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
     /// those the module declares itself with <c>[Decorate]</c>.
     /// </summary>
     private static IReadOnlyList<DecoratorModel> CollectDecorators(
-        SourceProductionContext context,
+        DiagnosticReporter report,
         ModuleEntryPointModel entryPointModel,
         ImmutableArray<DecoratorModel> declared,
         ModuleDecorators moduleDecorators,
@@ -426,7 +491,7 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
             decorators.Add(resolution.Model);
         }
 
-        ReportAmbiguousOrdering(context, decorators, logger);
+        ReportAmbiguousOrdering(report, decorators, logger);
 
         return decorators;
     }
@@ -441,7 +506,7 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
     /// one reached emission carrying an unbound service type and produced CS7003 in generated code.
     /// </remarks>
     private static void ReportOpenGenericDecoration(
-        SourceProductionContext context,
+        DiagnosticReporter report,
         IReadOnlyList<DecoratorModel> refused,
         FileLogger logger) {
 
@@ -453,12 +518,11 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
                 $"'{decoratorName}' cannot decorate '{serviceName}' because it is registered as an " +
                 "open generic.");
 
-            context.ReportDiagnostic(
-                Diagnostic.Create(
-                    DependencyModuleDiagnostics.OpenGenericCannotBeDecorated,
-                    decorator.Location?.ToLocationOrNone() ?? Location.None,
-                    serviceName,
-                    decoratorName));
+            report.Report(
+                DependencyModuleDiagnostics.OpenGenericCannotBeDecorated,
+                decorator.Location,
+                serviceName,
+                decoratorName);
         }
     }
 
@@ -467,7 +531,7 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
     /// reported rather than resolved arbitrarily.
     /// </summary>
     private static void ReportAmbiguousOrdering(
-        SourceProductionContext context, IReadOnlyList<DecoratorModel> decorators, FileLogger logger) {
+        DiagnosticReporter report, IReadOnlyList<DecoratorModel> decorators, FileLogger logger) {
 
         for (var i = 0; i < decorators.Count; i++) {
             for (var j = i + 1; j < decorators.Count; j++) {
@@ -480,14 +544,13 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
                     $"'{decorators[i].DecoratorType.Name}' and '{decorators[j].DecoratorType.Name}' both " +
                     $"decorate '{decorators[i].ServiceType.Name}' with order {decorators[i].Order}.");
 
-                context.ReportDiagnostic(
-                    Diagnostic.Create(
-                        DependencyModuleDiagnostics.AmbiguousDecoratorOrder,
-                        decorators[i].Location?.ToLocationOrNone() ?? Location.None,
-                        decorators[i].DecoratorType.Name,
-                        decorators[j].DecoratorType.Name,
-                        decorators[i].ServiceType.Name,
-                        decorators[i].Order));
+                report.Report(
+                    DependencyModuleDiagnostics.AmbiguousDecoratorOrder,
+                    decorators[i].Location,
+                    decorators[i].DecoratorType.Name,
+                    decorators[j].DecoratorType.Name,
+                    decorators[i].ServiceType.Name,
+                    decorators[i].Order);
             }
         }
     }
@@ -500,7 +563,7 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
     /// explanation — exactly the silent failure the rest of this generator is built to avoid.
     /// </remarks>
     private static void ReportUnclaimedModules(
-        SourceProductionContext context,
+        DiagnosticReporter report,
         ImmutableArray<ConventionModuleModel> conventionModules,
         HashSet<ConventionModuleModel> claimed,
         FileLogger logger) {
@@ -514,11 +577,11 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
 
             logger.Error($"'{name}' implements IConventionModule but is not a [DependencyModule].");
 
-            context.ReportDiagnostic(Diagnostic.Create(
+            report.Report(
                 DependencyModuleDiagnostics.ConventionCannotBeRead,
-                conventionModule.Location?.ToLocationOrNone() ?? Location.None,
+                conventionModule.Location,
                 "the declaring type is not marked with [DependencyModule], so it registers nothing",
-                name));
+                name);
         }
     }
 }

--- a/src/DependencyModules.SourceGenerator/Conventions/ConventionGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/Conventions/ConventionGenerator.cs
@@ -427,6 +427,9 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
 
         ReportOpenGenericDecoration(report, refusedForOpenGenericRegistration, logger);
 
+        ReportImplementationUnderFactories(
+            report, decorators, entryPointModel, configurationModel, logger);
+
         if (expanded.Count == 0 || !emit) {
             return;
         }
@@ -494,6 +497,45 @@ public class ConventionGenerator : IDependencyModuleSourceGenerator {
         ReportAmbiguousOrdering(report, decorators, logger);
 
         return decorators;
+    }
+
+    /// <summary>
+    /// Reports a decorator naming an implementation in a project that emits factories.
+    /// </summary>
+    /// <remarks>
+    /// The decorator would wrap every registration of the service instead of the one it named,
+    /// because a factory descriptor cannot say what it built. An intercepted service is exempted
+    /// from the property automatically - the interception is declared on the class being registered,
+    /// so the writer emitting that registration sees it. A decorator is declared on the decorator,
+    /// and the registration it targets is written by a pass that never learns about it.
+    /// </remarks>
+    private static void ReportImplementationUnderFactories(
+        DiagnosticReporter report,
+        IReadOnlyList<DecoratorModel> decorators,
+        ModuleEntryPointModel entryPointModel,
+        DependencyModuleConfigurationModel configurationModel,
+        FileLogger logger) {
+
+        if (!entryPointModel.GenerateFactories.GetValueOrDefault(configurationModel.GenerateFactories)) {
+            return;
+        }
+
+        foreach (var decorator in decorators) {
+            if (decorator.Implementation == null) {
+                continue;
+            }
+
+            logger.Error(
+                $"'{decorator.DecoratorType.Name}' names an implementation, which generated " +
+                "factories cannot be told apart by.");
+
+            report.Report(
+                DependencyModuleDiagnostics.DecoratorImplementationNeedsTypeRegistration,
+                decorator.Location,
+                decorator.DecoratorType.Name,
+                decorator.Implementation.Name,
+                decorator.ServiceType.Name);
+        }
     }
 
     /// <summary>

--- a/src/DependencyModules.SourceGenerator/Conventions/Utilities/ConventionMatcher.cs
+++ b/src/DependencyModules.SourceGenerator/Conventions/Utilities/ConventionMatcher.cs
@@ -47,7 +47,7 @@ public static class ConventionMatcher {
         ModuleEntryPointModel entryPointModel,
         ConventionModuleModel conventionModule,
         IReadOnlyList<ConventionCandidateModel> candidates,
-        Action<Diagnostic> report,
+        DiagnosticReporter report,
         FileLogger logger) {
 
         var moduleName = entryPointModel.EntryPointType.Name;
@@ -55,11 +55,11 @@ public static class ConventionMatcher {
         foreach (var unreadable in conventionModule.Unreadable) {
             logger.Error($"{moduleName}: refused '{unreadable.Text}' — {unreadable.Reason}.");
 
-            report(Diagnostic.Create(
+            report.Report(
                 DependencyModuleDiagnostics.ConventionCannotBeRead,
-                unreadable.Location.ToLocationOrNone(),
+                unreadable.Location,
                 unreadable.Reason,
-                unreadable.Text));
+                unreadable.Text);
         }
 
         var merged = MergePartialDeclarations(candidates);
@@ -94,7 +94,7 @@ public static class ConventionMatcher {
         IReadOnlyList<ConventionCandidateModel> candidates,
         string moduleName,
         List<ConventionRegistrationMatch> matches,
-        Action<Diagnostic> report,
+        DiagnosticReporter report,
         FileLogger logger) {
 
         var serviceName = convention.DisplayName;
@@ -102,11 +102,11 @@ public static class ConventionMatcher {
         if (convention.Lifestyle == null) {
             logger.Error($"{moduleName}: the convention registering '{serviceName}' declared no lifetime.");
 
-            report(Diagnostic.Create(
+            report.Report(
                 DependencyModuleDiagnostics.ConventionCannotBeRead,
-                convention.Location.ToLocationOrNone(),
+                convention.Location,
                 "no lifetime was declared; call AsSingleton(), AsScoped() or AsTransient()",
-                $"RegisterAll({serviceName})"));
+                $"RegisterAll({serviceName})");
 
             return;
         }
@@ -166,14 +166,12 @@ public static class ConventionMatcher {
                     $"{moduleName}: '{candidate.ImplementationType.Name}' matched '{serviceName}' " +
                     "but has no accessible constructor.");
 
-                report(Diagnostic.Create(
+                report.Report(
                     DependencyModuleDiagnostics.ConventionMatchNotConstructable,
-                    candidate.Location == LocationModel.None
-                        ? convention.Location.ToLocationOrNone()
-                        : candidate.Location.ToLocation(),
+                    candidate.Location == LocationModel.None ? convention.Location : candidate.Location,
                     candidate.ImplementationType.Name,
                     serviceName,
-                    moduleName));
+                    moduleName);
 
                 continue;
             }
@@ -186,12 +184,12 @@ public static class ConventionMatcher {
         if (found == 0) {
             logger.Info($"{moduleName}: the convention registering '{serviceName}' matched nothing.");
 
-            report(Diagnostic.Create(
+            report.Report(
                 DependencyModuleDiagnostics.ConventionMatchedNothing,
-                convention.Location.ToLocationOrNone(),
+                convention.Location,
                 serviceName,
                 moduleName,
-                AdviceForEmptyMatch(convention, serviceName)));
+                AdviceForEmptyMatch(convention, serviceName));
         }
     }
 
@@ -455,7 +453,7 @@ public static class ConventionMatcher {
     private static List<PendingRegistration> RemoveAmbiguous(
         List<PendingRegistration> pending,
         string moduleName,
-        Action<Diagnostic> report,
+        DiagnosticReporter report,
         FileLogger logger) {
 
         // Keyed on what actually reaches the container: this implementation, under this service
@@ -505,13 +503,13 @@ public static class ConventionMatcher {
                 $"{moduleName}: '{key.Implementation.Name}' is registered as " +
                 $"'{serviceName}' by two conventions. {difference}");
 
-            report(Diagnostic.Create(
+            report.Report(
                 DependencyModuleDiagnostics.AmbiguousConventionMatch,
                 LocationOf(first.Match),
                 key.Implementation.Name,
                 moduleName,
                 serviceName,
-                difference));
+                difference);
         }
 
         return usable;
@@ -558,10 +556,10 @@ public static class ConventionMatcher {
     /// match read out of a referenced assembly has no class to squiggle, so it reports at the
     /// convention that asked for it, which is the only place the developer can act on it.
     /// </remarks>
-    private static Location LocationOf(ConventionRegistrationMatch match) =>
+    private static LocationModel LocationOf(ConventionRegistrationMatch match) =>
         match.Candidate.Location == LocationModel.None
-            ? match.Convention.Location.ToLocationOrNone()
-            : match.Candidate.Location.ToLocation();
+            ? match.Convention.Location
+            : match.Candidate.Location;
 
     /// <summary>
     /// Whether an interface is one the BCL declares, and so not something to expand a service into.
@@ -618,7 +616,7 @@ public static class ConventionMatcher {
     /// match was not direct.
     /// </summary>
     private static void ReportExposure(
-        IReadOnlyList<PendingRegistration> usable, string moduleName, Action<Diagnostic> report) {
+        IReadOnlyList<PendingRegistration> usable, string moduleName, DiagnosticReporter report) {
 
         foreach (var entry in usable) {
             var serviceType = entry.Registration.ServiceType;
@@ -631,10 +629,10 @@ public static class ConventionMatcher {
                 ? $" (via {entry.Match.Interface.ViaTypeName})"
                 : "";
 
-            report(Diagnostic.Create(
+            report.Report(
                 DependencyModuleDiagnostics.ExposedByConvention,
                 LocationOf(entry.Match),
-                $"{serviceType.Name} in {moduleName}{via}"));
+                $"{serviceType.Name} in {moduleName}{via}");
         }
     }
 

--- a/src/DependencyModules.SourceGenerator/Conventions/Utilities/ConventionMatcher.cs
+++ b/src/DependencyModules.SourceGenerator/Conventions/Utilities/ConventionMatcher.cs
@@ -682,12 +682,33 @@ public static class ConventionMatcher {
                 null,
                 null,
                 registrations,
-                RegistrationFeature.None,
+                // Carried across for the same reason the attribute path sets it: interception picks
+                // its registration out by asking each descriptor what implementation it was built
+                // from, and a factory descriptor cannot say. A convention-registered class carrying
+                // [Intercept] needs the exemption as much as an attribute-registered one, and
+                // reaches this writer by a different route.
+                InterceptionFeature(group.Match.Candidate),
                 group.Conditions));
         }
 
         return models;
     }
+
+    /// <summary>
+    /// Whether a convention candidate carries <c>[Intercept]</c>.
+    /// </summary>
+    /// <remarks>
+    /// Read from the attribute keys the candidate already carries, which are resolved rather than
+    /// taken as written — so a qualified or aliased usage counts, matching how the attribute path
+    /// reads the same thing.
+    /// </remarks>
+    private static RegistrationFeature InterceptionFeature(ConventionCandidateModel candidate) =>
+        candidate.AttributeTypeKeys?.Contains(InterceptAttributeKey) == true
+            ? RegistrationFeature.Intercepted
+            : RegistrationFeature.None;
+
+    private static readonly string InterceptAttributeKey =
+        ConventionTypeKey.For(KnownTypes.DependencyModules.Attributes.InterceptAttribute);
 
     /// <summary>
     /// One ServiceModel's worth of matches: the same implementation under the same conditions.

--- a/src/DependencyModules.SourceGenerator/InterceptorSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/InterceptorSourceGenerator.cs
@@ -153,6 +153,7 @@ public class InterceptorSourceGenerator : BaseAttributeSourceGenerator<Intercept
     /// <summary>Whether any member has an interceptor that can serve it.</summary>
     private static bool ServesAnyMember(InterceptorModel model) =>
         model.Members.Any(member =>
+            !member.Excluded &&
             model.Interceptors.Any(interceptor => interceptor.CanServe(member.Kind)));
 
     /// <summary>
@@ -285,7 +286,9 @@ public class InterceptorSourceGenerator : BaseAttributeSourceGenerator<Intercept
                 }
 
                 var unserved = model.Members
-                    .Where(member => member.Kind == kind)
+                    // An excluded member was never meant to be served, so an interceptor not
+                    // covering it is not the omission DM0015 is about.
+                    .Where(member => !member.Excluded && member.Kind == kind)
                     .Select(member => member.Name)
                     .Distinct()
                     .OrderBy(name => name, StringComparer.Ordinal)

--- a/src/DependencyModules.SourceGenerator/InterceptorSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/InterceptorSourceGenerator.cs
@@ -53,7 +53,9 @@ public class InterceptorSourceGenerator : BaseAttributeSourceGenerator<Intercept
 
         var (entryPointList, configurationModel) = EntryModelUtil.ConsolidateEntryPointModels(inputData.Left);
 
-        var usable = ReportUnsupported(context, inputData.Right, logger);
+        // Filtering only; ReportUnsupported's explanations live in ReportDiagnostics, which shares
+        // the same predicate.
+        var usable = Usable(inputData.Right);
 
         if (usable.Count == 0) {
             return;
@@ -123,22 +125,63 @@ public class InterceptorSourceGenerator : BaseAttributeSourceGenerator<Intercept
     }
 
     /// <summary>
-    /// Reports declarations that cannot be intercepted and drops them, so an unsupported shape
-    /// produces an explanation rather than a wrapper that does not compile.
+    /// The interceptions a wrapper is worth generating for.
     /// </summary>
-    private static IReadOnlyList<InterceptorModel> ReportUnsupported(
-        SourceProductionContext context, ImmutableArray<InterceptorModel> models, FileLogger logger) {
-
+    /// <remarks>
+    /// Drops a declaration that cannot be intercepted at all, and one where no member has an
+    /// interceptor able to serve it — a wrapper for the second would forward every call untouched.
+    /// Both are explained by <see cref="ReportDiagnostics"/>; this only decides what to write.
+    /// </remarks>
+    private static IReadOnlyList<InterceptorModel> Usable(ImmutableArray<InterceptorModel> models) {
         var usable = new List<InterceptorModel>();
 
         foreach (var model in models) {
+            if (model.Refusal != null || model.IsIgnored || model.Members.Count == 0) {
+                continue;
+            }
+
+            if (!ServesAnyMember(model)) {
+                continue;
+            }
+
+            usable.Add(model);
+        }
+
+        return usable;
+    }
+
+    /// <summary>Whether any member has an interceptor that can serve it.</summary>
+    private static bool ServesAnyMember(InterceptorModel model) =>
+        model.Members.Any(member =>
+            model.Interceptors.Any(interceptor => interceptor.CanServe(member.Kind)));
+
+    /// <summary>
+    /// Why an interception was refused, or is quietly absent from members it was applied to.
+    /// </summary>
+    /// <remarks>
+    /// Reported apart from emission so the locations carry their syntax tree, which is what lets
+    /// one of these be silenced where it is written rather than only across the whole project.
+    /// </remarks>
+    protected override void ReportDiagnostics(SourceProductionContext context,
+        (ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Left,
+            ImmutableArray<InterceptorModel> Right) data,
+        SyntaxTreeLookup lookup,
+        FileLogger logger) {
+
+        if (data.Left.Length == 0 || data.Right.Length == 0) {
+            return;
+        }
+
+        foreach (var model in data.Right) {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             if (model.Refusal != null) {
                 logger.Error($"Cannot intercept: {model.Refusal.Message}");
 
                 context.ReportDiagnostic(
                     Diagnostic.Create(
                         DependencyModuleDiagnostics.CannotIntercept,
-                        model.Location?.ToLocationOrNone() ?? Location.None,
+                        model.Location?.ToLocationOrNone(lookup) ?? Location.None,
                         model.Refusal.Message));
 
                 continue;
@@ -148,21 +191,11 @@ public class InterceptorSourceGenerator : BaseAttributeSourceGenerator<Intercept
                 continue;
             }
 
-            ReportUnservedMembers(context, model, logger);
-
-            // No member has an interceptor that can serve it, so a wrapper would forward every call
-            // untouched. Dropped after reporting rather than before, which is what makes the case
-            // visible at all.
-            if (!model.Members.Any(member =>
-                    model.Interceptors.Any(interceptor => interceptor.CanServe(member.Kind)))) {
-
-                continue;
-            }
-
-            usable.Add(model);
+            // Reported whether or not the model survives Usable: an interception that serves no
+            // member at all is exactly the case worth explaining, and dropping it first is what
+            // used to make it invisible.
+            ReportUnservedMembers(context, model, lookup, logger);
         }
-
-        return usable;
     }
 
     /// <summary>
@@ -178,7 +211,8 @@ public class InterceptorSourceGenerator : BaseAttributeSourceGenerator<Intercept
     /// than one per member.
     /// </remarks>
     private static void ReportUnservedMembers(
-        SourceProductionContext context, InterceptorModel model, FileLogger logger) {
+        SourceProductionContext context, InterceptorModel model, SyntaxTreeLookup lookup,
+        FileLogger logger) {
 
         foreach (var interceptor in model.Interceptors) {
             foreach (var kind in new[] {
@@ -207,7 +241,7 @@ public class InterceptorSourceGenerator : BaseAttributeSourceGenerator<Intercept
                 context.ReportDiagnostic(
                     Diagnostic.Create(
                         DependencyModuleDiagnostics.InterceptorCannotServeMembers,
-                        model.Location?.ToLocationOrNone() ?? Location.None,
+                        model.Location?.ToLocationOrNone(lookup) ?? Location.None,
                         interceptor.Type.Name,
                         InterfaceFor(kind),
                         DescriptionFor(kind),

--- a/src/DependencyModules.SourceGenerator/InterceptorSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/InterceptorSourceGenerator.cs
@@ -196,6 +196,67 @@ public class InterceptorSourceGenerator : BaseAttributeSourceGenerator<Intercept
             // used to make it invisible.
             ReportUnservedMembers(context, model, lookup, logger);
         }
+
+        ReportUnappliedInterceptions(context, data.Left, Usable(data.Right), lookup, logger);
+    }
+
+    /// <summary>
+    /// Reports an interception no module applies, which is a wrapper generated and never used.
+    /// </summary>
+    /// <remarks>
+    /// Placement is per module, and every module individually follows the rule, so an interception
+    /// can be refused by all of them without any one of them doing anything wrong. That is the shape
+    /// worth reporting: not an interception on the wrong module, which is a judgement, but one on no
+    /// module, which cannot be right in any configuration.
+    ///
+    /// The case that reaches here is a realm-only module registering the class by convention. Its
+    /// registrations are stamped with its own realm when they are matched, long after the
+    /// interception model was built, so an interception naming no realm is offered only to the
+    /// modules that are not realm-only - and if that is none of them, it is applied by nobody.
+    /// </remarks>
+    private static void ReportUnappliedInterceptions(
+        SourceProductionContext context,
+        ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> entryPoints,
+        IReadOnlyList<InterceptorModel> usable,
+        SyntaxTreeLookup lookup,
+        FileLogger logger) {
+
+        if (usable.Count == 0) {
+            return;
+        }
+
+        var (entryPointList, _) = EntryModelUtil.ConsolidateEntryPointModels(entryPoints);
+        var targets = EntryModelUtil.RegistrationTargets(entryPointList).ToArray();
+
+        if (targets.Length == 0) {
+            return;
+        }
+
+        var applied = new HashSet<ITypeDefinition>();
+
+        foreach (var entryPointModel in targets) {
+            foreach (var model in ForModule(usable, entryPointModel)) {
+                applied.Add(model.ImplementationType);
+            }
+        }
+
+        foreach (var model in usable) {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            if (applied.Contains(model.ImplementationType)) {
+                continue;
+            }
+
+            logger.Error(
+                $"No module applies the interception on '{model.ImplementationType.Name}', " +
+                "so its interceptors never run.");
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    DependencyModuleDiagnostics.InterceptionAppliedByNoModule,
+                    model.Location?.ToLocationOrNone(lookup) ?? Location.None,
+                    model.ImplementationType.Name));
+        }
     }
 
     /// <summary>

--- a/src/DependencyModules.SourceGenerator/ReferencedModuleLookup.cs
+++ b/src/DependencyModules.SourceGenerator/ReferencedModuleLookup.cs
@@ -1,0 +1,128 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace DependencyModules.SourceGenerator;
+
+/// <summary>
+/// Finds the module a name refers to when the module was not declared in this compilation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A module generates an attribute implementing <c>IDependencyModuleProvider</c>, in the module's
+/// own namespace. That interface is what makes a referenced module attribute recognisable: nothing
+/// else implements it, so a type carrying it is a module's attribute and its containing namespace
+/// is the module's namespace.
+/// </para>
+/// <para>
+/// Two paths, deliberately unequal in cost. If the developer wrote the <c>using</c>, the attribute
+/// resolves and the namespace is one of the file's imports — so trying each import by name is a
+/// handful of dictionary lookups, and that is the case that happens on every successful build. If
+/// it does not resolve, the build is already failing with <c>CS0246</c>, and only then is it worth
+/// walking the referenced assemblies to find where the type actually lives, which is the whole
+/// point of DM0016.
+/// </para>
+/// </remarks>
+internal sealed class ReferencedModuleLookup {
+    private const string ProviderInterface = "DependencyModules.Runtime.Interfaces.IDependencyModuleProvider";
+
+    private readonly Compilation? _compilation;
+    private readonly INamedTypeSymbol? _providerInterface;
+    private Dictionary<string, string>? _byName;
+
+    public ReferencedModuleLookup(Compilation? compilation) {
+        _compilation = compilation;
+        _providerInterface = compilation?.GetTypeByMetadataName(ProviderInterface);
+    }
+
+    /// <summary>
+    /// The namespace of a module whose attribute is <paramref name="name"/> and which one of
+    /// <paramref name="candidateNamespaces"/> brings into scope, or null.
+    /// </summary>
+    public string? FindImported(string name, IEnumerable<string> candidateNamespaces) {
+        if (_compilation == null || _providerInterface == null) {
+            return null;
+        }
+
+        foreach (var candidate in candidateNamespaces) {
+            if (string.IsNullOrEmpty(candidate)) {
+                continue;
+            }
+
+            foreach (var typeName in AttributeNames(name)) {
+                var symbol = _compilation.GetTypeByMetadataName($"{candidate}.{typeName}");
+
+                if (symbol != null && IsModuleAttribute(symbol)) {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The namespace of a module whose attribute is <paramref name="name"/>, wherever it lives.
+    /// </summary>
+    /// <remarks>
+    /// Walks the referenced assemblies. Reached only for a usage that resolved to nothing, so the
+    /// compilation it walks is one that is already failing to build.
+    /// </remarks>
+    public string? FindAnywhere(string name) {
+        if (_compilation == null || _providerInterface == null) {
+            return null;
+        }
+
+        _byName ??= BuildIndex();
+
+        foreach (var typeName in AttributeNames(name)) {
+            if (_byName.TryGetValue(typeName, out var moduleNamespace)) {
+                return moduleNamespace;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Written as <c>[assembly: Foo]</c> or <c>[assembly: FooAttribute]</c>.</summary>
+    private static IEnumerable<string> AttributeNames(string name) {
+        yield return name;
+
+        if (!name.EndsWith("Attribute", System.StringComparison.Ordinal)) {
+            yield return name + "Attribute";
+        }
+    }
+
+    private bool IsModuleAttribute(INamedTypeSymbol symbol) =>
+        symbol.AllInterfaces.Any(i => SymbolEqualityComparer.Default.Equals(i, _providerInterface));
+
+    private Dictionary<string, string> BuildIndex() {
+        var index = new Dictionary<string, string>(System.StringComparer.Ordinal);
+
+        foreach (var reference in _compilation!.References) {
+            if (_compilation.GetAssemblyOrModuleSymbol(reference) is not IAssemblySymbol assembly) {
+                continue;
+            }
+
+            Walk(assembly.GlobalNamespace, index);
+        }
+
+        return index;
+    }
+
+    private void Walk(INamespaceSymbol namespaceSymbol, Dictionary<string, string> index) {
+        foreach (var type in namespaceSymbol.GetTypeMembers()) {
+            if (type.DeclaredAccessibility == Accessibility.Public && IsModuleAttribute(type)) {
+                // First wins. Two packages can ship a same-named module, and naming one of them is
+                // more useful than naming neither.
+                if (!index.ContainsKey(type.Name)) {
+                    index.Add(type.Name, namespaceSymbol.ToDisplayString());
+                }
+            }
+        }
+
+        foreach (var nested in namespaceSymbol.GetNamespaceMembers()) {
+            Walk(nested, index);
+        }
+    }
+}

--- a/src/DependencyModules.SourceGenerator/ServiceSourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/ServiceSourceGenerator.cs
@@ -38,15 +38,14 @@ public class ServiceSourceGenerator : BaseAttributeSourceGenerator<ServiceModel>
 
         LogDiscovery(inputData, logger);
 
-        var serviceModels = ReportUnconstructableServices(context, inputData.Right, logger);
-
-        serviceModels = ReportCrossWiredGenerics(context, serviceModels, logger);
+        // Filtering only. What each of these removes is reported by ReportDiagnostics, which shares
+        // the predicates rather than repeating them - a service that cannot be constructed, or a
+        // generic that cannot be cross-wired, is dropped here and explained there.
+        var serviceModels = Registerable(inputData.Right);
 
         if (serviceModels.Length == 0) {
             return;
         }
-
-        ReportEnvironmentConditions(context, serviceModels, logger);
 
         var (entryPointList, configurationModel) =
             EntryModelUtil.ConsolidateEntryPointModels(inputData.Left);
@@ -124,43 +123,35 @@ public class ServiceSourceGenerator : BaseAttributeSourceGenerator<ServiceModel>
     }
 
     /// <summary>
-    /// Reports the services the container could never construct and removes them from generation.
-    /// Emitting a registration for an abstract or static type produces code that throws when the
-    /// provider is built, a long way from the declaration responsible.
+    /// The services worth emitting a registration for.
     /// </summary>
-    private static ImmutableArray<ServiceModel> ReportUnconstructableServices(
-        SourceProductionContext context, ImmutableArray<ServiceModel> serviceModels, FileLogger logger) {
-
-        if (!serviceModels.Any(IsUnconstructable)) {
+    /// <remarks>
+    /// Drops what the container could never construct and what cannot be cross-wired. Emitting
+    /// either produces code that fails a long way from the declaration responsible — at provider
+    /// build for an abstract or static type, and at compile time for a cross-wired generic. Each is
+    /// explained by a diagnostic; this only decides what not to write.
+    /// </remarks>
+    private static ImmutableArray<ServiceModel> Registerable(ImmutableArray<ServiceModel> serviceModels) {
+        if (!serviceModels.Any(m => IsUnconstructable(m) || IsCrossWiredGeneric(m))) {
             return serviceModels;
         }
 
         var builder = ImmutableArray.CreateBuilder<ServiceModel>(serviceModels.Length);
 
         foreach (var serviceModel in serviceModels) {
-            if (!IsUnconstructable(serviceModel)) {
+            if (!IsUnconstructable(serviceModel) && !IsCrossWiredGeneric(serviceModel)) {
                 builder.Add(serviceModel);
-                continue;
             }
-
-            var reason = serviceModel.Features.HasFlag(RegistrationFeature.StaticImplementation)
-                ? "a static class"
-                : "abstract";
-
-            var typeName = serviceModel.ImplementationType.Name;
-
-            logger.Error($"Skipping '{typeName}' because it is {reason}.");
-
-            context.ReportDiagnostic(
-                Diagnostic.Create(
-                    DependencyModuleDiagnostics.ServiceCannotBeConstructed,
-                    serviceModel.Location?.ToLocationOrNone() ?? Location.None,
-                    typeName,
-                    reason));
         }
 
         return builder.ToImmutable();
     }
+
+    /// <summary>Why a service cannot be constructed, phrased for the message.</summary>
+    private static string UnconstructableReason(ServiceModel serviceModel) =>
+        serviceModel.Features.HasFlag(RegistrationFeature.StaticImplementation)
+            ? "a static class"
+            : "abstract";
 
     /// <summary>
     /// Reports cross-wired generic types and removes them from generation.
@@ -177,19 +168,56 @@ public class ServiceSourceGenerator : BaseAttributeSourceGenerator<ServiceModel>
     /// longer be reachable through any of its interfaces, which is the entire reason the attribute
     /// was written.
     /// </remarks>
-    private static ImmutableArray<ServiceModel> ReportCrossWiredGenerics(
-        SourceProductionContext context, ImmutableArray<ServiceModel> serviceModels, FileLogger logger) {
+    /// <summary>
+    /// A cross-wired registration on an implementation that is itself generic.
+    /// </summary>
+    private static bool IsCrossWiredGeneric(ServiceModel serviceModel) =>
+        serviceModel.ImplementationType is GenericTypeDefinition { TypeArguments.Count: > 0 } &&
+        serviceModel.Registrations.Any(registration => registration.CrossWire == true);
 
-        if (!serviceModels.Any(IsCrossWiredGeneric)) {
-            return serviceModels;
+    /// <summary>
+    /// Everything this generator has to say about the services it found.
+    /// </summary>
+    /// <remarks>
+    /// Runs apart from emission so that the locations can carry their syntax tree, which is what
+    /// lets a developer silence one of these where it is written rather than only across the whole
+    /// project. The two halves share their predicates: what <see cref="Registerable"/> drops is
+    /// exactly what the first two loops here explain.
+    /// </remarks>
+    protected override void ReportDiagnostics(SourceProductionContext context,
+        (ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)> Left,
+            ImmutableArray<ServiceModel> Right) data,
+        SyntaxTreeLookup lookup,
+        FileLogger logger) {
+
+        if (data.Left.Length == 0 || data.Right.Length == 0) {
+            return;
         }
 
-        var builder = ImmutableArray.CreateBuilder<ServiceModel>(serviceModels.Length);
+        foreach (var serviceModel in data.Right) {
+            context.CancellationToken.ThrowIfCancellationRequested();
 
-        foreach (var serviceModel in serviceModels) {
+            if (!IsUnconstructable(serviceModel)) {
+                continue;
+            }
+
+            var reason = UnconstructableReason(serviceModel);
+            var typeName = serviceModel.ImplementationType.Name;
+
+            logger.Error($"Skipping '{typeName}' because it is {reason}.");
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    DependencyModuleDiagnostics.ServiceCannotBeConstructed,
+                    serviceModel.Location?.ToLocationOrNone(lookup) ?? Location.None,
+                    typeName,
+                    reason));
+        }
+
+        foreach (var serviceModel in data.Right) {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             if (!IsCrossWiredGeneric(serviceModel)) {
-                builder.Add(serviceModel);
-
                 continue;
             }
 
@@ -200,19 +228,16 @@ public class ServiceSourceGenerator : BaseAttributeSourceGenerator<ServiceModel>
             context.ReportDiagnostic(
                 Diagnostic.Create(
                     DependencyModuleDiagnostics.CrossWireCannotBeGeneric,
-                    serviceModel.Location?.ToLocationOrNone() ?? Location.None,
+                    serviceModel.Location?.ToLocationOrNone(lookup) ?? Location.None,
                     typeName));
         }
 
-        return builder.ToImmutable();
-    }
+        var registerable = Registerable(data.Right);
 
-    /// <summary>
-    /// A cross-wired registration on an implementation that is itself generic.
-    /// </summary>
-    private static bool IsCrossWiredGeneric(ServiceModel serviceModel) =>
-        serviceModel.ImplementationType is GenericTypeDefinition { TypeArguments.Count: > 0 } &&
-        serviceModel.Registrations.Any(registration => registration.CrossWire == true);
+        if (registerable.Length > 0) {
+            ReportEnvironmentConditions(context, registerable, lookup, logger);
+        }
+    }
 
     /// <summary>
     /// Reports what each conditional registration depends on, and refuses conditions that name
@@ -225,7 +250,8 @@ public class ServiceSourceGenerator : BaseAttributeSourceGenerator<ServiceModel>
     /// meant to say.
     /// </remarks>
     private static void ReportEnvironmentConditions(
-        SourceProductionContext context, ImmutableArray<ServiceModel> serviceModels, FileLogger logger) {
+        SourceProductionContext context, ImmutableArray<ServiceModel> serviceModels,
+        SyntaxTreeLookup lookup, FileLogger logger) {
 
         foreach (var serviceModel in serviceModels) {
             if (serviceModel.Conditions is not { Count: > 0 } conditions) {
@@ -246,7 +272,7 @@ public class ServiceSourceGenerator : BaseAttributeSourceGenerator<ServiceModel>
                 context.ReportDiagnostic(
                     Diagnostic.Create(
                         DependencyModuleDiagnostics.EmptyEnvironmentCondition,
-                        serviceModel.Location?.ToLocationOrNone() ?? Location.None,
+                        serviceModel.Location?.ToLocationOrNone(lookup) ?? Location.None,
                         typeName,
                         kind));
             }
@@ -267,7 +293,7 @@ public class ServiceSourceGenerator : BaseAttributeSourceGenerator<ServiceModel>
             context.ReportDiagnostic(
                 Diagnostic.Create(
                     DependencyModuleDiagnostics.RegisteredConditionally,
-                    serviceModel.Location?.ToLocationOrNone() ?? Location.None,
+                    serviceModel.Location?.ToLocationOrNone(lookup) ?? Location.None,
                     summary));
         }
     }

--- a/src/DependencyModules.SourceGenerator/SourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/SourceGenerator.cs
@@ -31,7 +31,8 @@ public class SourceGenerator : BaseSourceGenerator {
         // DM0016. Registered here rather than on the base class so that a framework generator loaded
         // alongside this one does not report the same usage twice.
         context.RegisterSourceOutput(
-            valuesProvider.Combine(AssemblyModuleAttributeDiagnostics.Collect(context)),
+            valuesProvider.Combine(AssemblyModuleAttributeDiagnostics.Collect(context))
+                .Combine(context.CompilationProvider),
             AssemblyModuleAttributeDiagnostics.Report);
     }
 }

--- a/src/DependencyModules.SourceGenerator/SourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/SourceGenerator.cs
@@ -26,7 +26,7 @@ public class SourceGenerator : BaseSourceGenerator {
     protected override void SetupRootGenerator(IncrementalGeneratorInitializationContext context,
         IncrementalValueProvider<ImmutableArray<(ModuleEntryPointModel Left, DependencyModuleConfigurationModel Right)>> valuesProvider) {
 
-        context.RegisterSourceOutput(valuesProvider, new DependencyModuleWriter(true).GenerateSource);
+        DependencyModuleWriter.Register(context, valuesProvider, generateAttribute: true);
 
         // DM0016. Registered here rather than on the base class so that a framework generator loaded
         // alongside this one does not report the same usage twice.

--- a/src/DependencyModules.SourceGenerator/SourceGenerator.cs
+++ b/src/DependencyModules.SourceGenerator/SourceGenerator.cs
@@ -28,6 +28,10 @@ public class SourceGenerator : BaseSourceGenerator {
 
         DependencyModuleWriter.Register(context, valuesProvider, generateAttribute: true);
 
+        // DM0021. Registered here for the same reason DM0016 is: a framework generator loaded
+        // alongside this one would otherwise report the same test method twice.
+        TestAttributeDiagnostics.Setup(context);
+
         // DM0016. Registered here rather than on the base class so that a framework generator loaded
         // alongside this one does not report the same usage twice.
         context.RegisterSourceOutput(

--- a/src/DependencyModules.SourceGenerator/TestAttributeDiagnostics.cs
+++ b/src/DependencyModules.SourceGenerator/TestAttributeDiagnostics.cs
@@ -1,0 +1,167 @@
+using System.Collections.Generic;
+using System.Linq;
+using CSharpAuthor;
+using DependencyModules.SourceGenerator.Impl;
+using DependencyModules.SourceGenerator.Impl.Models;
+using DependencyModules.SourceGenerator.Impl.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace DependencyModules.SourceGenerator;
+
+/// <summary>
+/// DM0021: a <c>[Mock]</c> parameter and a <c>[TestExport]</c> on the same method, both naming one
+/// service.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generator has nothing to emit for a test method. This is here because the question is
+/// decidable at compile time and the answer is otherwise a surprise at run time: the parameter wins,
+/// so the <c>[TestExport]</c> beside it does nothing, and a test written that way reads as though it
+/// should get the real implementation.
+/// </para>
+/// <para>
+/// Only the same method. A <c>[TestExport]</c> on the class or the assembly is the default for
+/// everything under it, and one test overriding that for one argument is what having both scopes is
+/// for — reporting that would be reporting the feature.
+/// </para>
+/// </remarks>
+internal static class TestAttributeDiagnostics {
+
+    internal static void Setup(IncrementalGeneratorInitializationContext context) {
+        var methods = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                static (node, _) =>
+                    node is MethodDeclarationSyntax { AttributeLists.Count: > 0, ParameterList.Parameters.Count: > 0 },
+                Read)
+            .Where(static finding => finding != null)
+            .Collect();
+
+        // With the compilation, so the location carries its syntax tree and .editorconfig and
+        // #pragma can reach this like any other code. Emits nothing, so re-running it per keystroke
+        // costs a walk over findings that are almost always none.
+        context.RegisterSourceOutput(methods.Combine(context.CompilationProvider), Report);
+    }
+
+    /// <summary>
+    /// A method that carries both, and the service they disagree about.
+    /// </summary>
+    /// <remarks>
+    /// The location is rendered to primitives like every other model's, so this can be cached
+    /// without pinning a syntax tree. The finding is only produced for a method that already
+    /// carries both attributes, which is rare enough that the common case allocates nothing.
+    /// </remarks>
+    private record Finding(string MethodName, string ServiceName, LocationModel Location);
+
+    private static Finding? Read(GeneratorSyntaxContext syntaxContext, System.Threading.CancellationToken cancellationToken) {
+        var context = (SyntaxTransformContext)syntaxContext;
+        var method = (MethodDeclarationSyntax)context.Node;
+
+        var exported = ExportedServices(method, context, cancellationToken);
+
+        if (exported.Count == 0) {
+            return null;
+        }
+
+        foreach (var parameter in method.ParameterList.Parameters) {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!CarriesMock(parameter, context, cancellationToken)) {
+                continue;
+            }
+
+            var parameterType = parameter.Type?.GetTypeDefinition(context);
+
+            if (parameterType == null) {
+                continue;
+            }
+
+            foreach (var service in exported) {
+                if (service.Equals(parameterType)) {
+                    return new Finding(
+                        method.Identifier.ToString(),
+                        service.Name,
+                        LocationModel.From(parameter));
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The services this method's own <c>[TestExport]</c> attributes name.
+    /// </summary>
+    private static List<ITypeDefinition> ExportedServices(
+        MethodDeclarationSyntax method,
+        SyntaxTransformContext context,
+        System.Threading.CancellationToken cancellationToken) {
+
+        var services = new List<ITypeDefinition>();
+
+        foreach (var attributeList in method.AttributeLists) {
+            foreach (var attribute in attributeList.Attributes) {
+                if (!AttributeTypeMatcher.Matches(
+                        context.SemanticModel,
+                        attribute,
+                        KnownTypes.DependencyModules.Testing.TestExportAttribute,
+                        cancellationToken)) {
+                    continue;
+                }
+
+                // The service is the first positional argument: [TestExport(typeof(IFoo), ...)].
+                var first = attribute.ArgumentList?.Arguments.FirstOrDefault(
+                    argument => argument.NameEquals == null);
+
+                if (first?.Expression is TypeOfExpressionSyntax typeOf &&
+                    typeOf.Type.GetTypeDefinition(context) is { } service) {
+                    services.Add(service);
+                }
+            }
+        }
+
+        return services;
+    }
+
+    private static bool CarriesMock(
+        ParameterSyntax parameter,
+        SyntaxTransformContext context,
+        System.Threading.CancellationToken cancellationToken) {
+
+        foreach (var attributeList in parameter.AttributeLists) {
+            foreach (var attribute in attributeList.Attributes) {
+                if (AttributeTypeMatcher.Matches(
+                        context.SemanticModel,
+                        attribute,
+                        KnownTypes.DependencyModules.Testing.MockAttribute,
+                        cancellationToken)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void Report(
+        SourceProductionContext context,
+        (System.Collections.Immutable.ImmutableArray<Finding?> Findings, Compilation Compilation) data) {
+
+        var lookup = new SyntaxTreeLookup(data.Compilation);
+
+        foreach (var finding in data.Findings) {
+            if (finding == null) {
+                continue;
+            }
+
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    DependencyModuleDiagnostics.MockAndTestExportOnOneMethod,
+                    finding.Location.ToLocationOrNone(lookup),
+                    finding.MethodName,
+                    finding.ServiceName));
+        }
+    }
+}

--- a/src/DependencyModules.Testing/Attributes/Interfaces/IMockSupportAttribute.cs
+++ b/src/DependencyModules.Testing/Attributes/Interfaces/IMockSupportAttribute.cs
@@ -15,4 +15,25 @@ public interface IMockSupportAttribute {
     /// <param name="type">The type for which a mock instance is to be provided.</param>
     /// <returns>A mock object instance of the specified type.</returns>
     object ProvideMock(Type type);
+
+    /// <summary>
+    /// Whether this attribute registers <paramref name="serviceType"/> itself for this test, so a
+    /// <c>[Mock]</c> parameter naming it should stand aside.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Only a library that separates the double from the object it produces needs this. Moq does:
+    /// a <c>Mock&lt;T&gt;</c> parameter makes it register both halves, and they have to be halves of
+    /// one mock. A <c>[Mock] T</c> parameter on the same test would otherwise register a second,
+    /// unrelated double over the top, and the test would configure one mock while the container
+    /// handed out another.
+    /// </para>
+    /// <para>
+    /// False by default, which is right for a library with only one spelling — NSubstitute and
+    /// FakeItEasy register nothing of their own, so there is nothing for <c>[Mock]</c> to defer to.
+    /// </para>
+    /// </remarks>
+    /// <param name="testMethod">The test the container is being built for.</param>
+    /// <param name="serviceType">The service a <c>[Mock]</c> parameter is about to register.</param>
+    bool RegistersService(ITestMethodContext testMethod, Type serviceType) => false;
 }

--- a/src/DependencyModules.Testing/Attributes/MockAttribute.cs
+++ b/src/DependencyModules.Testing/Attributes/MockAttribute.cs
@@ -54,6 +54,13 @@ public class MockAttribute : Attribute, ITestParameterValueProvider {
             throw new Exception("Mock library not found, please ensure the Type or Assembly is attributed correctly.");
         }
 
+        // The mock library owns this type for this test - a Moq test naming both Mock<IFoo> and
+        // [Mock] IFoo wants one mock seen two ways, and registering a second one here would leave
+        // the test configuring one while the container handed out another.
+        if (mockAttribute.RegistersService(testMethod, parameter.ParameterType)) {
+            return;
+        }
+
         var mockedValue = mockAttribute.ProvideMock(parameter.ParameterType);
         var key = ServiceKeyOf(parameter);
 

--- a/src/DependencyModules.Testing/Attributes/MockAttribute.cs
+++ b/src/DependencyModules.Testing/Attributes/MockAttribute.cs
@@ -57,6 +57,8 @@ public class MockAttribute : Attribute, ITestParameterValueProvider {
         var mockedValue = mockAttribute.ProvideMock(parameter.ParameterType);
         var key = ServiceKeyOf(parameter);
 
+        _double = mockedValue;
+
         // Registered under the parameter's key when it has one. Registering unkeyed regardless left
         // the keyed registration — the one the consumer actually injects — untouched, so the service
         // under test kept the real implementation while the test held a double it believed was wired
@@ -88,11 +90,58 @@ public class MockAttribute : Attribute, ITestParameterValueProvider {
         ITestMethodContext testMethod, IServiceProvider serviceProvider, ParameterInfo parameter) {
         var key = ServiceKeyOf(parameter);
 
-        if (key != null && serviceProvider is IKeyedServiceProvider keyedServiceProvider) {
-            return Task.FromResult(keyedServiceProvider.GetKeyedService(parameter.ParameterType, key));
+        var resolved = key != null && serviceProvider is IKeyedServiceProvider keyedServiceProvider
+            ? keyedServiceProvider.GetKeyedService(parameter.ParameterType, key)
+            : serviceProvider.GetService(parameter.ParameterType);
+
+        return Task.FromResult(Verified(resolved, parameter));
+    }
+
+    /// <summary>
+    /// The double this attribute registered, kept so the value resolved afterwards can be checked
+    /// against it.
+    /// </summary>
+    private object? _double;
+
+    /// <summary>
+    /// Confirms the container still holds the double this attribute put there.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The parameter is resolved from the container rather than handed the stashed double
+    /// deliberately: it guarantees the test holds the same instance the service under test was
+    /// built against, which is the whole point of registering during setup rather than merely
+    /// supplying an argument.
+    /// </para>
+    /// <para>
+    /// That leaves one way to be wrong. Something registered later for the same service - a
+    /// <c>[TestExport]</c> naming it, which runs in a pass after this one and is meant to win -
+    /// displaces the double, and the parameter comes back holding the real implementation while the
+    /// test believes it holds a mock. The arrangement then throws a mocking-library error naming
+    /// neither attribute.
+    /// </para>
+    /// <para>
+    /// Both behaviours are intended on their own, so neither moves. Asking for both is the
+    /// contradiction, and it is now reported as one.
+    /// </para>
+    /// </remarks>
+    private object? Verified(object? resolved, ParameterInfo parameter) {
+        // Compared by type rather than by instance. The mocking-support attribute registers its own
+        // view of the same double in the later pass - which is how a [Mock] parameter and a
+        // Mock<T> parameter come back as one pair - so the instance legitimately differs while the
+        // double does not. What cannot happen is a different *kind* of object arriving, which is
+        // what a real implementation displacing the mock looks like.
+        if (_double == null || resolved == null || resolved.GetType() == _double.GetType()) {
+            return resolved;
         }
 
-        return Task.FromResult(serviceProvider.GetService(parameter.ParameterType));
+        throw new InvalidOperationException(
+            $"[Mock] on '{parameter.Name}' registered a double for " +
+            $"'{parameter.ParameterType.Name}', but the container resolved a " +
+            $"'{resolved.GetType().Name}' instead - something registered later replaced it. " +
+            "[TestExport] naming the same service is the usual cause, and it is meant to win, so " +
+            "the two cannot both apply to one service. Drop whichever of [Mock] and [TestExport] " +
+            "is not the one you want.");
     }
 
     /// <summary>

--- a/src/DependencyModules.Testing/Attributes/MockAttribute.cs
+++ b/src/DependencyModules.Testing/Attributes/MockAttribute.cs
@@ -57,8 +57,6 @@ public class MockAttribute : Attribute, ITestParameterValueProvider {
         var mockedValue = mockAttribute.ProvideMock(parameter.ParameterType);
         var key = ServiceKeyOf(parameter);
 
-        _double = mockedValue;
-
         // Registered under the parameter's key when it has one. Registering unkeyed regardless left
         // the keyed registration — the one the consumer actually injects — untouched, so the service
         // under test kept the real implementation while the test held a double it believed was wired
@@ -90,58 +88,11 @@ public class MockAttribute : Attribute, ITestParameterValueProvider {
         ITestMethodContext testMethod, IServiceProvider serviceProvider, ParameterInfo parameter) {
         var key = ServiceKeyOf(parameter);
 
-        var resolved = key != null && serviceProvider is IKeyedServiceProvider keyedServiceProvider
-            ? keyedServiceProvider.GetKeyedService(parameter.ParameterType, key)
-            : serviceProvider.GetService(parameter.ParameterType);
-
-        return Task.FromResult(Verified(resolved, parameter));
-    }
-
-    /// <summary>
-    /// The double this attribute registered, kept so the value resolved afterwards can be checked
-    /// against it.
-    /// </summary>
-    private object? _double;
-
-    /// <summary>
-    /// Confirms the container still holds the double this attribute put there.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// The parameter is resolved from the container rather than handed the stashed double
-    /// deliberately: it guarantees the test holds the same instance the service under test was
-    /// built against, which is the whole point of registering during setup rather than merely
-    /// supplying an argument.
-    /// </para>
-    /// <para>
-    /// That leaves one way to be wrong. Something registered later for the same service - a
-    /// <c>[TestExport]</c> naming it, which runs in a pass after this one and is meant to win -
-    /// displaces the double, and the parameter comes back holding the real implementation while the
-    /// test believes it holds a mock. The arrangement then throws a mocking-library error naming
-    /// neither attribute.
-    /// </para>
-    /// <para>
-    /// Both behaviours are intended on their own, so neither moves. Asking for both is the
-    /// contradiction, and it is now reported as one.
-    /// </para>
-    /// </remarks>
-    private object? Verified(object? resolved, ParameterInfo parameter) {
-        // Compared by type rather than by instance. The mocking-support attribute registers its own
-        // view of the same double in the later pass - which is how a [Mock] parameter and a
-        // Mock<T> parameter come back as one pair - so the instance legitimately differs while the
-        // double does not. What cannot happen is a different *kind* of object arriving, which is
-        // what a real implementation displacing the mock looks like.
-        if (_double == null || resolved == null || resolved.GetType() == _double.GetType()) {
-            return resolved;
+        if (key != null && serviceProvider is IKeyedServiceProvider keyedServiceProvider) {
+            return Task.FromResult(keyedServiceProvider.GetKeyedService(parameter.ParameterType, key));
         }
 
-        throw new InvalidOperationException(
-            $"[Mock] on '{parameter.Name}' registered a double for " +
-            $"'{parameter.ParameterType.Name}', but the container resolved a " +
-            $"'{resolved.GetType().Name}' instead - something registered later replaced it. " +
-            "[TestExport] naming the same service is the usual cause, and it is meant to win, so " +
-            "the two cannot both apply to one service. Drop whichever of [Mock] and [TestExport] " +
-            "is not the one you want.");
+        return Task.FromResult(serviceProvider.GetService(parameter.ParameterType));
     }
 
     /// <summary>

--- a/src/DependencyModules.xUnit/DependencyModules.xUnit.csproj
+++ b/src/DependencyModules.xUnit/DependencyModules.xUnit.csproj
@@ -25,8 +25,16 @@
           hard-error unless the project is an executable test project — this ships [ModuleTest] for
           other people's test projects and is not one. That error names this package as the
           supported answer, which replaces the previous ExcludeAssets workaround.
+
+          Upper-bounded deliberately. A bare Version="3.2.2" packs as [3.2.2, ), so
+          `dotnet add package xunit.v3` resolving 4.0.0 unified this reference up to 4.0.0 and every
+          [ModuleTest] failed at discovery: 4.0.0 removed the seven-parameter
+          TestIntrospectionHelper.GetTestCaseDetails overload the compiled discoverer holds a
+          memberref to. Source-compatible, binary-incompatible, and nothing warned at restore or
+          build — the message named an xUnit internal rather than this package. The range turns that
+          into a NuGet resolution error, which says where the problem is.
         -->
-        <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2"/>
+        <PackageReference Include="xunit.v3.extensibility.core" Version="[3.2.2,4.0.0)"/>
 
         <!--
           Referenced explicitly because xunit.v3.extensibility.core does not carry it the way

--- a/src/DependencyModules.xUnit/Impl/ModuleTestCase.cs
+++ b/src/DependencyModules.xUnit/Impl/ModuleTestCase.cs
@@ -86,9 +86,14 @@ public class ModuleTestCase : XunitTestCase {
 
         SetupModules(serviceCollection, knownAttributes);
 
-        resolver.SetupServiceCollection(serviceCollection);
-
         SetupServiceSetupAttributes(context, serviceCollection, knownAttributes);
+
+        // Last, so a [Mock] on a parameter beats a [TestExport] naming the same service. A
+        // parameter attribute is the narrowest thing a test can say and the only one that names a
+        // single argument, so it decides for that argument - the class or assembly sets the default
+        // and this is the one test opting out of it. A [Mock] stands aside where the mock library
+        // registers the type itself, which is what keeps [Mock] IFoo and Mock<IFoo> one pair.
+        resolver.SetupServiceCollection(serviceCollection);
 
         var provider = BuildServiceProvider(context, serviceCollection, knownAttributes);
 
@@ -131,13 +136,18 @@ public class ModuleTestCase : XunitTestCase {
     }
 
     /// <remarks>
-    /// The whole pass runs after the parameter value providers, so a <c>[TestExport]</c> overrides a
-    /// <c>[Mock]</c> of the same service rather than the other way round.
+    /// The whole pass runs <em>before</em> the parameter value providers, so a <c>[Mock]</c> on a
+    /// parameter overrides a <c>[TestExport]</c> naming the same service. These attributes apply to
+    /// a method, a class or an assembly; a parameter attribute names one argument, and that is the
+    /// narrowest thing a test can say, so it is the one that decides.
     ///
     /// Mock support goes first within the pass, everything else keeping its declared order behind it.
     /// A mock is the stand-in a test falls back to, so naming a real implementation has to beat it —
     /// and has to beat it whether <c>[MoqSupport]</c> sits on the assembly, the class or the method,
-    /// which relying on attribute order alone would not guarantee.
+    /// which relying on attribute order alone would not guarantee. A <c>Mock&lt;T&gt;</c> parameter
+    /// goes through this pass rather than the parameter one, so it does <em>not</em> override a
+    /// <c>[TestExport]</c>: asking for the mock object is not the same as declaring the service
+    /// mocked, which is what <c>[Mock]</c> is for.
     /// </remarks>
     private void SetupServiceSetupAttributes(
         ITestMethodContext context, ServiceCollection serviceCollection, Attribute[] knownAttributes) {

--- a/src/DependencyModules.xUnit/Impl/ModuleTestCase.cs
+++ b/src/DependencyModules.xUnit/Impl/ModuleTestCase.cs
@@ -190,7 +190,40 @@ public class ModuleTestCase : XunitTestCase {
         if (dataAttributes.Length == 0) {
             return await UnitTestWithNoDataAttributes();
         }
+
+        SupplyReflectedType(dataAttributes);
+
         return await UnitTestFromDataAttributes(dataAttributes);
+    }
+
+    /// <summary>
+    /// Tells every type-aware data attribute which type it was found on.
+    /// </summary>
+    /// <remarks>
+    /// xUnit does this in <c>ExtensibilityPointFactory.GetMethodDataAttributes</c>, and
+    /// <see cref="ITypeAwareDataAttribute"/>'s own documentation makes it the obligation of any
+    /// framework that discovers data attributes some other way — which this one does, because it
+    /// also sweeps the assembly and the declaring type for the attributes that compose the module.
+    ///
+    /// Skipping it was silent in the worst way. <c>[MemberData]</c> resolves its member against
+    /// <see cref="ITypeAwareDataAttribute.MemberType"/>, and left null it returns an *empty* row
+    /// collection rather than throwing — so every row vanished, the test case produced no tests,
+    /// and the run reported a pass. Only <c>[MemberData(…, MemberType = typeof(X))]</c>, which
+    /// needs no back-fill, kept working.
+    ///
+    /// Conditional, as the interface requires: an explicit MemberType is the author's answer and is
+    /// never overwritten.
+    /// </remarks>
+    private void SupplyReflectedType(IDataAttribute[] dataAttributes) {
+        var reflectedType = TestMethod.Method.ReflectedType;
+
+        if (reflectedType == null) {
+            return;
+        }
+
+        foreach (var typeAware in dataAttributes.OfType<ITypeAwareDataAttribute>()) {
+            typeAware.MemberType ??= reflectedType;
+        }
     }
 
     private async Task<IReadOnlyCollection<IXunitTest>> UnitTestFromDataAttributes(IDataAttribute[] dataAttributes) {
@@ -231,8 +264,37 @@ public class ModuleTestCase : XunitTestCase {
             }
         }
 
+        if (unitTests.Count == 0) {
+            // Failing rather than returning nothing, which is what xUnit's own delay-enumerated
+            // theory does for a theory without data. Returning an empty collection here is reported
+            // as a pass, so a row source that stopped producing rows — for any reason, not only the
+            // MemberType one above — took its coverage with it and left a green suite behind. The
+            // NUnit half of this integration already refuses the equivalent case as NotRunnable.
+            //
+            // Exceptions thrown from CreateTests are caught and converted into a test case failure,
+            // which is the documented way to surface this.
+            throw new InvalidOperationException(
+                $"No data was found for '{TestMethod.TestClass.TestClassName}.{TestMethod.MethodName}'. " +
+                $"It carries {DescribeAttributes(dataAttributes)}, and every one of them returned no rows. " +
+                "A data-driven test with no rows runs nothing, so it is reported as a failure rather " +
+                "than as a pass.");
+        }
+
         return unitTests;
     }
+
+    private static string DescribeAttributes(IDataAttribute[] dataAttributes) {
+        var names = dataAttributes
+            .Select(attribute => "[" + TrimAttributeSuffix(attribute.GetType().Name) + "]")
+            .ToArray();
+
+        return names.Length == 1 ? names[0] : string.Join(", ", names);
+    }
+
+    private static string TrimAttributeSuffix(string name) =>
+        name.EndsWith("Attribute", StringComparison.Ordinal)
+            ? name.Substring(0, name.Length - "Attribute".Length)
+            : name;
 
     /// <summary>
     /// Names a data row after its own arguments, the way [Theory] does. Without this every row of

--- a/tests/DependencyModules.Tests/GeneratorTests/ApplicationModuleCollisionTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ApplicationModuleCollisionTests.cs
@@ -1,0 +1,168 @@
+using System.Collections.Generic;
+using System.Linq;
+using DependencyModules.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// Declaring <c>[DependencyModule] partial class ApplicationModule</c> in a project that already
+/// gets one generated for it.
+///
+/// Two conditions have to hold together: top-level statements, which is what makes the generator
+/// emit its own <c>ApplicationModule</c> into the project's RootNamespace, and a declared module of
+/// that name in that same namespace. Neither alone does anything. Getting Started tells the reader
+/// to use exactly that name, and putting your own classes in the project's root namespace is the
+/// default, so the pair is not an unusual thing to write.
+///
+/// What it produced was CS8785 — a *warning*, so invisible at <c>-v quiet</c> or under NoWarn —
+/// followed by CS0311 blaming the reader's own type for not implementing an interface they had
+/// never heard of. The two models had different namespaces at the point they were grouped (the
+/// generated one is created with none and given the RootNamespace afterwards), so they were never
+/// recognised as the same module; by the time the file name was computed they had converged, and
+/// the RootNamespace prefix is stripped out of it, so both asked for ApplicationModule.Module.g.cs.
+///
+/// The variants below are kept as a set on purpose: every one of them was reported as the trigger
+/// at some point, and only the last is.
+/// </summary>
+public class ApplicationModuleCollisionTests {
+
+    [Fact]
+    public void DeclaringApplicationModuleInTheRootNamespace_DoesNotCollide() {
+        var result = Run(DeclaredModule("ConfiguredRoot"));
+
+        Assert.Empty(result.DuplicateHintNames);
+        result.AssertNoErrors();
+    }
+
+    /// <summary>
+    /// CS8785 is how a duplicate hint name reaches the build, and it is only a warning — which is
+    /// the reason this shipped. Asserted separately from AssertNoErrors for that reason.
+    /// </summary>
+    [Fact]
+    public void DeclaringApplicationModuleInTheRootNamespace_DoesNotWarn() {
+        var result = Run(DeclaredModule("ConfiguredRoot"));
+
+        Assert.DoesNotContain(
+            result.CompilationDiagnostics.Concat(result.GeneratorDiagnostics),
+            diagnostic => diagnostic.Id == "CS8785");
+    }
+
+    /// <summary>
+    /// The declared module is the one that survives: it is the one with a body the developer can
+    /// add to. Consolidation already preferred a declared module over a generated one wherever it
+    /// recognised the two as the same — this only ever failed to recognise them.
+    /// </summary>
+    [Fact]
+    public void TheDeclaredModuleIsTheOneGenerated() {
+        var result = Run(DeclaredModule("ConfiguredRoot"));
+
+        var module = result.SourceContaining("ApplicationModule.Module");
+
+        Assert.Contains("namespace ConfiguredRoot", module);
+    }
+
+    /// <summary>
+    /// The registrations still have to arrive. Merging the two models is only correct if the
+    /// surviving one carries what the project asked for.
+    /// </summary>
+    [Fact]
+    public void TheSurvivingModuleStillRegistersTheProjectsServices() {
+        var result = Run(DeclaredModule("ConfiguredRoot"));
+
+        Assert.Contains("Thing", result.SourceContaining("ApplicationModule.Dependencies"));
+    }
+
+    /// <summary>
+    /// The four shapes that always built cleanly, kept so that a fix cannot quietly change them.
+    /// Each differs from the failing case in exactly one way.
+    /// </summary>
+    [Theory]
+    // A different name never collides with the generated ApplicationModule.
+    [InlineData("different name", """
+                                  namespace ConfiguredRoot;
+                                  [DependencyModules.Runtime.Attributes.DependencyModule]
+                                  public partial class CompositionModule;
+                                  """)]
+    // A namespace other than RootNamespace produces a different hint name.
+    [InlineData("different namespace", """
+                                       namespace SomewhereElse;
+                                       [DependencyModules.Runtime.Attributes.DependencyModule]
+                                       public partial class ApplicationModule;
+                                       """)]
+    // The global namespace, likewise.
+    [InlineData("global namespace", """
+                                    [DependencyModules.Runtime.Attributes.DependencyModule]
+                                    public partial class ApplicationModule;
+                                    """)]
+    public void AShapeThatNeverCollided_StillBuildsCleanly(string variant, string declaration) {
+        var result = Run(declaration);
+
+        Assert.Empty(result.DuplicateHintNames);
+        result.AssertNoErrors();
+        Assert.NotEmpty(variant);
+    }
+
+    /// <summary>
+    /// An explicit Main was reported as one of the shapes that built cleanly. Measured here, it
+    /// collides exactly like top-level statements do: the compilation unit is approved on its file
+    /// name alone — <c>Program.cs</c> — with nothing checking for top-level statements, so a project
+    /// with a hand-written Main in Program.cs gets a generated ApplicationModule too.
+    ///
+    /// That is worth knowing on its own, because it is not what the documentation describes. It is
+    /// left as it is rather than narrowed: a project relying on the generated module today would
+    /// lose it, and this fix makes the shape work either way.
+    /// </summary>
+    [Fact]
+    public void AnExplicitMainWithADeclaredApplicationModule_BuildsCleanly() {
+        var result = GeneratorTestHarness.Run(
+            new Dictionary<string, string> {
+                ["Program.cs"] =
+                    """
+                    namespace ConfiguredRoot;
+
+                    public static class Program {
+                        public static void Main() => System.Console.WriteLine("hello");
+                    }
+                    """,
+                ["Composition.cs"] = DeclaredModule("ConfiguredRoot"),
+                ["Services.cs"] = Services
+            },
+            new Dictionary<string, string> { ["RootNamespace"] = "ConfiguredRoot" },
+            OutputKind.ConsoleApplication);
+
+        Assert.Empty(result.DuplicateHintNames);
+        result.AssertNoErrors();
+    }
+
+    private static string DeclaredModule(string namespaceName) =>
+        $$"""
+          namespace {{namespaceName}};
+
+          [DependencyModules.Runtime.Attributes.DependencyModule]
+          public partial class ApplicationModule;
+          """;
+
+    private const string Services =
+        """
+        namespace ConfiguredRoot;
+
+        public interface IThing;
+
+        [DependencyModules.Runtime.Attributes.SingletonService]
+        public class Thing : IThing;
+        """;
+
+    private static GeneratorResult Run(string declaration) =>
+        GeneratorTestHarness.Run(
+            new Dictionary<string, string> {
+                // Top-level statements: this is what makes the generator emit its own
+                // ApplicationModule into RootNamespace.
+                ["Program.cs"] = """System.Console.WriteLine("hello");""",
+                ["Composition.cs"] = declaration,
+                ["Services.cs"] = Services
+            },
+            new Dictionary<string, string> { ["RootNamespace"] = "ConfiguredRoot" },
+            OutputKind.ConsoleApplication);
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/DecoratorImplementationTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/DecoratorImplementationTests.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using System.Linq;
+using DependencyModules.Tests.Infrastructure;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// <c>[Decorator(Implementation = typeof(X))]</c> — decorating one implementation rather than every
+/// registration of the service.
+///
+/// A decorator is declared against an interface, and wrapping everything behind it is the right
+/// default: that is what a decorator is for, and what separates it from interception. But a project
+/// with several implementations of one interface had no way to say "wrap this one" — the report's
+/// agents accepted decoration of every registration because there was nothing else to write.
+///
+/// This is the inverse of the change 1.1.0 made to interception, which went from per-service to
+/// per-implementation. The runtime already had what it needs: DecoratorHelper.Decorate takes an
+/// implementation type and skips descriptors built from anything else, which is the overload
+/// interception uses. Only the attribute could not say so.
+/// </summary>
+public class DecoratorImplementationTests {
+
+    /// <summary>
+    /// The default, unchanged: no Implementation named, so every registration of the service is
+    /// wrapped.
+    /// </summary>
+    [Fact]
+    public void WithNoImplementationNamed_EveryRegistrationIsWrapped() {
+        var resolved = Resolve("[Decorator]");
+
+        Assert.Equal(["Logged", "Logged"], resolved.Select(Outer));
+    }
+
+    [Fact]
+    public void NamingAnImplementation_WrapsOnlyThatOne() {
+        var resolved = Resolve("[Decorator(Implementation = typeof(Loud))]");
+
+        Assert.Equal(["Logged", "Quiet"], resolved.Select(Outer));
+    }
+
+    /// <summary>
+    /// And the one it wrapped is still the one it wrapped — the decorator holds the named
+    /// implementation, not whichever registration happened to be first.
+    /// </summary>
+    [Fact]
+    public void TheWrappedInstance_IsTheNamedImplementation() {
+        var resolved = Resolve("[Decorator(Implementation = typeof(Loud))]");
+
+        var logged = Assert.Single(resolved, greeter => Outer(greeter) == "Logged");
+
+        Assert.Equal("loud", Greet(logged));
+    }
+
+    [Fact]
+    public void TheUnnamedImplementation_IsUntouched() {
+        var resolved = Resolve("[Decorator(Implementation = typeof(Loud))]");
+
+        var quiet = Assert.Single(resolved, greeter => Outer(greeter) == "Quiet");
+
+        Assert.Equal("quiet", Greet(quiet));
+    }
+
+    /// <summary>
+    /// Naming an implementation nothing registers wraps nothing, rather than falling back to
+    /// wrapping everything — the failure mode that would make a typo silently behave like the
+    /// default.
+    /// </summary>
+    [Fact]
+    public void NamingAnImplementationThatIsNotRegistered_WrapsNothing() {
+        var resolved = Resolve("[Decorator(Implementation = typeof(Unregistered))]");
+
+        Assert.Equal(["Loud", "Quiet"], resolved.Select(Outer));
+    }
+
+    /// <summary>
+    /// The same limit interception has, and for the same reason: a factory descriptor cannot say
+    /// what implementation it was built from, so naming one has nothing to match against and the
+    /// decorator wraps everything — the opposite of what it asked for.
+    ///
+    /// An intercepted service escapes this automatically, because the interception is declared on
+    /// the class being registered and the writer emitting that registration can see it. A decorator
+    /// is declared on the decorator, so the registration it targets is written by a pass that never
+    /// learns about it. Reported rather than silently doing the wrong thing.
+    /// </summary>
+    [Fact]
+    public void NamingAnImplementationUnderGenerateFactories_ReportsDM0022() {
+        var result = Generate("[Decorator(Implementation = typeof(Loud))]", generateFactories: true);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0022");
+
+        Assert.Contains("Logged", diagnostic.GetMessage());
+        Assert.Contains("Loud", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void NamingNoImplementationUnderGenerateFactories_IsNotReported() {
+        var result = Generate("[Decorator]", generateFactories: true);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0022");
+    }
+
+    [Fact]
+    public void NamingAnImplementationWithoutGenerateFactories_IsNotReported() {
+        var result = Generate("[Decorator(Implementation = typeof(Loud))]", generateFactories: false);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0022");
+    }
+
+    private static string Outer(object greeter) => greeter.GetType().Name;
+
+    private static string Greet(object greeter) =>
+        (string)greeter.GetType().GetMethod("Greet")!.Invoke(greeter, null)!;
+
+    private static GeneratorResult Generate(string decoratorAttribute, bool generateFactories) =>
+        GeneratorTestHarness.Run(
+            Source(decoratorAttribute),
+            new Dictionary<string, string> {
+                ["DependencyModules_GenerateFactories"] = generateFactories ? "true" : "false"
+            });
+
+    private static object[] Resolve(string decoratorAttribute, bool generateFactories = false) {
+        var generated = GeneratedAssembly.Create(
+            Source(decoratorAttribute),
+            buildProperties: new Dictionary<string, string> {
+                ["DependencyModules_GenerateFactories"] = generateFactories ? "true" : "false"
+            });
+
+        var provider = generated.BuildProvider();
+
+        return ((System.Collections.IEnumerable)provider
+                .GetService(typeof(IEnumerable<>).MakeGenericType(generated.Type("IGreeter")))!)
+            .Cast<object>()
+            .OrderBy(greeter => greeter.GetType().Name, System.StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string Source(string decoratorAttribute) =>
+            $$"""
+              using DependencyModules.Runtime.Attributes;
+
+              namespace TestNamespace;
+
+              public interface IGreeter { string Greet(); }
+
+              [SingletonService]
+              public class Loud : IGreeter { public string Greet() => "loud"; }
+
+              [SingletonService]
+              public class Quiet : IGreeter { public string Greet() => "quiet"; }
+
+              public class Unregistered : IGreeter { public string Greet() => "nowhere"; }
+
+              {{decoratorAttribute}}
+              public class Logged(IGreeter inner) : IGreeter {
+                  public string Greet() => inner.Greet();
+              }
+
+              [DependencyModule]
+              public partial class TestModule;
+              """;
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/DiagnosticSuppressionTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/DiagnosticSuppressionTests.cs
@@ -1,0 +1,284 @@
+using System.Collections.Generic;
+using System.Linq;
+using DependencyModules.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// Whether a DM diagnostic can be silenced where it is written.
+///
+/// Roslyn decides both <c>.editorconfig</c> severity and <c>#pragma warning disable</c> from the
+/// diagnostic's syntax tree. A location built from a file path alone has none — it is an
+/// <see cref="LocationKind.ExternalFile"/> location, and <c>SourceTree</c> is null — so neither
+/// mechanism can reach it and only the compilation-wide <c>NoWarn</c> works.
+///
+/// That is what happened here, and it happened *because* of a fix: 1.1.0 moved ten diagnostics off
+/// the project and onto the declaration they are about, using a location rebuilt from primitives
+/// because a model cannot hold a SyntaxTree without pinning it and defeating the incremental cache.
+/// The same release documented that <c>.editorconfig</c> worked. It worked for exactly the two codes
+/// that had never been moved.
+///
+/// Asserting on the tree rather than on filtered output is deliberate: the tree is the precondition
+/// Roslyn actually keys off, and it is the thing that can regress. Nothing here exercised any
+/// suppression mechanism before this file existed.
+///
+/// Every code that has a location is covered. DM0001 is the only one absent, and it is absent
+/// because a generator that failed has nothing to point at. Adding a code without adding it here
+/// means shipping one more diagnostic nobody can turn off where they wrote it.
+/// </summary>
+public class DiagnosticSuppressionTests {
+
+    [Theory]
+    [MemberData(nameof(Triggers))]
+    public void ADiagnostic_IsReportedAgainstASyntaxTree(string code, string source) {
+        var result = GeneratorTestHarness.Run(source);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == code);
+
+        Assert.True(diagnostic.Location.SourceTree != null,
+            $"{code} was reported at {diagnostic.Location.Kind} with no syntax tree, so neither " +
+            ".editorconfig nor #pragma can silence it. Location: " + diagnostic.Location);
+    }
+
+    [Theory]
+    [MemberData(nameof(Triggers))]
+    public void ADiagnostic_IsReportedInTheFileThatCausedIt(string code, string source) {
+        var result = GeneratorTestHarness.Run(source);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == code);
+
+        Assert.Equal("Test.cs", System.IO.Path.GetFileName(diagnostic.Location.GetLineSpan().Path));
+    }
+
+    /// <summary>
+    /// One trigger per code, kept minimal. DM0001 is deliberately absent: it reports a generator
+    /// that failed, where there is genuinely nothing to point at. DM0016 and DM0019 are absent
+    /// because they are the two that were never moved and already carry a real location — they are
+    /// covered by AssemblyModuleAttributeDiagnosticsTests.
+    /// </summary>
+    public static IEnumerable<object[]> Triggers() {
+        yield return ["DM0002", Module("""
+                                       public interface IThing;
+                                       [SingletonService]
+                                       public abstract class Thing : IThing;
+                                       """)];
+
+        yield return ["DM0003", """
+                                using DependencyModules.Runtime.Attributes;
+                                namespace TestNamespace;
+                                [DependencyModule]
+                                public class NotPartialModule;
+                                """];
+
+        yield return ["DM0012", Module("""
+                                       public interface IThing;
+                                       [SingletonService]
+                                       [IfEnvironment]
+                                       public class Thing : IThing;
+                                       """)];
+
+        yield return ["DM0014", Module("""
+                                       public interface IThing<T>;
+                                       [CrossWireService]
+                                       public class Thing<T> : IThing<T>;
+                                       """)];
+
+        yield return ["DM0017", """
+                                using DependencyModules.Runtime.Attributes;
+                                namespace TestNamespace;
+                                public static class Outer {
+                                    [DependencyModule]
+                                    public partial class NestedModule;
+                                }
+                                """];
+
+        yield return ["DM0004", Convention("""
+                                           public interface IFoo { }
+                                           public class Foo : IFoo { }
+
+                                           [DependencyModule]
+                                           public partial class TestModule : IConventionModule {
+                                               void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                                                   conventions.RegisterAll<IFoo>().AsSingleton();
+                                                   conventions.RegisterAll<IFoo>().AsScoped();
+                                               }
+                                           }
+                                           """)];
+
+        yield return ["DM0005", Convention("""
+                                           [DependencyModule]
+                                           public partial class TestModule : IConventionModule {
+                                               void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                                                   conventions.RegisterAll().WithName("NothingMatchesThis").AsSelf().AsScoped();
+                                               }
+                                           }
+                                           """)];
+
+        yield return ["DM0006", Convention("""
+                                           public interface IFoo { }
+                                           public class Foo : IFoo { private Foo() { } }
+
+                                           [DependencyModule]
+                                           public partial class TestModule : IConventionModule {
+                                               void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                                                   conventions.RegisterAll<IFoo>().AsSingleton();
+                                               }
+                                           }
+                                           """)];
+
+        yield return ["DM0009", Convention("""
+                                           public interface IFoo { }
+                                           public class Foo : IFoo { }
+
+                                           [DependencyModule]
+                                           public partial class TestModule : IConventionModule {
+                                               void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                                                   conventions.RegisterAll<IFoo>().AsSelf().AlsoAsSelf().AsSingleton();
+                                               }
+                                           }
+                                           """)];
+
+        yield return ["DM0010", Convention("""
+                                           public interface IFoo { }
+                                           public class Foo : IFoo { }
+
+                                           [DependencyModule]
+                                           public partial class TestModule : IConventionModule {
+                                               void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                                                   conventions.RegisterAll<IFoo>().AsSingleton();
+                                               }
+                                           }
+                                           """)];
+
+        yield return ["DM0011", Module("""
+                                       public interface IThing;
+                                       [SingletonService]
+                                       [IfEnvironment("Development")]
+                                       public class Thing : IThing;
+                                       """)];
+
+        yield return ["DM0007", """
+                                using DependencyModules.Runtime.Attributes;
+
+                                namespace TestNamespace;
+
+                                public interface IThing { string Read(); }
+
+                                [SingletonService]
+                                public class Thing : IThing {
+                                    public string Read() => "";
+                                }
+
+                                [Decorator(Order = 1)]
+                                public class FirstDecorator(IThing inner) : IThing {
+                                    public string Read() => inner.Read();
+                                }
+
+                                [Decorator(Order = 1)]
+                                public class SecondDecorator(IThing inner) : IThing {
+                                    public string Read() => inner.Read();
+                                }
+
+                                [DependencyModule]
+                                public partial class TestModule;
+                                """];
+
+        yield return ["DM0013", """
+                                using DependencyModules.Runtime.Attributes;
+
+                                namespace TestNamespace;
+
+                                public interface IStore<T> { string Read(T key); }
+
+                                [SingletonService]
+                                public class Store<T> : IStore<T> {
+                                    public string Read(T key) => "";
+                                }
+
+                                [Decorator]
+                                public class LoggingStore<T>(IStore<T> inner) : IStore<T> {
+                                    public string Read(T key) => inner.Read(key);
+                                }
+
+                                [DependencyModule]
+                                public partial class TestModule;
+                                """];
+
+        yield return ["DM0008", Intercepted("""
+                                            public interface IAwkward {
+                                                bool TryGet(string key, out string value);
+                                            }
+
+                                            [SingletonService]
+                                            [Intercept(typeof(SyncOnlyInterceptor))]
+                                            public class Awkward : IAwkward {
+                                                public bool TryGet(string key, out string value) { value = key; return true; }
+                                            }
+                                            """)];
+
+        yield return ["DM0015", Intercepted("""
+                                            public interface IAsyncOnly {
+                                                Task<string> GetAsync(string key);
+                                            }
+
+                                            [SingletonService]
+                                            [Intercept(typeof(SyncOnlyInterceptor))]
+                                            public class AsyncOnly : IAsyncOnly {
+                                                public Task<string> GetAsync(string key) => Task.FromResult(key);
+                                            }
+                                            """)];
+
+        yield return ["DM0018", """
+                                using DependencyModules.Runtime.Attributes;
+                                namespace TestNamespace;
+                                [DependencyModule]
+                                public partial class TestModule {
+                                    public int SizeLimit { get; set; }
+                                }
+                                """];
+    }
+
+    private static string Convention(string body) =>
+        $$"""
+          using System;
+          using DependencyModules.Runtime.Attributes;
+          using DependencyModules.Runtime.Conventions;
+
+          namespace TestNamespace;
+
+          {{body}}
+          """;
+
+    private static string Intercepted(string body) =>
+        $$"""
+          using System.Threading.Tasks;
+          using DependencyModules.Runtime.Attributes;
+          using DependencyModules.Runtime.Interception;
+
+          namespace TestNamespace;
+
+          [SingletonService]
+          public class SyncOnlyInterceptor : IInterceptor {
+              public TResult Intercept<TResult>(InvocationContext<TResult> context) => context.Proceed();
+          }
+
+          {{body}}
+
+          [DependencyModule]
+          public partial class TestModule;
+          """;
+
+    private static string Module(string body) =>
+        $$"""
+          using DependencyModules.Runtime.Attributes;
+
+          namespace TestNamespace;
+
+          [DependencyModule]
+          public partial class TestModule;
+
+          {{body}}
+          """;
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/DiagnosticSuppressionTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/DiagnosticSuppressionTests.cs
@@ -140,6 +140,26 @@ public class DiagnosticSuppressionTests {
                                            }
                                            """)];
 
+        yield return ["DM0020", Convention("""
+                                           using DependencyModules.Runtime.Interception;
+
+                                           public interface IGreeter { string Greet(); }
+
+                                           public sealed class CountingInterceptor : IInterceptor {
+                                               public TResult Intercept<TResult>(InvocationContext<TResult> context) => context.Proceed();
+                                           }
+
+                                           [Intercept(typeof(CountingInterceptor))]
+                                           public sealed class Greeter : IGreeter { public string Greet() => "hi"; }
+
+                                           [DependencyModule(OnlyRealm = true)]
+                                           public partial class ConventionModule : IConventionModule {
+                                               void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                                                   conventions.RegisterAll<IGreeter>().AsSingleton();
+                                               }
+                                           }
+                                           """)];
+
         yield return ["DM0010", Convention("""
                                            public interface IFoo { }
                                            public class Foo : IFoo { }

--- a/tests/DependencyModules.Tests/GeneratorTests/DiagnosticSuppressionTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/DiagnosticSuppressionTests.cs
@@ -140,6 +140,22 @@ public class DiagnosticSuppressionTests {
                                            }
                                            """)];
 
+        yield return ["DM0021", """
+                                using DependencyModules.Runtime.Attributes;
+                                using DependencyModules.Testing.Attributes;
+
+                                namespace TestNamespace;
+
+                                public interface IThing;
+
+                                public class RealThing : IThing;
+
+                                public class Fixture {
+                                    [TestExport(typeof(IThing), Implementation = typeof(RealThing))]
+                                    public void Conflicting([Mock] IThing thing) { }
+                                }
+                                """];
+
         yield return ["DM0020", Convention("""
                                            using DependencyModules.Runtime.Interception;
 

--- a/tests/DependencyModules.Tests/GeneratorTests/DiagnosticSuppressionTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/DiagnosticSuppressionTests.cs
@@ -140,6 +140,25 @@ public class DiagnosticSuppressionTests {
                                            }
                                            """)];
 
+        yield return ["DM0022", """
+                                using DependencyModules.Runtime.Attributes;
+
+                                namespace TestNamespace;
+
+                                public interface IGreeter { string Greet(); }
+
+                                [SingletonService]
+                                public class Loud : IGreeter { public string Greet() => "loud"; }
+
+                                [Decorator(Implementation = typeof(Loud))]
+                                public class Logged(IGreeter inner) : IGreeter {
+                                    public string Greet() => inner.Greet();
+                                }
+
+                                [DependencyModule(GenerateFactories = true)]
+                                public partial class TestModule;
+                                """];
+
         yield return ["DM0021", """
                                 using DependencyModules.Runtime.Attributes;
                                 using DependencyModules.Testing.Attributes;

--- a/tests/DependencyModules.Tests/GeneratorTests/GenerateFactoriesInterceptionTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/GenerateFactoriesInterceptionTests.cs
@@ -1,0 +1,185 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using DependencyModules.Tests.Infrastructure;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// Interception under <c>DependencyModules_GenerateFactories</c>.
+///
+/// The property emits a <c>provider =&gt; new Impl(...)</c> factory in place of
+/// <c>typeof(Impl)</c>, which is what removes the container's reflection and what the AOT guidance
+/// recommends turning on. It also erased the implementation type from the descriptor — and the
+/// per-implementation interception filter works by asking a descriptor what implementation it was
+/// built from. With no answer, the filter never engaged and interception went back to wrapping
+/// every registration of the service type: an unmarked sibling returning inside another class's
+/// wrapper, interceptors running once per registration, and realm isolation gone.
+///
+/// So the property that exists for the published build quietly undid the release's headline fix, in
+/// exactly the configuration hardest to test.
+///
+/// These run each case with the property off and on and require the same answer. That is the
+/// property's whole contract — it is meant to change how a service is constructed, not what is
+/// registered or what wraps it.
+/// </summary>
+public class GenerateFactoriesInterceptionTests {
+
+    private const string Interceptor =
+        """
+        public sealed class CountingInterceptor : IInterceptor {
+            public TResult Intercept<TResult>(InvocationContext<TResult> context) => context.Proceed();
+        }
+        """;
+
+    /// <summary>
+    /// The 1.1.0 fix itself: a sibling implementation carrying no [Intercept] is not wrapped.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnUnmarkedSibling_IsNotWrapped(bool generateFactories) {
+        var resolved = Resolve(
+            """
+            [SingletonService] [Intercept(typeof(CountingInterceptor))]
+            public sealed class Loud : IGreeter { public string Greet() => "loud"; }
+
+            [SingletonService]
+            public sealed class Quiet : IGreeter { public string Greet() => "quiet"; }
+            """,
+            generateFactories);
+
+        Assert.Equal(["Loud_Intercepted", "Quiet"], resolved);
+    }
+
+    /// <summary>
+    /// And the same registration is not wrapped twice. Two marked implementations each get their
+    /// own wrapper rather than both getting both.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void TwoMarkedImplementations_EachGetTheirOwnWrapper(bool generateFactories) {
+        var resolved = Resolve(
+            """
+            [SingletonService] [Intercept(typeof(CountingInterceptor))]
+            public sealed class Loud : IGreeter { public string Greet() => "loud"; }
+
+            [SingletonService] [Intercept(typeof(CountingInterceptor))]
+            public sealed class Quiet : IGreeter { public string Greet() => "quiet"; }
+            """,
+            generateFactories);
+
+        Assert.Equal(["Loud_Intercepted", "Quiet_Intercepted"], resolved);
+    }
+
+    /// <summary>
+    /// A keyed registration is still one registration. Agent 08 measured a keyed service coming back
+    /// as another implementation's wrapper.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AKeyedSibling_IsNotWrapped(bool generateFactories) {
+        var generated = Build(
+            """
+            [SingletonService(Key = "loud")] [Intercept(typeof(CountingInterceptor))]
+            public sealed class Loud : IGreeter { public string Greet() => "loud"; }
+
+            [SingletonService(Key = "quiet")]
+            public sealed class Quiet : IGreeter { public string Greet() => "quiet"; }
+            """,
+            generateFactories);
+
+        var provider = generated.BuildProvider();
+        var serviceType = generated.Type("IGreeter");
+
+        var loud = ((IKeyedServiceProvider)provider).GetRequiredKeyedService(serviceType, "loud");
+        var quiet = ((IKeyedServiceProvider)provider).GetRequiredKeyedService(serviceType, "quiet");
+
+        Assert.Equal("Loud_Intercepted", loud.GetType().Name);
+        Assert.Equal("Quiet", quiet.GetType().Name);
+    }
+
+    /// <summary>
+    /// The convention route to the same registrations. Convention-produced models are built by a
+    /// different path from attribute-produced ones, so the exemption has to reach both.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AConventionRegisteredSibling_IsNotWrapped(bool generateFactories) {
+        var generated = GeneratedAssembly.Create(
+            $$"""
+              using DependencyModules.Runtime.Attributes;
+              using DependencyModules.Runtime.Conventions;
+              using DependencyModules.Runtime.Interception;
+
+              namespace TestNamespace;
+
+              public interface IGreeter { string Greet(); }
+
+              {{Interceptor}}
+
+              [Intercept(typeof(CountingInterceptor))]
+              public sealed class Loud : IGreeter { public string Greet() => "loud"; }
+
+              public sealed class Quiet : IGreeter { public string Greet() => "quiet"; }
+
+              [DependencyModule]
+              public partial class TestModule : IConventionModule {
+                  void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                      conventions.RegisterAll<IGreeter>().AsSingleton();
+                  }
+              }
+              """,
+            buildProperties: new Dictionary<string, string> {
+                ["DependencyModules_GenerateFactories"] = generateFactories ? "true" : "false"
+            });
+
+        var provider = generated.BuildProvider();
+
+        var resolved = ((System.Collections.IEnumerable)provider
+                .GetService(typeof(IEnumerable<>).MakeGenericType(generated.Type("IGreeter")))!)
+            .Cast<object>()
+            .Select(greeter => greeter.GetType().Name)
+            .OrderBy(name => name, System.StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(["Loud_Intercepted", "Quiet"], resolved);
+    }
+
+    private static string[] Resolve(string body, bool generateFactories) {
+        var generated = Build(body, generateFactories);
+        var provider = generated.BuildProvider();
+
+        return ((System.Collections.IEnumerable)provider
+                .GetService(typeof(IEnumerable<>).MakeGenericType(generated.Type("IGreeter")))!)
+            .Cast<object>()
+            .Select(greeter => greeter.GetType().Name)
+            .OrderBy(name => name, System.StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static GeneratedAssembly Build(string body, bool generateFactories) =>
+        GeneratedAssembly.Create(
+            $$"""
+              using DependencyModules.Runtime.Attributes;
+              using DependencyModules.Runtime.Interception;
+
+              namespace TestNamespace;
+
+              public interface IGreeter { string Greet(); }
+
+              {{Interceptor}}
+
+              {{body}}
+
+              [DependencyModule]
+              public partial class TestModule;
+              """,
+            buildProperties: new Dictionary<string, string> {
+                ["DependencyModules_GenerateFactories"] = generateFactories ? "true" : "false"
+            });
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/InterceptAttributeSpellingTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/InterceptAttributeSpellingTests.cs
@@ -1,0 +1,74 @@
+using DependencyModules.Tests.Infrastructure;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// Every legal way of writing <c>[Intercept]</c> has to mean <c>[Intercept]</c>.
+///
+/// 1.1.0 fixed this for the service attributes: the usage is resolved through the semantic model
+/// rather than compared as written, so a qualified name, a <c>global::</c> prefix and a using alias
+/// all land on the same attribute. Before that they were discovered but read back wrong, and the
+/// registration was silently the wrong lifetime.
+///
+/// <c>[Intercept]</c> never got the same treatment. It was matched against the literal text
+/// "Intercept" or "InterceptAttribute", so any other spelling produced no interception at all — no
+/// wrapper, no diagnostic, a green build, and a cross-cutting concern that simply stopped running.
+/// Interceptors are audit, authorisation, retry and metrics, which is the worst set of things to
+/// silently not run.
+/// </summary>
+public class InterceptAttributeSpellingTests {
+
+    [Theory]
+    [InlineData("[Intercept(typeof(LoggingInterceptor))]")]
+    [InlineData("[InterceptAttribute(typeof(LoggingInterceptor))]")]
+    [InlineData("[DependencyModules.Runtime.Attributes.Intercept(typeof(LoggingInterceptor))]")]
+    [InlineData("[DependencyModules.Runtime.Attributes.InterceptAttribute(typeof(LoggingInterceptor))]")]
+    [InlineData("[global::DependencyModules.Runtime.Attributes.Intercept(typeof(LoggingInterceptor))]")]
+    [InlineData("[global::DependencyModules.Runtime.Attributes.InterceptAttribute(typeof(LoggingInterceptor))]")]
+    [InlineData("[Wrap(typeof(LoggingInterceptor))]")]
+    public void EverySpelling_GeneratesTheWrapper(string attribute) {
+        var result = Run(attribute).AssertNoErrors();
+
+        Assert.Contains("Thing_Intercepted", string.Join(", ", result.GeneratedSources.Keys));
+    }
+
+    [Theory]
+    [InlineData("[Intercept(typeof(LoggingInterceptor))]")]
+    [InlineData("[DependencyModules.Runtime.Attributes.Intercept(typeof(LoggingInterceptor))]")]
+    [InlineData("[global::DependencyModules.Runtime.Attributes.InterceptAttribute(typeof(LoggingInterceptor))]")]
+    [InlineData("[Wrap(typeof(LoggingInterceptor))]")]
+    public void EverySpelling_AppliesTheInterception(string attribute) {
+        var interceptors = Run(attribute).SourceContaining("Interceptors");
+
+        Assert.Contains("Thing_Intercepted", interceptors);
+    }
+
+    private static GeneratorResult Run(string attribute) =>
+        GeneratorTestHarness.Run(
+            $$"""
+              using DependencyModules.Runtime.Attributes;
+              using DependencyModules.Runtime.Interception;
+              using Wrap = DependencyModules.Runtime.Attributes.InterceptAttribute;
+
+              namespace TestNamespace;
+
+              public interface IThing {
+                  string Read(string key);
+              }
+
+              [SingletonService]
+              public class LoggingInterceptor : IInterceptor {
+                  public TResult Intercept<TResult>(InvocationContext<TResult> context) => context.Proceed();
+              }
+
+              [SingletonService]
+              {{attribute}}
+              public class Thing : IThing {
+                  public string Read(string key) => key;
+              }
+
+              [DependencyModule]
+              public partial class TestModule;
+              """);
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/InterceptedMembersTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/InterceptedMembersTests.cs
@@ -1,0 +1,144 @@
+using System.Linq;
+using DependencyModules.Tests.Infrastructure;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// <c>[Intercept].Members</c> — which kinds of member the interceptors are placed around.
+///
+/// Covering the whole interface is the right default: an interceptor written for auditing or retry
+/// has no way to know which members matter, and leaving one out silently is the failure this library
+/// works hardest to avoid. It is the wrong default for an interface carrying properties, where a
+/// timing or logging interceptor records a call per read. The report's agent kept metrics readable
+/// by keying them on member name and filtering afterwards, which is the workaround this removes.
+///
+/// A member left out is still forwarded — the wrapper implements the whole interface either way. It
+/// just does not run through the chain, which is the same path a member no interceptor can serve
+/// already took.
+/// </summary>
+public class InterceptedMembersTests {
+
+    [Fact]
+    public void WithNoKindsNamed_EveryMemberIsIntercepted() {
+        var calls = Run("[Intercept(typeof(CountingInterceptor))]");
+
+        Assert.Equal(["Handle", "get_Name"], calls);
+    }
+
+    [Fact]
+    public void NamingMethods_LeavesPropertiesAlone() {
+        var calls = Run(
+            "[Intercept(typeof(CountingInterceptor), Members = InterceptedMembers.Methods)]");
+
+        Assert.Equal(["Handle"], calls);
+    }
+
+    [Fact]
+    public void NamingProperties_LeavesMethodsAlone() {
+        var calls = Run(
+            "[Intercept(typeof(CountingInterceptor), Members = InterceptedMembers.Properties)]");
+
+        Assert.Equal(["get_Name"], calls);
+    }
+
+    [Fact]
+    public void KindsCombine() {
+        var calls = Run(
+            "[Intercept(typeof(CountingInterceptor), " +
+            "Members = InterceptedMembers.Methods | InterceptedMembers.Properties)]");
+
+        Assert.Equal(["Handle", "get_Name"], calls);
+    }
+
+    /// <summary>
+    /// The excluded member still works — it is forwarded rather than dropped, and the wrapper still
+    /// implements the interface.
+    /// </summary>
+    [Fact]
+    public void AnExcludedMember_IsStillForwarded() {
+        var generated = Build(
+            "[Intercept(typeof(CountingInterceptor), Members = InterceptedMembers.Methods)]");
+
+        var service = generated.BuildProvider().GetService(generated.Type("IHandler"))!;
+
+        Assert.Equal("Handler_Intercepted", service.GetType().Name);
+        Assert.Equal("named", service.GetType().GetProperty("Name")!.GetValue(service));
+    }
+
+    /// <summary>
+    /// An interceptor that cannot serve a member's shape is DM0015. An interceptor that was never
+    /// asked to cover it is not — reporting that would report the feature.
+    /// </summary>
+    [Fact]
+    public void AnExcludedMember_IsNotReportedAsUnserved() {
+        var result = GeneratorTestHarness.Run(
+            Source("[Intercept(typeof(SyncOnlyInterceptor), Members = InterceptedMembers.Methods)]",
+                interceptor: SyncOnly));
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0015");
+    }
+
+    private static string[] Run(string attribute) {
+        var generated = Build(attribute);
+        var provider = generated.BuildProvider();
+        var service = provider.GetService(generated.Type("IHandler"))!;
+
+        service.GetType().GetMethod("Handle")!.Invoke(service, ["x"]);
+        _ = service.GetType().GetProperty("Name")!.GetValue(service);
+
+        var interceptor = generated.Type("CountingInterceptor");
+
+        return ((System.Collections.IEnumerable)interceptor.GetField("Calls")!.GetValue(null)!)
+            .Cast<string>()
+            .OrderBy(name => name, System.StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static GeneratedAssembly Build(string attribute) =>
+        GeneratedAssembly.Create(Source(attribute));
+
+    private const string Counting =
+        """
+        public sealed class CountingInterceptor : IInterceptor {
+            public static readonly System.Collections.Generic.List<string> Calls = new();
+
+            public TResult Intercept<TResult>(InvocationContext<TResult> context) {
+                Calls.Add(context.Caller.MemberName);
+                return context.Proceed();
+            }
+        }
+        """;
+
+    private const string SyncOnly =
+        """
+        public sealed class SyncOnlyInterceptor : IInterceptor {
+            public TResult Intercept<TResult>(InvocationContext<TResult> context) => context.Proceed();
+        }
+        """;
+
+    private static string Source(string attribute, string interceptor = Counting) =>
+        $$"""
+          using DependencyModules.Runtime.Attributes;
+          using DependencyModules.Runtime.Interception;
+
+          namespace TestNamespace;
+
+          public interface IHandler {
+              string Name { get; }
+              string Handle(string input);
+          }
+
+          {{interceptor}}
+
+          [SingletonService]
+          {{attribute}}
+          public class Handler : IHandler {
+              public string Name => "named";
+              public string Handle(string input) => input;
+          }
+
+          [DependencyModule]
+          public partial class TestModule;
+          """;
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/InterceptionRealmTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/InterceptionRealmTests.cs
@@ -1,0 +1,251 @@
+using DependencyModules.Tests.Infrastructure;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// Where an interception's applicator is emitted, when realms are in play.
+///
+/// Three filters decide placement — one for registrations, one for decorations, one for
+/// interceptions — and all three read the same rule: named a realm, it belongs to that module;
+/// named none, it belongs to every module that is not <c>OnlyRealm</c>. They agree whenever the
+/// registration and the interception are scoped the same way, and they diverge when the
+/// registration names a realm and the interception does not: the registration lands only in the
+/// named module, the applicator lands everywhere except it, and the interception is dead in every
+/// container that could exist. Nothing was reported, because each half was individually correct.
+///
+/// The field report filed this twice without noticing it was once. Agent 05 reached it deliberately
+/// with a realm-scoped service; agent 08 reached it by accident through a convention, because
+/// convention registrations are always stamped with their declaring module's realm.
+/// </summary>
+public class InterceptionRealmTests {
+
+    private const string Preamble =
+        """
+        using DependencyModules.Runtime.Attributes;
+        using DependencyModules.Runtime.Conventions;
+        using DependencyModules.Runtime.Interception;
+
+        namespace TestNamespace;
+
+        public interface IGreeter { string Greet(); }
+
+        public sealed class CountingInterceptor : IInterceptor {
+            public TResult Intercept<TResult>(InvocationContext<TResult> context) => context.Proceed();
+        }
+
+        """;
+
+    /// <summary>
+    /// The service names a realm; the interception does not. The applicator has to follow the
+    /// registration, because a per-implementation interception is about that one registration.
+    /// </summary>
+    [Fact]
+    public void ARealmScopedService_WithAnUnrealmedInterception_IsInterceptedInThatRealm() {
+        var result = Run(
+            """
+            [DependencyModule(OnlyRealm = true)]
+            public partial class RealmModule;
+
+            [SingletonService(Realm = typeof(RealmModule))]
+            [Intercept(typeof(CountingInterceptor))]
+            public sealed class Greeter : IGreeter { public string Greet() => "hi"; }
+
+            [DependencyModule]
+            public partial class TestModule;
+            """).AssertNoErrors();
+
+        Assert.Contains("Greeter_Intercepted", result.SourceContaining("RealmModule.Interceptors"));
+    }
+
+    /// <summary>
+    /// And nowhere else. A module that does not register the implementation has nothing to apply the
+    /// wrapper to, so an applicator there is dead weight at best.
+    /// </summary>
+    [Fact]
+    public void ARealmScopedService_IsNotInterceptedOutsideItsRealm() {
+        var result = Run(
+            """
+            [DependencyModule(OnlyRealm = true)]
+            public partial class RealmModule;
+
+            [SingletonService(Realm = typeof(RealmModule))]
+            [Intercept(typeof(CountingInterceptor))]
+            public sealed class Greeter : IGreeter { public string Greet() => "hi"; }
+
+            [DependencyModule]
+            public partial class TestModule;
+            """).AssertNoErrors();
+
+        Assert.DoesNotContain("Greeter_Intercepted", result.SourceContaining("TestModule.Interceptors"));
+    }
+
+    /// <summary>
+    /// An explicit <c>[Intercept(Realm = ...)]</c> still wins outright. It is the escape hatch the
+    /// changelog documents, and following the registration must not take it away.
+    /// </summary>
+    [Fact]
+    public void AnExplicitInterceptRealm_StillDecides() {
+        var result = Run(
+            """
+            [DependencyModule(OnlyRealm = true)]
+            public partial class RealmModule;
+
+            [SingletonService]
+            [Intercept(typeof(CountingInterceptor), Realm = typeof(RealmModule))]
+            public sealed class Greeter : IGreeter { public string Greet() => "hi"; }
+
+            [DependencyModule]
+            public partial class TestModule;
+            """).AssertNoErrors();
+
+        Assert.Contains("Greeter_Intercepted", result.SourceContaining("RealmModule.Interceptors"));
+        Assert.DoesNotContain("Greeter_Intercepted", result.SourceContaining("TestModule.Interceptors"));
+    }
+
+    /// <summary>
+    /// The ordinary case, unchanged: nothing names a realm, so the interception belongs to every
+    /// module that is not realm-only.
+    /// </summary>
+    [Fact]
+    public void AnUnrealmedService_WithAnUnrealmedInterception_IsInterceptedNormally() {
+        var result = Run(
+            """
+            [SingletonService]
+            [Intercept(typeof(CountingInterceptor))]
+            public sealed class Greeter : IGreeter { public string Greet() => "hi"; }
+
+            [DependencyModule]
+            public partial class TestModule;
+            """).AssertNoErrors();
+
+        Assert.Contains("Greeter_Intercepted", result.SourceContaining("TestModule.Interceptors"));
+    }
+
+    /// <summary>
+    /// The convention route into the same divergence, and the half that has no fix at this layer.
+    ///
+    /// A convention registration is stamped with its declaring module's realm at match time -
+    /// deliberately, so an OnlyRealm module does not drop its own convention registrations - which
+    /// is long after the interception model was built and in a different generator. So the
+    /// interception cannot inherit that realm the way it now inherits a service attribute's. Left
+    /// alone it was silent; it is now DM0020, which says the interceptors never run and names the
+    /// property that fixes it.
+    ///
+    /// Widening the placement rule instead was the alternative and is worse: an OnlyRealm module
+    /// would receive applicators for interceptions on classes it does not register, and each
+    /// applicator registers its interceptor - which is exactly the leak 1.1.0 closed, where an
+    /// interceptor needing a dependency the isolated container lacks threw while building the
+    /// provider.
+    /// </summary>
+    [Fact]
+    public void AConventionRegisteredClass_InAnOnlyRealmModule_ReportsDM0020() {
+        var result = Run(
+            """
+            [Intercept(typeof(CountingInterceptor))]
+            public sealed class Greeter : IGreeter { public string Greet() => "hi"; }
+
+            [DependencyModule(OnlyRealm = true)]
+            public partial class ConventionModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IGreeter>().AsSingleton();
+                }
+            }
+            """);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0020");
+
+        Assert.Contains("Greeter", diagnostic.GetMessage());
+        Assert.Contains("Realm", diagnostic.GetMessage());
+    }
+
+    /// <summary>
+    /// An interception a module does apply is not reported. The diagnostic is about a wrapper that
+    /// can never run, not about every realm arrangement that looks unusual.
+    /// </summary>
+    [Fact]
+    public void AnInterceptionSomeModuleApplies_IsNotReported() {
+        var result = Run(
+            """
+            [SingletonService]
+            [Intercept(typeof(CountingInterceptor))]
+            public sealed class Greeter : IGreeter { public string Greet() => "hi"; }
+
+            [DependencyModule]
+            public partial class TestModule;
+            """);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0020");
+    }
+
+    /// <summary>
+    /// Nor is the realm-scoped case that now works: the interception follows the registration, so a
+    /// module applies it and there is nothing to report.
+    /// </summary>
+    [Fact]
+    public void ARealmScopedServiceFollowingItsRegistration_IsNotReported() {
+        var result = Run(
+            """
+            [DependencyModule(OnlyRealm = true)]
+            public partial class RealmModule;
+
+            [SingletonService(Realm = typeof(RealmModule))]
+            [Intercept(typeof(CountingInterceptor))]
+            public sealed class Greeter : IGreeter { public string Greet() => "hi"; }
+
+            [DependencyModule]
+            public partial class TestModule;
+            """);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0020");
+    }
+
+    /// <summary>
+    /// The shape that happened to work, kept as a control: one convention module, not realm-only,
+    /// so the unrealmed interception landed on it by luck rather than by rule.
+    /// </summary>
+    [Fact]
+    public void AConventionRegisteredClass_InAPlainModule_IsStillIntercepted() {
+        var result = Run(
+            """
+            [Intercept(typeof(CountingInterceptor))]
+            public sealed class Greeter : IGreeter { public string Greet() => "hi"; }
+
+            [DependencyModule]
+            public partial class ConventionModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IGreeter>().AsSingleton();
+                }
+            }
+            """).AssertNoErrors();
+
+        Assert.Contains("Greeter_Intercepted", result.SourceContaining("ConventionModule.Interceptors"));
+    }
+
+    /// <summary>
+    /// A convention registering the class as itself rather than as its interface. Recorded because
+    /// it is a separate reason interception can go missing from a convention-registered class, and
+    /// telling the two apart matters: this one is about which service type was registered, not
+    /// about which module the applicator landed on.
+    /// </summary>
+    [Fact]
+    public void AConventionRegisteringAsSelf_StillInterceptsTheInterface() {
+        var result = Run(
+            """
+            [Intercept(typeof(CountingInterceptor))]
+            public sealed class Greeter : IGreeter { public string Greet() => "hi"; }
+
+            [DependencyModule]
+            public partial class ConventionModule : IConventionModule {
+                void IConventionModule.Conventions(IConventionDefinitions conventions) {
+                    conventions.RegisterAll<IGreeter>().AsSelf().AsSingleton();
+                }
+            }
+            """).AssertNoErrors();
+
+        Assert.Contains("Greeter_Intercepted", result.SourceContaining("ConventionModule.Interceptors"));
+    }
+
+    private static GeneratorResult Run(string body) =>
+        GeneratorTestHarness.Run(Preamble + body);
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/InterceptorLifetimeTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/InterceptorLifetimeTests.cs
@@ -1,0 +1,93 @@
+using DependencyModules.Tests.Infrastructure;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// The lifetime an interceptor is registered with.
+///
+/// It was always <c>TryAddSingleton</c>, and that is the only place an interceptor type is
+/// registered — so an interceptor taking a scoped dependency became a captive dependency, held for
+/// the life of the container by a singleton that should not have outlived the scope. Silent unless
+/// <c>ValidateScopes</c> is on, and <c>GenerateFactories</c> switches that off for the whole
+/// project.
+///
+/// The escape hatch was to put a service attribute on the interceptor so the <c>TryAdd</c> found a
+/// registration already there and yielded — which works, because services are applied before
+/// decorators, but only somebody reading the generated code would ever find it. Naming the lifetime
+/// where the interception is declared says it out loud.
+/// </summary>
+public class InterceptorLifetimeTests {
+
+    [Fact]
+    public void WithNoLifetimeNamed_TheInterceptorIsASingleton() {
+        var interceptors = Run("[Intercept(typeof(CountingInterceptor))]");
+
+        Assert.Contains("TryAddSingleton", interceptors);
+    }
+
+    [Theory]
+    [InlineData("Scoped", "TryAddScoped")]
+    [InlineData("Transient", "TryAddTransient")]
+    [InlineData("Singleton", "TryAddSingleton")]
+    public void ANamedLifetime_IsTheOneRegistered(string lifetime, string expected) {
+        var interceptors = Run(
+            $"[Intercept(typeof(CountingInterceptor), Lifetime = ServiceLifetime.{lifetime})]");
+
+        Assert.Contains(expected, interceptors);
+    }
+
+    /// <summary>
+    /// A scoped interceptor must not also be registered as a singleton. The point is to choose,
+    /// not to add a second registration the container resolves ahead of the first.
+    /// </summary>
+    [Fact]
+    public void AScopedInterceptor_IsNotAlsoRegisteredAsASingleton() {
+        var interceptors = Run(
+            "[Intercept(typeof(CountingInterceptor), Lifetime = ServiceLifetime.Scoped)]");
+
+        Assert.DoesNotContain("TryAddSingleton", interceptors);
+    }
+
+    /// <summary>
+    /// The registration still has to work end to end, not merely be emitted with the right name.
+    /// </summary>
+    [Fact]
+    public void AScopedInterceptor_Runs() {
+        var generated = GeneratedAssembly.Create(
+            Source("[Intercept(typeof(CountingInterceptor), Lifetime = ServiceLifetime.Scoped)]"));
+
+        var provider = generated.BuildProvider();
+        var greeter = provider.GetService(generated.Type("IGreeter"))!;
+
+        Assert.Equal("Greeter_Intercepted", greeter.GetType().Name);
+        Assert.Equal("hi", greeter.GetType().GetMethod("Greet")!.Invoke(greeter, null));
+    }
+
+    private static string Run(string attribute) =>
+        GeneratorTestHarness.Run(Source(attribute))
+            .AssertNoErrors()
+            .SourceContaining("Interceptors");
+
+    private static string Source(string attribute) =>
+        $$"""
+          using DependencyModules.Runtime.Attributes;
+          using DependencyModules.Runtime.Interception;
+          using Microsoft.Extensions.DependencyInjection;
+
+          namespace TestNamespace;
+
+          public interface IGreeter { string Greet(); }
+
+          public sealed class CountingInterceptor : IInterceptor {
+              public TResult Intercept<TResult>(InvocationContext<TResult> context) => context.Proceed();
+          }
+
+          [SingletonService]
+          {{attribute}}
+          public sealed class Greeter : IGreeter { public string Greet() => "hi"; }
+
+          [DependencyModule]
+          public partial class TestModule;
+          """;
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/MockTestExportDiagnosticTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/MockTestExportDiagnosticTests.cs
@@ -1,0 +1,158 @@
+using DependencyModules.Tests.Infrastructure;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// DM0021: a <c>[Mock]</c> parameter and a <c>[TestExport]</c> on the same method, both naming one
+/// service.
+///
+/// A parameter attribute is the narrowest thing a test can say, so <c>[Mock]</c> wins and the
+/// <c>[TestExport]</c> beside it does nothing. Written on the same method the two say opposite
+/// things about one service in the same breath, and only one of them can have been meant — so it is
+/// reported rather than resolved quietly, which is how the field report met it.
+///
+/// The scope is the whole point. A <c>[TestExport]</c> on the class or the assembly is a default for
+/// everything under it, and one test overriding it for one argument is exactly what having both
+/// scopes is for. Reporting that would be reporting the feature.
+/// </summary>
+public class MockTestExportDiagnosticTests {
+
+    [Fact]
+    public void BothOnOneMethod_ReportsDM0021() {
+        var result = Run(
+            """
+            [TestExport(typeof(IThing), Implementation = typeof(RealThing))]
+            public void Conflicting([Mock] IThing thing) { }
+            """);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0021");
+
+        Assert.Contains("Conflicting", diagnostic.GetMessage());
+        Assert.Contains("IThing", diagnostic.GetMessage());
+    }
+
+    /// <summary>
+    /// Reported at the parameter, which is the half that wins and the half a reader has to look at
+    /// to see what actually happens.
+    /// </summary>
+    [Fact]
+    public void ItIsReportedAtTheParameter() {
+        var result = Run(
+            """
+            [TestExport(typeof(IThing), Implementation = typeof(RealThing))]
+            public void Conflicting([Mock] IThing thing) { }
+            """);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0021");
+
+        Assert.NotNull(diagnostic.Location.SourceTree);
+        Assert.Equal("Test.cs", System.IO.Path.GetFileName(diagnostic.Location.GetLineSpan().Path));
+    }
+
+    /// <summary>
+    /// The class-level default a test opts out of. This is the shape the override exists for.
+    /// </summary>
+    [Fact]
+    public void TestExportOnTheClass_IsNotReported() {
+        var result = GeneratorTestHarness.Run(
+            $$"""
+              {{Preamble}}
+
+              [TestExport(typeof(IThing), Implementation = typeof(RealThing))]
+              public class Fixture {
+                  public void Overriding([Mock] IThing thing) { }
+              }
+              """);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0021");
+    }
+
+    [Fact]
+    public void TestExportOnTheAssembly_IsNotReported() {
+        var result = GeneratorTestHarness.Run(
+            $$"""
+              {{Preamble}}
+
+              [assembly: TestExport(typeof(IThing), Implementation = typeof(RealThing))]
+
+              public class Fixture {
+                  public void Overriding([Mock] IThing thing) { }
+              }
+              """);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0021");
+    }
+
+    /// <summary>
+    /// Naming different services is two unrelated declarations, not a disagreement.
+    /// </summary>
+    [Fact]
+    public void BothOnOneMethodNamingDifferentServices_IsNotReported() {
+        var result = Run(
+            """
+            [TestExport(typeof(IOther), Implementation = typeof(RealOther))]
+            public void Unrelated([Mock] IThing thing) { }
+            """);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0021");
+    }
+
+    [Fact]
+    public void AMockWithNoTestExport_IsNotReported() {
+        var result = Run("public void JustAMock([Mock] IThing thing) { }");
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0021");
+    }
+
+    [Fact]
+    public void ATestExportWithNoMock_IsNotReported() {
+        var result = Run(
+            """
+            [TestExport(typeof(IThing), Implementation = typeof(RealThing))]
+            public void JustAnExport(IThing thing) { }
+            """);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0021");
+    }
+
+    /// <summary>
+    /// Resolved rather than string-matched, the way every other attribute this generator reads is.
+    /// </summary>
+    [Fact]
+    public void QualifiedSpellings_AreStillReported() {
+        var result = Run(
+            """
+            [DependencyModules.Testing.Attributes.TestExport(typeof(IThing), Implementation = typeof(RealThing))]
+            public void Conflicting([global::DependencyModules.Testing.Attributes.Mock] IThing thing) { }
+            """);
+
+        Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0021");
+    }
+
+    private const string Preamble =
+        """
+        using DependencyModules.Runtime.Attributes;
+        using DependencyModules.Testing.Attributes;
+
+        namespace TestNamespace;
+
+        public interface IThing;
+
+        public interface IOther;
+
+        public class RealThing : IThing;
+
+        public class RealOther : IOther;
+        """;
+
+    private static GeneratorResult Run(string body) =>
+        GeneratorTestHarness.Run(
+            $$"""
+              {{Preamble}}
+
+              public class Fixture {
+                  {{body}}
+              }
+              """);
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/ModelComparerTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ModelComparerTests.cs
@@ -191,6 +191,61 @@ public class ModelComparerTests {
             { nameof(DependencyModuleConfigurationModel.ExcludeGeneratedCodeFromCoverage), ModelFactory.Configuration(excludeGeneratedCodeFromCoverage: false) }
         };
 
+    private readonly InterceptorModelComparer _interceptorComparer = new();
+
+    /// <summary>
+    /// Realm decides which module emits an interception's applicator, and it was the one field this
+    /// comparer left out — so changing only `Realm = typeof(X)` served the previous run's output and
+    /// the interception stayed on whichever module had it before. Both sibling comparers already
+    /// compared theirs.
+    /// </summary>
+    [Fact]
+    public void Interceptors_DifferingByRealm_AreNotEqual() {
+        Assert.False(_interceptorComparer.Equals(
+            Interceptor(realm: TypeDefinition.Get("Ns", "OneRealm")),
+            Interceptor(realm: TypeDefinition.Get("Ns", "OtherRealm"))));
+    }
+
+    [Fact]
+    public void Interceptors_GainingARealm_AreNotEqual() {
+        Assert.False(_interceptorComparer.Equals(
+            Interceptor(),
+            Interceptor(realm: TypeDefinition.Get("Ns", "OneRealm"))));
+    }
+
+    [Fact]
+    public void Interceptors_BuiltFromTheSameValues_AreEqual() {
+        Assert.True(_interceptorComparer.Equals(Interceptor(), Interceptor()));
+    }
+
+    [Fact]
+    public void EqualInterceptors_ShareAHashCode() {
+        Assert.Equal(
+            _interceptorComparer.GetHashCode(Interceptor()),
+            _interceptorComparer.GetHashCode(Interceptor()));
+    }
+
+    [Fact]
+    public void Interceptors_DifferingByRealm_DoNotShareAHashCode() {
+        Assert.NotEqual(
+            _interceptorComparer.GetHashCode(Interceptor()),
+            _interceptorComparer.GetHashCode(Interceptor(realm: TypeDefinition.Get("Ns", "OneRealm"))));
+    }
+
+    [Fact]
+    public void Interceptors_DifferingByOrder_AreNotEqual() {
+        Assert.False(_interceptorComparer.Equals(Interceptor(order: 1), Interceptor(order: 2)));
+    }
+
+    private static InterceptorModel Interceptor(ITypeDefinition? realm = null, int order = 0) =>
+        new(TypeDefinition.Get("Ns", "IService"),
+            TypeDefinition.Get("Ns", "Service"),
+            [],
+            [],
+            [],
+            order,
+            Realm: realm);
+
     private static ParameterInfoModel Parameter(string name) =>
         new(name, TypeDefinition.Get("Ns", "SomeType"), null, []);
 

--- a/tests/DependencyModules.Tests/GeneratorTests/ModelComparerTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ModelComparerTests.cs
@@ -195,7 +195,7 @@ public class ModelComparerTests {
         new(name, TypeDefinition.Get("Ns", "SomeType"), null, []);
 
     private static PropertyInfoModel Property(string name) =>
-        new(TypeDefinition.Get("Ns", "SomeType"), name, false, false);
+        new(TypeDefinition.Get("Ns", "SomeType"), name, false, false, true);
 
     private static AttributeModel Attribute(string name) =>
         new(TypeDefinition.Get("Ns", name), [], [], []);

--- a/tests/DependencyModules.Tests/GeneratorTests/ModuleParameterAccessibilityTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ModuleParameterAccessibilityTests.cs
@@ -1,0 +1,84 @@
+using System.Linq;
+using DependencyModules.Tests.Infrastructure;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// Which of a module's properties become parameters on its generated attribute.
+///
+/// The rule was "settable and not static", read off the syntax without ever looking at
+/// accessibility. The generated attribute is a separate <c>public partial class</c>, so a private
+/// property copied onto it produced <c>CS0122: … is inaccessible due to its protection level</c> in
+/// generated code, twice — once on the attribute's own property and once on the assignment back in
+/// <c>GetModule()</c> — with no DM diagnostic saying why. A private member's name leaking onto a
+/// public attribute is wrong on its own, before the compile error.
+///
+/// Accessibility is judged from where the generated attribute sits: same assembly, different type.
+/// So internal reaches it and private does not, and an unmodified property is private by default.
+/// </summary>
+public class ModuleParameterAccessibilityTests {
+
+    [Theory]
+    [InlineData("private int SizeLimit { get; set; }")]
+    [InlineData("protected int SizeLimit { get; set; }")]
+    [InlineData("private protected int SizeLimit { get; set; }")]
+    [InlineData("int SizeLimit { get; set; }")]
+    public void APropertyTheAttributeCannotReach_CompilesCleanly(string property) {
+        Run(property).AssertNoErrors();
+    }
+
+    [Theory]
+    [InlineData("private int SizeLimit { get; set; }")]
+    [InlineData("protected int SizeLimit { get; set; }")]
+    [InlineData("private protected int SizeLimit { get; set; }")]
+    [InlineData("int SizeLimit { get; set; }")]
+    public void APropertyTheAttributeCannotReach_IsNotCopiedOntoIt(string property) {
+        var attribute = Run(property).SourceContaining("TestModule.Module");
+
+        Assert.DoesNotContain("SizeLimit", attribute);
+    }
+
+    /// <summary>
+    /// It is not a parameter, so there is no identity question and DM0018 has nothing to report.
+    /// Reporting it would have sent the reader to a page describing a property they cannot set.
+    /// </summary>
+    [Theory]
+    [InlineData("private int SizeLimit { get; set; }")]
+    [InlineData("protected int SizeLimit { get; set; }")]
+    [InlineData("private protected int SizeLimit { get; set; }")]
+    [InlineData("int SizeLimit { get; set; }")]
+    public void APropertyTheAttributeCannotReach_IsNotReportedAsDM0018(string property) {
+        var result = Run(property);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0018");
+    }
+
+    /// <summary>
+    /// The controls. internal and protected internal are both reachable from a type in the same
+    /// assembly, which is what the generated attribute is, so they stay parameters.
+    /// </summary>
+    [Theory]
+    [InlineData("public int SizeLimit { get; set; }")]
+    [InlineData("internal int SizeLimit { get; set; }")]
+    [InlineData("protected internal int SizeLimit { get; set; }")]
+    public void AReachableProperty_IsStillAParameter(string property) {
+        var result = Run(property).AssertNoErrors();
+
+        Assert.Contains("SizeLimit", result.SourceContaining("TestModule.Module"));
+        Assert.Contains(result.GeneratorDiagnostics, d => d.Id == "DM0018");
+    }
+
+    private static GeneratorResult Run(string body) =>
+        GeneratorTestHarness.Run(
+            $$"""
+              using DependencyModules.Runtime.Attributes;
+
+              namespace TestNamespace;
+
+              [DependencyModule]
+              public partial class TestModule {
+                  {{body}}
+              }
+              """);
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/ReferencedAssemblyModuleAttributeTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ReferencedAssemblyModuleAttributeTests.cs
@@ -114,7 +114,7 @@ public class ReferencedAssemblyModuleAttributeTests {
     /// </summary>
     [Fact]
     public void AClassLibrary_IsSilent() {
-        var library = GeneratorTestHarness.CompileLibrary(LibrarySource, "ThePackage", runGenerator: true);
+        var library = GeneratorTestHarness.CompileLibrary(LibrarySource, "TheModulePackage", runGenerator: true);
 
         var result = GeneratorTestHarness.Run(
             new Dictionary<string, string> {
@@ -147,7 +147,7 @@ public class ReferencedAssemblyModuleAttributeTests {
         string? programExtra = null,
         IReadOnlyDictionary<string, string>? extraFiles = null) {
 
-        var library = GeneratorTestHarness.CompileLibrary(LibrarySource, "ThePackage", runGenerator: true);
+        var library = GeneratorTestHarness.CompileLibrary(LibrarySource, "TheModulePackage", runGenerator: true);
 
         var sources = new Dictionary<string, string> {
             // Top-level statements, so an ApplicationModule is generated and there is an entry

--- a/tests/DependencyModules.Tests/GeneratorTests/ReferencedAssemblyModuleAttributeTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ReferencedAssemblyModuleAttributeTests.cs
@@ -1,0 +1,171 @@
+using System.Collections.Generic;
+using System.Linq;
+using DependencyModules.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// DM0016 and DM0019 for a module that lives in a referenced assembly.
+///
+/// This is the case both codes exist for. A module declared in the same project is the one shape a
+/// developer can see all of; a module arriving from a package is the one where an assembly-level
+/// attribute silently does nothing, because it was read by nobody and the failure is an
+/// InvalidOperationException at the first resolve. The reference page prints exactly that shape as
+/// its DM0019 example — <c>using MyApp.Library;</c> above <c>[assembly: LibraryModule]</c> — and it
+/// did not fire, because both codes were built only from the modules declared in this compilation.
+/// </summary>
+public class ReferencedAssemblyModuleAttributeTests {
+
+    private const string LibrarySource =
+        """
+        using DependencyModules.Runtime.Attributes;
+
+        namespace ThePackage.Composition;
+
+        public interface IPackageThing;
+
+        [SingletonService]
+        public class PackageThing : IPackageThing;
+
+        [DependencyModule]
+        public partial class LibraryModule;
+        """;
+
+    /// <summary>
+    /// The documented DM0019 example, verbatim in shape: the attribute compiles, and it sits in a
+    /// file the generated ApplicationModule was not built from, so nothing reads it.
+    /// </summary>
+    [Fact]
+    public void AnAssemblyAttributeOutsideTheEntryPointFile_ReportsDM0019() {
+        var result = Run(
+            bootstrap: """
+                       using ThePackage.Composition;
+
+                       [assembly: LibraryModule]
+                       """);
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0019");
+
+        Assert.Contains("LibraryModule", diagnostic.GetMessage());
+        Assert.Contains("Program.cs", diagnostic.GetMessage());
+    }
+
+    [Fact]
+    public void AnAssemblyAttributeInTheEntryPointFile_IsSilent() {
+        var result = Run(
+            bootstrap: null,
+            programExtra: """
+                          using ThePackage.Composition;
+
+                          [assembly: LibraryModule]
+                          """);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0019");
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0016");
+    }
+
+    /// <summary>
+    /// Without the using the attribute does not resolve at all, and the compiler's own message
+    /// names a type the developer never wrote in a namespace it does not mention. DM0016 is what
+    /// turns that into the one-line fix.
+    /// </summary>
+    [Fact]
+    public void AnAssemblyAttributeWithoutItsNamespaceImported_ReportsDM0016() {
+        var result = Run(bootstrap: "[assembly: LibraryModule]");
+
+        var diagnostic = Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0016");
+
+        Assert.Contains("LibraryModule", diagnostic.GetMessage());
+        Assert.Contains("ThePackage.Composition", diagnostic.GetMessage());
+    }
+
+    /// <summary>
+    /// It does not compile yet, so which file it belongs in is a later question — the same order
+    /// the in-compilation path already reports in.
+    /// </summary>
+    [Fact]
+    public void AnAssemblyAttributeWithoutItsNamespaceImported_DoesNotAlsoReportDM0019() {
+        var result = Run(bootstrap: "[assembly: LibraryModule]");
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0019");
+    }
+
+    /// <summary>
+    /// A global using satisfies the import wherever it is written, exactly as for a local module.
+    /// </summary>
+    [Fact]
+    public void AGlobalUsingSatisfiesTheImport() {
+        var result = Run(
+            bootstrap: "[assembly: LibraryModule]",
+            extraFiles: new Dictionary<string, string> {
+                ["Usings.cs"] = "global using ThePackage.Composition;"
+            });
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0016");
+        Assert.Single(result.GeneratorDiagnostics, d => d.Id == "DM0019");
+    }
+
+    /// <summary>
+    /// A class library has no entry point, so nothing composes assembly-level attributes and there
+    /// is nothing to be outside of. Unchanged by any of this, and worth pinning: a test project is
+    /// the same shape, and that is where these attributes are supposed to live in their own file.
+    /// </summary>
+    [Fact]
+    public void AClassLibrary_IsSilent() {
+        var library = GeneratorTestHarness.CompileLibrary(LibrarySource, "ThePackage", runGenerator: true);
+
+        var result = GeneratorTestHarness.Run(
+            new Dictionary<string, string> {
+                ["Bootstrap.cs"] = """
+                                   using ThePackage.Composition;
+
+                                   [assembly: LibraryModule]
+                                   """
+            },
+            additionalReferences: [library.Reference]);
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0019");
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0016");
+    }
+
+    /// <summary>
+    /// An attribute naming no module anywhere is somebody else's attribute. Staying quiet for it is
+    /// what keeps this from reporting on every unrelated assembly-level attribute in the project.
+    /// </summary>
+    [Fact]
+    public void AnAttributeThatNamesNoModule_IsSilent() {
+        var result = Run(bootstrap: "[assembly: System.CLSCompliant(true)]");
+
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0016");
+        Assert.DoesNotContain(result.GeneratorDiagnostics, d => d.Id == "DM0019");
+    }
+
+    private static GeneratorResult Run(
+        string? bootstrap,
+        string? programExtra = null,
+        IReadOnlyDictionary<string, string>? extraFiles = null) {
+
+        var library = GeneratorTestHarness.CompileLibrary(LibrarySource, "ThePackage", runGenerator: true);
+
+        var sources = new Dictionary<string, string> {
+            // Top-level statements, so an ApplicationModule is generated and there is an entry
+            // point file for DM0019 to measure against.
+            ["Program.cs"] = (programExtra ?? "") + "\nSystem.Console.WriteLine(\"hello\");"
+        };
+
+        if (bootstrap != null) {
+            sources["Bootstrap.cs"] = bootstrap;
+        }
+
+        foreach (var extra in extraFiles ?? new Dictionary<string, string>()) {
+            sources[extra.Key] = extra.Value;
+        }
+
+        return GeneratorTestHarness.Run(
+            sources,
+            outputKind: OutputKind.ConsoleApplication,
+            additionalReferences: [library.Reference]);
+    }
+}

--- a/tests/DependencyModules.Tests/GeneratorTests/ServiceOrderTests.cs
+++ b/tests/DependencyModules.Tests/GeneratorTests/ServiceOrderTests.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using System.Linq;
+using DependencyModules.Tests.Infrastructure;
+using Xunit;
+
+namespace DependencyModules.Tests.GeneratorTests;
+
+/// <summary>
+/// <c>Order</c> on a service attribute, deciding where an implementation lands in
+/// <c>IEnumerable&lt;T&gt;</c>.
+///
+/// Decorators and interceptors have had an <c>Order</c> since they existed, because nesting is
+/// meaningless without one. Registrations did not, and several implementations of one interface came
+/// out in whatever order the generator emitted them — which is sorted by class name, so renaming a
+/// class reordered a pipeline. Both agents who hit it put an <c>int Order</c> on their own interface
+/// and sorted in the consuming loop, which is the workaround this removes.
+///
+/// The default is 0 for everything, and the sort is stable within an order, so a project that names
+/// no orders sees exactly what it saw before.
+/// </summary>
+public class ServiceOrderTests {
+
+    [Fact]
+    public void WithNoOrderNamed_TheExistingOrderIsKept() {
+        Assert.Equal(["Alpha", "Beta", "Gamma"], Resolve("", "", ""));
+    }
+
+    [Fact]
+    public void OrderDecidesTheSequence() {
+        Assert.Equal(
+            ["Gamma", "Beta", "Alpha"],
+            Resolve(", Order = 30", ", Order = 20", ", Order = 10"));
+    }
+
+    /// <summary>
+    /// Negative orders sort ahead of the unordered majority, which is what "run this one first"
+    /// looks like when the rest of the project has never named an order.
+    /// </summary>
+    [Fact]
+    public void ANegativeOrder_SortsAhead() {
+        Assert.Equal(["Gamma", "Alpha", "Beta"], Resolve("", "", ", Order = -1"));
+    }
+
+    /// <summary>
+    /// Within one order the previous rule still decides, so naming an order for some services does
+    /// not scramble the rest.
+    /// </summary>
+    [Fact]
+    public void WithinOneOrder_TheSortIsStable() {
+        Assert.Equal(["Alpha", "Beta", "Gamma"], Resolve(", Order = 5", ", Order = 5", ", Order = 5"));
+    }
+
+    /// <summary>
+    /// The container returns the last registration for a single resolve, so ordering decides this
+    /// too — worth pinning, because it is the half a reader does not think about.
+    /// </summary>
+    [Fact]
+    public void TheLastInOrder_IsWhatASingleResolveReturns() {
+        var generated = Build(", Order = 30", ", Order = 20", ", Order = 10");
+
+        var resolved = generated.BuildProvider().GetService(generated.Type("IStep"))!;
+
+        Assert.Equal("Alpha", resolved.GetType().Name);
+    }
+
+    private static string[] Resolve(string alpha, string beta, string gamma) {
+        var generated = Build(alpha, beta, gamma);
+
+        return ((System.Collections.IEnumerable)generated.BuildProvider()
+                .GetService(typeof(IEnumerable<>).MakeGenericType(generated.Type("IStep")))!)
+            .Cast<object>()
+            .Select(step => step.GetType().Name)
+            .ToArray();
+    }
+
+    private static GeneratedAssembly Build(string alpha, string beta, string gamma) =>
+        GeneratedAssembly.Create(
+            $$"""
+              using DependencyModules.Runtime.Attributes;
+
+              namespace TestNamespace;
+
+              public interface IStep;
+
+              [SingletonService(As = typeof(IStep){{alpha}})]
+              public class Alpha : IStep;
+
+              [SingletonService(As = typeof(IStep){{beta}})]
+              public class Beta : IStep;
+
+              [SingletonService(As = typeof(IStep){{gamma}})]
+              public class Gamma : IStep;
+
+              [DependencyModule]
+              public partial class TestModule;
+              """);
+}

--- a/tests/DependencyModules.Tests/Infrastructure/GeneratorTestHarness.cs
+++ b/tests/DependencyModules.Tests/Infrastructure/GeneratorTestHarness.cs
@@ -245,6 +245,19 @@ public static class GeneratorTestHarness {
         // Assembly.Load(byte[]) puts it in the default context but does not make it discoverable by
         // name, so generated code referencing it fails to bind at run time. The resolver closes that.
         lock (LoadedLibraries) {
+            // Two test classes compiling different libraries under one name is a trap worth being
+            // loud about. The resolver below is keyed by name, so the second registration decides
+            // what every earlier reference binds to at run time - and the tests that break are
+            // whichever ones happened to run second, which is a failure that appears and disappears
+            // with the filter you ran.
+            Xunit.Assert.True(
+                !LibrarySources.TryGetValue(assemblyName, out var previousSource) ||
+                previousSource == source,
+                $"'{assemblyName}' was compiled more than once from different source. The runtime " +
+                "resolver is keyed by assembly name, so one of them would silently stand in for the " +
+                "other. Give each test class its own assembly name.");
+
+            LibrarySources[assemblyName] = source;
             LoadedLibraries[assemblyName] = assembly;
 
             if (!_resolverHooked) {
@@ -264,6 +277,9 @@ public static class GeneratorTestHarness {
     }
 
     private static readonly Dictionary<string, System.Reflection.Assembly> LoadedLibraries = new();
+
+    /// <summary>What each library name was compiled from, so a reused name is caught.</summary>
+    private static readonly Dictionary<string, string> LibrarySources = new();
 
     private static bool _resolverHooked;
 

--- a/tests/DependencyModules.Tests/Infrastructure/GeneratorTestHarness.cs
+++ b/tests/DependencyModules.Tests/Infrastructure/GeneratorTestHarness.cs
@@ -1,5 +1,7 @@
 
+using System.Collections;
 using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 using System.Reflection;
 using DependencyModules.Runtime.Attributes;
 using Microsoft.CodeAnalysis;
@@ -159,15 +161,30 @@ public static class GeneratorTestHarness {
         driver = driver.RunGenerators(Compile(second));
         var secondRun = driver.GetRunResult();
 
-        var reasons = secondRun.Results
+        var outputs = secondRun.Results
             .SelectMany(result => result.TrackedOutputSteps)
             .SelectMany(step => step.Value)
             .SelectMany(step => step.Outputs)
-            .Select(output => output.Reason)
+            .Select(output => (output.Reason, EmittedSource: EmittedSourceCount(output.Value)))
             .ToArray();
 
-        return new IncrementalRunResult(firstOutputs, Outputs(secondRun), reasons);
+        return new IncrementalRunResult(firstOutputs, Outputs(secondRun), outputs);
     }
+
+    /// <summary>
+    /// How many files a tracked source output produced.
+    /// </summary>
+    /// <remarks>
+    /// Each one carries a <c>(sources, diagnostics)</c> pair, which is what tells an output that
+    /// emits from one that only reports. The distinction matters: a diagnostics-only output is
+    /// combined with the compilation on purpose, so it re-runs whenever anything is typed, and
+    /// counting that as a cache miss would say the generator regenerates on every keystroke when it
+    /// does not.
+    ///
+    /// Read through ITuple rather than by casting: the element type is not public.
+    /// </remarks>
+    private static int EmittedSourceCount(object? value) =>
+        value is ITuple { Length: 2 } tuple && tuple[0] is ICollection sources ? sources.Count : 0;
 
     private static IReadOnlyDictionary<string, string> Outputs(GeneratorDriverRunResult runResult) =>
         runResult.Results
@@ -362,22 +379,34 @@ public class GeneratorResult(
 public class IncrementalRunResult(
     IReadOnlyDictionary<string, string> firstRun,
     IReadOnlyDictionary<string, string> secondRun,
-    IReadOnlyList<IncrementalStepRunReason> outputReasons) {
+    IReadOnlyList<(IncrementalStepRunReason Reason, int EmittedSource)> outputs) {
 
     public IReadOnlyDictionary<string, string> FirstRun { get; } = firstRun;
 
     public IReadOnlyDictionary<string, string> SecondRun { get; } = secondRun;
 
-    public IReadOnlyList<IncrementalStepRunReason> OutputReasons { get; } = outputReasons;
+    public IReadOnlyList<IncrementalStepRunReason> OutputReasons { get; } =
+        outputs.Select(output => output.Reason).ToArray();
 
     /// <summary>
-    /// True when the second run reused every cached output, meaning the edit was correctly
-    /// recognised as irrelevant to generation.
+    /// True when the second run reused every output that produced a file, meaning the edit was
+    /// correctly recognised as irrelevant to generation.
     /// </summary>
+    /// <remarks>
+    /// Outputs that emit nothing are excluded, and the exclusion is the point rather than a
+    /// loophole. Diagnostics are reported from their own outputs, combined with the compilation so
+    /// that a location can carry the syntax tree Roslyn needs before .editorconfig or #pragma can
+    /// silence it. The compilation changes on every keystroke, so those outputs re-run on every
+    /// keystroke by design - they write no source, and holding them to a cache that cannot apply
+    /// would report a regression that is not there. What must stay cached is emission, and that is
+    /// what this measures.
+    /// </remarks>
     public bool AllOutputsCached =>
-        OutputReasons.Count > 0 &&
-        OutputReasons.All(reason =>
-            reason is IncrementalStepRunReason.Cached or IncrementalStepRunReason.Unchanged);
+        outputs.Any(output => output.EmittedSource > 0) &&
+        outputs
+            .Where(output => output.EmittedSource > 0)
+            .All(output => output.Reason
+                is IncrementalStepRunReason.Cached or IncrementalStepRunReason.Unchanged);
 }
 
 internal class TestAnalyzerConfigOptionsProvider(IReadOnlyDictionary<string, string>? buildProperties)

--- a/tests/DependencyModules.Tests/Infrastructure/GeneratorTestHarness.cs
+++ b/tests/DependencyModules.Tests/Infrastructure/GeneratorTestHarness.cs
@@ -208,14 +208,27 @@ public static class GeneratorTestHarness {
     /// InAssemblyOf exists for. Loading it as well lets a behavioural test resolve the services the
     /// generated code registers.
     /// </remarks>
+    /// <param name="runGenerator">
+    /// Whether to run the generator over the library before emitting it. A package built the normal
+    /// way carries what the generator wrote for it — a module's attribute above all — and a consumer
+    /// sees that in metadata. Off by default because most callers only need plain types to scan.
+    /// </param>
     public static (MetadataReference Reference, System.Reflection.Assembly Assembly) CompileLibrary(
-        string source, string assemblyName) {
+        string source, string assemblyName, bool runGenerator = false) {
 
-        var compilation = CSharpCompilation.Create(
+        Compilation compilation = CSharpCompilation.Create(
             assemblyName,
             new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
             References.Value,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        if (runGenerator) {
+            CSharpGeneratorDriver.Create(
+                    Generators(),
+                    optionsProvider: new TestAnalyzerConfigOptionsProvider(null),
+                    parseOptions: new CSharpParseOptions(LanguageVersion.Latest))
+                .RunGeneratorsAndUpdateCompilation(compilation, out compilation, out _);
+        }
 
         using var stream = new MemoryStream();
 

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.MoqApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.MoqApi.verified.txt
@@ -5,6 +5,7 @@ namespace DependencyModules.Moq
     {
         public MoqSupportAttribute() { }
         public object ProvideMock(System.Type type) { }
+        public bool RegistersService(DependencyModules.Testing.Attributes.Interfaces.ITestMethodContext testMethod, System.Type serviceType) { }
         public void SetupServiceCollection(DependencyModules.Testing.Attributes.Interfaces.ITestMethodContext testMethod, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
     }
 }

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
@@ -6,6 +6,7 @@ namespace DependencyModules.Runtime.Attributes
         public System.Type? As { get; set; }
         public object? Key { get; set; }
         protected abstract Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime { get; }
+        public int Order { get; set; }
         public System.Type? Realm { get; set; }
         public DependencyModules.Runtime.Attributes.RegistrationType Using { get; set; }
     }

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
@@ -88,9 +88,19 @@ namespace DependencyModules.Runtime.Attributes
         public InterceptAttribute(params System.Type[] interceptors) { }
         public System.Type[] Interceptors { get; }
         public Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime { get; set; }
+        public DependencyModules.Runtime.Attributes.InterceptedMembers Members { get; set; }
         public int Order { get; set; }
         public System.Type? Realm { get; set; }
         public System.Type? Service { get; set; }
+    }
+    [System.Flags]
+    public enum InterceptedMembers
+    {
+        Methods = 1,
+        Properties = 2,
+        Indexers = 4,
+        Events = 8,
+        All = 15,
     }
     public enum RegistrationType
     {

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
@@ -30,6 +30,7 @@ namespace DependencyModules.Runtime.Attributes
     public class DecoratorAttribute : System.Attribute
     {
         public DecoratorAttribute() { }
+        public System.Type? Implementation { get; set; }
         public int Order { get; set; }
         public System.Type? Realm { get; set; }
         public System.Type? Service { get; set; }

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.RuntimeApi.verified.txt
@@ -85,6 +85,7 @@ namespace DependencyModules.Runtime.Attributes
     {
         public InterceptAttribute(params System.Type[] interceptors) { }
         public System.Type[] Interceptors { get; }
+        public Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime { get; set; }
         public int Order { get; set; }
         public System.Type? Realm { get; set; }
         public System.Type? Service { get; set; }

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -1083,6 +1083,7 @@ namespace DependencyModules.SourceGenerator.Impl
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor GeneratorFailure;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor InterceptionAppliedByNoModule;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor InterceptorCannotServeMembers;
+        public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor MockAndTestExportOnOneMethod;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ModuleAttributeNamespaceNotImported;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ModuleCannotBeNested;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ModuleMustBePartial;
@@ -1165,6 +1166,12 @@ namespace DependencyModules.SourceGenerator.Impl
                 public static readonly CSharpAuthor.ITypeDefinition IDependencyModule;
                 public static readonly CSharpAuthor.ITypeDefinition IDependencyModuleProvider;
                 public static readonly CSharpAuthor.ITypeDefinition IModuleEnvironment;
+            }
+            public static class Testing
+            {
+                public const string Namespace = "DependencyModules.Testing.Attributes";
+                public static readonly CSharpAuthor.ITypeDefinition MockAttribute;
+                public static readonly CSharpAuthor.ITypeDefinition TestExportAttribute;
             }
         }
         public static class Microsoft

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -1416,8 +1416,9 @@ namespace DependencyModules.SourceGenerator.Impl.Models
     }
     public class InterceptorTypeModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.InterceptorTypeModel>
     {
-        public InterceptorTypeModel(CSharpAuthor.ITypeDefinition Type, bool Sync, bool Async, bool Stream) { }
+        public InterceptorTypeModel(CSharpAuthor.ITypeDefinition Type, bool Sync, bool Async, bool Stream, DependencyModules.SourceGenerator.Impl.Models.ServiceLifestyle Lifestyle = 2) { }
         public bool Async { get; init; }
+        public DependencyModules.SourceGenerator.Impl.Models.ServiceLifestyle Lifestyle { get; init; }
         public bool Stream { get; init; }
         public bool Sync { get; init; }
         public CSharpAuthor.ITypeDefinition Type { get; init; }

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -1478,9 +1478,11 @@ namespace DependencyModules.SourceGenerator.Impl.Models
     }
     public class PropertyInfoModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.PropertyInfoModel>
     {
-        public PropertyInfoModel(CSharpAuthor.ITypeDefinition PropertyType, string PropertyName, bool IsReadOnly, bool IsStatic) { }
+        public PropertyInfoModel(CSharpAuthor.ITypeDefinition PropertyType, string PropertyName, bool IsReadOnly, bool IsStatic, bool IsVisibleToAttribute) { }
+        public bool IsModuleParameter { get; }
         public bool IsReadOnly { get; init; }
         public bool IsStatic { get; init; }
+        public bool IsVisibleToAttribute { get; init; }
         public string PropertyName { get; init; }
         public CSharpAuthor.ITypeDefinition PropertyType { get; init; }
     }

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -1078,6 +1078,7 @@ namespace DependencyModules.SourceGenerator.Impl
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ConventionMatchNotConstructable;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ConventionMatchedNothing;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor CrossWireCannotBeGeneric;
+        public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor DecoratorImplementationNeedsTypeRegistration;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor EmptyEnvironmentCondition;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ExposedByConvention;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor GeneratorFailure;
@@ -1278,12 +1279,13 @@ namespace DependencyModules.SourceGenerator.Impl.Models
     public class DecoratorModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.DecoratorModel>
     {
         public static readonly DependencyModules.SourceGenerator.Impl.Models.DecoratorModel Ignore;
-        public DecoratorModel(CSharpAuthor.ITypeDefinition ServiceType, CSharpAuthor.ITypeDefinition DecoratorType, int Order, CSharpAuthor.ITypeDefinition? Realm, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.EnvironmentConditionModel>? Conditions = null, DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? Constructor = null, int InnerParameterIndex = -1, bool TypeParametersMatchService = true, DependencyModules.SourceGenerator.Impl.Models.LocationModel? Location = null) { }
+        public DecoratorModel(CSharpAuthor.ITypeDefinition ServiceType, CSharpAuthor.ITypeDefinition DecoratorType, int Order, CSharpAuthor.ITypeDefinition? Realm, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.EnvironmentConditionModel>? Conditions = null, DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? Constructor = null, int InnerParameterIndex = -1, bool TypeParametersMatchService = true, CSharpAuthor.ITypeDefinition? Implementation = null, DependencyModules.SourceGenerator.Impl.Models.LocationModel? Location = null) { }
         public bool CanMonomorphise { get; }
         public System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.EnvironmentConditionModel>? Conditions { get; init; }
         public DependencyModules.SourceGenerator.Impl.Models.ConstructorInfoModel? Constructor { get; init; }
         public CSharpAuthor.ITypeDefinition DecoratorType { get; init; }
         public bool HasUnboundServiceType { get; }
+        public CSharpAuthor.ITypeDefinition? Implementation { get; init; }
         public int InnerParameterIndex { get; init; }
         public bool IsIgnored { get; }
         public bool IsOpenGeneric { get; }

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -1589,11 +1589,12 @@ namespace DependencyModules.SourceGenerator.Impl.Models
     }
     public class ServiceRegistrationModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.ServiceRegistrationModel>
     {
-        public ServiceRegistrationModel(CSharpAuthor.ITypeDefinition ServiceType, DependencyModules.SourceGenerator.Impl.Models.ServiceLifestyle Lifestyle, DependencyModules.SourceGenerator.Impl.Models.RegistrationType? RegistrationType = default, CSharpAuthor.ITypeDefinition? Realm = null, object? Key = null, bool? CrossWire = false, System.Collections.Generic.IReadOnlyList<string>? Namespaces = null) { }
+        public ServiceRegistrationModel(CSharpAuthor.ITypeDefinition ServiceType, DependencyModules.SourceGenerator.Impl.Models.ServiceLifestyle Lifestyle, DependencyModules.SourceGenerator.Impl.Models.RegistrationType? RegistrationType = default, CSharpAuthor.ITypeDefinition? Realm = null, object? Key = null, bool? CrossWire = false, System.Collections.Generic.IReadOnlyList<string>? Namespaces = null, int Order = 0) { }
         public bool? CrossWire { get; init; }
         public object? Key { get; init; }
         public DependencyModules.SourceGenerator.Impl.Models.ServiceLifestyle Lifestyle { get; init; }
         public System.Collections.Generic.IReadOnlyList<string>? Namespaces { get; init; }
+        public int Order { get; init; }
         public CSharpAuthor.ITypeDefinition? Realm { get; init; }
         public DependencyModules.SourceGenerator.Impl.Models.RegistrationType? RegistrationType { get; init; }
         public CSharpAuthor.ITypeDefinition ServiceType { get; init; }

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -971,7 +971,7 @@ namespace DependencyModules.Conventions.Utilities
     }
     public static class ConventionMatcher
     {
-        public static System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ServiceModel> Match(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, DependencyModules.Conventions.Models.ConventionModuleModel conventionModule, System.Collections.Generic.IReadOnlyList<DependencyModules.Conventions.Models.ConventionCandidateModel> candidates, System.Action<Microsoft.CodeAnalysis.Diagnostic> report, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
+        public static System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.ServiceModel> Match(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, DependencyModules.Conventions.Models.ConventionModuleModel conventionModule, System.Collections.Generic.IReadOnlyList<DependencyModules.Conventions.Models.ConventionCandidateModel> candidates, DependencyModules.SourceGenerator.Impl.Models.DiagnosticReporter report, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
     }
     public static class ConventionModelUtility
     {
@@ -1009,6 +1009,11 @@ namespace DependencyModules.SourceGenerator.Impl
                 "Left",
                 "Right"})] System.ValueTuple<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>, System.Collections.Immutable.ImmutableArray<T>> valueTuple, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger);
         protected abstract System.Collections.Generic.IEqualityComparer<T> GetComparer();
+        protected virtual void ReportDiagnostics(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right",
+                "Left",
+                "Right"})] System.ValueTuple<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>, System.Collections.Immutable.ImmutableArray<T>> data, DependencyModules.SourceGenerator.Impl.Models.SyntaxTreeLookup lookup, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
         public void SetupGenerator(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "Left",
                 "Right"})] Microsoft.CodeAnalysis.IncrementalValuesProvider<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>> incrementalValueProvider) { }
@@ -1091,6 +1096,9 @@ namespace DependencyModules.SourceGenerator.Impl
         public void GenerateSource(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "Left",
                 "Right"})] System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>> allEntryPoints) { }
+        public static void Register(Microsoft.CodeAnalysis.IncrementalGeneratorInitializationContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right"})] Microsoft.CodeAnalysis.IncrementalValueProvider<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>> valuesProvider, bool generateAttribute) { }
     }
     public interface IDependencyModuleSourceGenerator
     {
@@ -1187,6 +1195,17 @@ namespace DependencyModules.SourceGenerator.Impl
     {
         public ModuleAttributeWriter() { }
         protected override void CustomImplementation(CSharpAuthor.IConstructContainer container, CSharpAuthor.ClassDefinition attributeClass, DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel model) { }
+    }
+    public static class ModuleEntryPointDiagnostics
+    {
+        public static bool IsNestedInType(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel model) { }
+        public static bool IsNotPartial(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel model) { }
+        public static bool ReliesOnGeneratedEquality(DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel model) { }
+        public static void Report(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Models",
+                "Compilation",
+                "Left",
+                "Right"})] System.ValueTuple<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>, Microsoft.CodeAnalysis.Compilation> input) { }
     }
 }
 namespace DependencyModules.SourceGenerator.Impl.Models
@@ -1290,6 +1309,15 @@ namespace DependencyModules.SourceGenerator.Impl.Models
         public DependencyModuleConfigurationModelComparer() { }
         public bool Equals(DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel? x, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel? y) { }
         public int GetHashCode(DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel obj) { }
+    }
+    public sealed class DiagnosticReporter
+    {
+        public static readonly DependencyModules.SourceGenerator.Impl.Models.DiagnosticReporter Silent;
+        public DiagnosticReporter(System.Action<Microsoft.CodeAnalysis.Diagnostic>? sink, DependencyModules.SourceGenerator.Impl.Models.SyntaxTreeLookup lookup) { }
+        public bool IsSilent { get; }
+        public Microsoft.CodeAnalysis.Location LocationFor(DependencyModules.SourceGenerator.Impl.Models.LocationModel? location) { }
+        public void Report(Microsoft.CodeAnalysis.DiagnosticDescriptor descriptor, DependencyModules.SourceGenerator.Impl.Models.LocationModel? location, params object?[] messageArgs) { }
+        public void Report(Microsoft.CodeAnalysis.DiagnosticDescriptor descriptor, Microsoft.CodeAnalysis.Location location, params object?[] messageArgs) { }
     }
     public enum EnvironmentConditionKind
     {
@@ -1406,7 +1434,9 @@ namespace DependencyModules.SourceGenerator.Impl.Models
         public int StartCharacter { get; init; }
         public int StartLine { get; init; }
         public Microsoft.CodeAnalysis.Location ToLocation() { }
+        public Microsoft.CodeAnalysis.Location ToLocation(DependencyModules.SourceGenerator.Impl.Models.SyntaxTreeLookup lookup) { }
         public Microsoft.CodeAnalysis.Location ToLocationOrNone() { }
+        public Microsoft.CodeAnalysis.Location ToLocationOrNone(DependencyModules.SourceGenerator.Impl.Models.SyntaxTreeLookup lookup) { }
         public static DependencyModules.SourceGenerator.Impl.Models.LocationModel From(Microsoft.CodeAnalysis.SyntaxNode node) { }
     }
     public enum LogOutputLevel
@@ -1555,6 +1585,12 @@ namespace DependencyModules.SourceGenerator.Impl.Models
         public CSharpAuthor.ITypeDefinition? Realm { get; init; }
         public DependencyModules.SourceGenerator.Impl.Models.RegistrationType? RegistrationType { get; init; }
         public CSharpAuthor.ITypeDefinition ServiceType { get; init; }
+    }
+    public sealed class SyntaxTreeLookup
+    {
+        public static readonly DependencyModules.SourceGenerator.Impl.Models.SyntaxTreeLookup None;
+        public SyntaxTreeLookup(Microsoft.CodeAnalysis.Compilation? compilation) { }
+        public Microsoft.CodeAnalysis.SyntaxTree? Find(string filePath) { }
     }
     public class TypeParameterModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.TypeParameterModel>
     {
@@ -1768,6 +1804,11 @@ namespace DependencyModules.SourceGenerator
                 "Left",
                 "Right"})] System.ValueTuple<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>, System.Collections.Immutable.ImmutableArray<DependencyModules.SourceGenerator.Impl.Models.InterceptorModel>> inputData, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
         protected override System.Collections.Generic.IEqualityComparer<DependencyModules.SourceGenerator.Impl.Models.InterceptorModel> GetComparer() { }
+        protected override void ReportDiagnostics(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right",
+                "Left",
+                "Right"})] System.ValueTuple<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>, System.Collections.Immutable.ImmutableArray<DependencyModules.SourceGenerator.Impl.Models.InterceptorModel>> data, DependencyModules.SourceGenerator.Impl.Models.SyntaxTreeLookup lookup, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
     }
     public class ServiceSourceGenerator : DependencyModules.SourceGenerator.Impl.BaseAttributeSourceGenerator<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>
     {
@@ -1782,6 +1823,11 @@ namespace DependencyModules.SourceGenerator
                 "Right"})] System.ValueTuple<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>, System.Collections.Immutable.ImmutableArray<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>> inputData, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
         protected void GenerateSourceOutput(Microsoft.CodeAnalysis.SourceProductionContext context, DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel entryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel configurationModel, System.Collections.Immutable.ImmutableArray<DependencyModules.SourceGenerator.Impl.Models.ServiceModel> serviceModels, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
         protected override System.Collections.Generic.IEqualityComparer<DependencyModules.SourceGenerator.Impl.Models.ServiceModel> GetComparer() { }
+        protected override void ReportDiagnostics(Microsoft.CodeAnalysis.SourceProductionContext context, [System.Runtime.CompilerServices.TupleElementNames(new string[] {
+                "Left",
+                "Right",
+                "Left",
+                "Right"})] System.ValueTuple<System.Collections.Immutable.ImmutableArray<System.ValueTuple<DependencyModules.SourceGenerator.Impl.Models.ModuleEntryPointModel, DependencyModules.SourceGenerator.Impl.Models.DependencyModuleConfigurationModel>>, System.Collections.Immutable.ImmutableArray<DependencyModules.SourceGenerator.Impl.Models.ServiceModel>> data, DependencyModules.SourceGenerator.Impl.Models.SyntaxTreeLookup lookup, DependencyModules.SourceGenerator.Impl.Utilities.FileLogger logger) { }
     }
     [Microsoft.CodeAnalysis.Generator]
     public class SourceGenerator : DependencyModules.SourceGenerator.Impl.BaseSourceGenerator

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -1081,6 +1081,7 @@ namespace DependencyModules.SourceGenerator.Impl
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor EmptyEnvironmentCondition;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ExposedByConvention;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor GeneratorFailure;
+        public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor InterceptionAppliedByNoModule;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor InterceptorCannotServeMembers;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ModuleAttributeNamespaceNotImported;
         public static readonly Microsoft.CodeAnalysis.DiagnosticDescriptor ModuleCannotBeNested;

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -1364,9 +1364,20 @@ namespace DependencyModules.SourceGenerator.Impl.Models
         public virtual bool Equals(DependencyModules.SourceGenerator.Impl.Models.InterceptedDeclarationModel? other) { }
         public override int GetHashCode() { }
     }
+    [System.Flags]
+    public enum InterceptedMemberKinds
+    {
+        None = 0,
+        Methods = 1,
+        Properties = 2,
+        Indexers = 4,
+        Events = 8,
+        All = 15,
+    }
     public class InterceptedMemberModel : System.IEquatable<DependencyModules.SourceGenerator.Impl.Models.InterceptedMemberModel>
     {
-        public InterceptedMemberModel(string Name, string Identifier, DependencyModules.SourceGenerator.Impl.Models.AccessorForm Form, CSharpAuthor.ITypeDefinition? ReturnType, CSharpAuthor.ITypeDefinition ResultType, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.InterceptedParameterModel> Parameters, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.TypeParameterModel> TypeParameters, DependencyModules.SourceGenerator.Impl.Models.ReturnShape ReturnShape) { }
+        public InterceptedMemberModel(string Name, string Identifier, DependencyModules.SourceGenerator.Impl.Models.AccessorForm Form, CSharpAuthor.ITypeDefinition? ReturnType, CSharpAuthor.ITypeDefinition ResultType, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.InterceptedParameterModel> Parameters, System.Collections.Generic.IReadOnlyList<DependencyModules.SourceGenerator.Impl.Models.TypeParameterModel> TypeParameters, DependencyModules.SourceGenerator.Impl.Models.ReturnShape ReturnShape, bool Excluded = false) { }
+        public bool Excluded { get; init; }
         public DependencyModules.SourceGenerator.Impl.Models.AccessorForm Form { get; init; }
         public string Identifier { get; init; }
         public DependencyModules.SourceGenerator.Impl.Models.InterceptorKind Kind { get; }

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.SourceGeneratorApi.verified.txt
@@ -1524,6 +1524,7 @@ namespace DependencyModules.SourceGenerator.Impl.Models
         AutoRegisterSourceGenerator = 1,
         AbstractImplementation = 2,
         StaticImplementation = 4,
+        Intercepted = 8,
     }
     public enum RegistrationType
     {

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.TestingApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.TestingApi.verified.txt
@@ -32,6 +32,7 @@ namespace DependencyModules.Testing.Attributes.Interfaces
     public interface IMockSupportAttribute
     {
         object ProvideMock(System.Type type);
+        bool RegistersService(DependencyModules.Testing.Attributes.Interfaces.ITestMethodContext testMethod, System.Type serviceType);
     }
     public interface IModuleTestAttribute
     {

--- a/tests/DependencyModules.Tests/TestingTests/TestParameterResolverTests.cs
+++ b/tests/DependencyModules.Tests/TestingTests/TestParameterResolverTests.cs
@@ -192,42 +192,44 @@ public class TestParameterResolverTests {
     }
 
     /// <summary>
-    /// A parameter attribute does not override an attribute on the method, the class or the
-    /// assembly, and <c>[Mock]</c> is parameter-only while <c>[TestExport]</c> is not. So naming a
-    /// real implementation displaces the double for the <c>[Mock]</c> parameter too, and the
-    /// parameter holds what everything else in the test holds.
+    /// A [Mock] on a parameter overrides a registration made from a wider scope — a [TestExport] on
+    /// the method, the class or the assembly. A parameter attribute names one argument, which is the
+    /// narrowest thing a test can say, so it is the one that decides.
     ///
-    /// Worth pinning rather than leaving implicit. It is the composition of two rules that are each
-    /// documented separately — parameter attributes register in the earlier pass, setup attributes
-    /// in the later one, and later wins — and read cold it looks like a bug: the parameter says
-    /// [Mock] and the object is real. It is the precedence working.
+    /// The hosts arrange that by running this pass last, after the setup attributes, and this is the
+    /// half of it the resolver owns: whatever was registered before it, the double registered here
+    /// is the one the container ends up with.
     /// </summary>
     [Fact]
-    public async Task ARegistrationFromAWiderScope_DisplacesAMockOnAParameter() {
+    public async Task AMockOnAParameter_BeatsARegistrationMadeBeforeIt() {
         var services = new ServiceCollection();
         var resolver = new TestParameterResolver(ContextFor(nameof(Samples.UnkeyedMock)));
 
+        // What a [TestExport] from any wider scope leaves behind, since the setup-attribute pass
+        // runs first.
         services.AddSingleton<IThing, Thing>();
-        resolver.SetupServiceCollection(services);
-
-        // What a [TestExport] on the method, class or assembly does: register in the pass that runs
-        // after the parameter attributes have had theirs.
         services.AddSingleton<IThing, Other2>();
+
+        resolver.SetupServiceCollection(services);
 
         var arguments = await resolver.ResolveArgumentsAsync(services.BuildServiceProvider(), []);
 
-        Assert.IsType<Other2>(Assert.Single(arguments));
+        Assert.IsType<Other>(Assert.Single(arguments));
     }
 
     /// <summary>
-    /// Control: with nothing from a wider scope naming the service, the parameter gets the double.
+    /// And the service under test sees the same double, which is why [Mock] registers at all rather
+    /// than merely supplying an argument.
     /// </summary>
     [Fact]
-    public async Task AMockNothingDisplaces_GetsTheDouble() {
-        var arguments = await Resolve(
-            nameof(Samples.UnkeyedMock), services => services.AddSingleton<IThing, Thing>());
+    public void AMockOnAParameter_IsWhatTheContainerHandsOut() {
+        var services = new ServiceCollection();
+        var resolver = new TestParameterResolver(ContextFor(nameof(Samples.UnkeyedMock)));
 
-        Assert.IsType<Other>(Assert.Single(arguments));
+        services.AddSingleton<IThing, Other2>();
+        resolver.SetupServiceCollection(services);
+
+        Assert.IsType<Other>(services.BuildServiceProvider().GetRequiredService<IThing>());
     }
 
     [Fact]

--- a/tests/DependencyModules.Tests/TestingTests/TestParameterResolverTests.cs
+++ b/tests/DependencyModules.Tests/TestingTests/TestParameterResolverTests.cs
@@ -192,45 +192,38 @@ public class TestParameterResolverTests {
     }
 
     /// <summary>
-    /// [Mock] and [TestExport] naming one service is a contradiction, and it used to resolve
-    /// silently in [TestExport]'s favour - for the [Mock] parameter too.
+    /// A parameter attribute does not override an attribute on the method, the class or the
+    /// assembly, and <c>[Mock]</c> is parameter-only while <c>[TestExport]</c> is not. So naming a
+    /// real implementation displaces the double for the <c>[Mock]</c> parameter too, and the
+    /// parameter holds what everything else in the test holds.
     ///
-    /// Both halves are deliberate. [Mock] registers its double during setup so the service under
-    /// test is built against it, then resolves the parameter back out of the container so the test
-    /// holds the same instance the subject got. [TestExport] registers in a later pass, so its
-    /// registration is last and wins - which is pinned by two tests and is the documented
-    /// precedence. Put together they hand the test the real implementation while it believes it
-    /// holds a double, and the first arrange line throws a mocking-library error naming neither
-    /// attribute.
-    ///
-    /// So neither half moves. The contradiction is reported instead, naming both attributes and the
-    /// service they disagree about.
+    /// Worth pinning rather than leaving implicit. It is the composition of two rules that are each
+    /// documented separately — parameter attributes register in the earlier pass, setup attributes
+    /// in the later one, and later wins — and read cold it looks like a bug: the parameter says
+    /// [Mock] and the object is real. It is the precedence working.
     /// </summary>
     [Fact]
-    public async Task AMockDisplacedByAnotherRegistration_IsReported() {
+    public async Task ARegistrationFromAWiderScope_DisplacesAMockOnAParameter() {
         var services = new ServiceCollection();
         var resolver = new TestParameterResolver(ContextFor(nameof(Samples.UnkeyedMock)));
 
         services.AddSingleton<IThing, Thing>();
         resolver.SetupServiceCollection(services);
 
-        // Stands in for [TestExport]: a registration of the same service made in the later pass,
-        // which is where the setup attributes run and why theirs is the one that wins.
+        // What a [TestExport] on the method, class or assembly does: register in the pass that runs
+        // after the parameter attributes have had theirs.
         services.AddSingleton<IThing, Other2>();
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => resolver.ResolveArgumentsAsync(services.BuildServiceProvider(), []));
+        var arguments = await resolver.ResolveArgumentsAsync(services.BuildServiceProvider(), []);
 
-        Assert.Contains("[Mock]", exception.Message);
-        Assert.Contains(nameof(IThing), exception.Message);
-        Assert.Contains(nameof(Other2), exception.Message);
+        Assert.IsType<Other2>(Assert.Single(arguments));
     }
 
     /// <summary>
-    /// Control: with nothing displacing it, the parameter still gets the double and says nothing.
+    /// Control: with nothing from a wider scope naming the service, the parameter gets the double.
     /// </summary>
     [Fact]
-    public async Task AMockNothingDisplaces_IsNotReported() {
+    public async Task AMockNothingDisplaces_GetsTheDouble() {
         var arguments = await Resolve(
             nameof(Samples.UnkeyedMock), services => services.AddSingleton<IThing, Thing>());
 

--- a/tests/DependencyModules.Tests/TestingTests/TestParameterResolverTests.cs
+++ b/tests/DependencyModules.Tests/TestingTests/TestParameterResolverTests.cs
@@ -23,6 +23,9 @@ public class TestParameterResolverTests {
 
     private class Other : IThing;
 
+    /// <summary>A second real implementation, for the displacement case.</summary>
+    private class Other2 : IThing;
+
     /// <summary>
     /// Takes a dependency the container has and a value it cannot possibly know, which is what
     /// [InjectValues] is for.
@@ -182,6 +185,52 @@ public class TestParameterResolverTests {
     /// <summary>Control: an unkeyed mock still replaces the unkeyed registration.</summary>
     [Fact]
     public async Task UnkeyedMockReplacesTheUnkeyedRegistration() {
+        var arguments = await Resolve(
+            nameof(Samples.UnkeyedMock), services => services.AddSingleton<IThing, Thing>());
+
+        Assert.IsType<Other>(Assert.Single(arguments));
+    }
+
+    /// <summary>
+    /// [Mock] and [TestExport] naming one service is a contradiction, and it used to resolve
+    /// silently in [TestExport]'s favour - for the [Mock] parameter too.
+    ///
+    /// Both halves are deliberate. [Mock] registers its double during setup so the service under
+    /// test is built against it, then resolves the parameter back out of the container so the test
+    /// holds the same instance the subject got. [TestExport] registers in a later pass, so its
+    /// registration is last and wins - which is pinned by two tests and is the documented
+    /// precedence. Put together they hand the test the real implementation while it believes it
+    /// holds a double, and the first arrange line throws a mocking-library error naming neither
+    /// attribute.
+    ///
+    /// So neither half moves. The contradiction is reported instead, naming both attributes and the
+    /// service they disagree about.
+    /// </summary>
+    [Fact]
+    public async Task AMockDisplacedByAnotherRegistration_IsReported() {
+        var services = new ServiceCollection();
+        var resolver = new TestParameterResolver(ContextFor(nameof(Samples.UnkeyedMock)));
+
+        services.AddSingleton<IThing, Thing>();
+        resolver.SetupServiceCollection(services);
+
+        // Stands in for [TestExport]: a registration of the same service made in the later pass,
+        // which is where the setup attributes run and why theirs is the one that wins.
+        services.AddSingleton<IThing, Other2>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => resolver.ResolveArgumentsAsync(services.BuildServiceProvider(), []));
+
+        Assert.Contains("[Mock]", exception.Message);
+        Assert.Contains(nameof(IThing), exception.Message);
+        Assert.Contains(nameof(Other2), exception.Message);
+    }
+
+    /// <summary>
+    /// Control: with nothing displacing it, the parameter still gets the double and says nothing.
+    /// </summary>
+    [Fact]
+    public async Task AMockNothingDisplaces_IsNotReported() {
         var arguments = await Resolve(
             nameof(Samples.UnkeyedMock), services => services.AddSingleton<IThing, Thing>());
 

--- a/tests/DependencyModules.Tests/xUnitTests/ModuleTestCaseDataTests.cs
+++ b/tests/DependencyModules.Tests/xUnitTests/ModuleTestCaseDataTests.cs
@@ -1,0 +1,230 @@
+using System.Reflection;
+using DependencyModules.xUnit.Attributes;
+using DependencyModules.xUnit.Impl;
+using Xunit;
+using Xunit.Sdk;
+using Xunit.v3;
+
+namespace DependencyModules.Tests.xUnitTests;
+
+/// <summary>
+/// Drives <see cref="ModuleTestCase.CreateTests"/> directly, for the data-driven shapes.
+///
+/// The failure these cover is the one a test integration can least afford: four of the five row
+/// sources below expanded to <em>zero</em> cases and the run reported <c>Passed!</c>. Moving a row
+/// set from [InlineData] to [MemberData] therefore dropped the coverage silently. Asserting on the
+/// count of tests produced is the only way that becomes visible, because every integration test
+/// runs through [ModuleTest] and a case that is never created is a suite that is quietly smaller.
+/// </summary>
+public class ModuleTestCaseDataTests {
+
+    /// <summary>
+    /// Regression test. [MemberData] resolves its member off <c>ITypeAwareDataAttribute.MemberType</c>,
+    /// which xUnit back-fills in <c>ExtensibilityPointFactory.GetMethodDataAttributes</c> — a path
+    /// this integration does not use, because it also sweeps assembly- and class-level attributes.
+    /// Left null, <c>MemberDataAttributeBase.GetData</c> returns an empty collection rather than
+    /// throwing, so the rows vanished without a diagnostic.
+    /// </summary>
+    [Fact]
+    public async Task MemberData_WithoutExplicitMemberType_ProducesOneTestPerRow() {
+        var tests = await CreateTests(nameof(DataSample.FromTheoryData));
+
+        Assert.Equal(2, tests.Count);
+    }
+
+    [Fact]
+    public async Task MemberData_ReturningObjectArrays_ProducesOneTestPerRow() {
+        var tests = await CreateTests(nameof(DataSample.FromObjectArrays));
+
+        Assert.Equal(2, tests.Count);
+    }
+
+    [Fact]
+    public async Task MemberData_ReturningTheoryDataRows_ProducesOneTestPerRow() {
+        var tests = await CreateTests(nameof(DataSample.FromTheoryDataRows));
+
+        Assert.Equal(2, tests.Count);
+    }
+
+    /// <summary>
+    /// The control that made the bug invisible: an explicit MemberType needs no back-fill, so this
+    /// shape worked throughout.
+    /// </summary>
+    [Fact]
+    public async Task MemberData_WithExplicitMemberType_ProducesOneTestPerRow() {
+        var tests = await CreateTests(nameof(DataSample.FromExplicitMemberType));
+
+        Assert.Equal(2, tests.Count);
+    }
+
+    [Fact]
+    public async Task ClassData_ProducesOneTestPerRow() {
+        var tests = await CreateTests(nameof(DataSample.FromClassData));
+
+        Assert.Equal(2, tests.Count);
+    }
+
+    /// <summary>
+    /// The other control. [InlineData] carries its own literals and never needed the back-fill.
+    /// </summary>
+    [Fact]
+    public async Task InlineData_ProducesOneTestPerRow() {
+        var tests = await CreateTests(nameof(DataSample.FromInlineData));
+
+        Assert.Equal(2, tests.Count);
+    }
+
+    /// <summary>
+    /// The shape the guide actually teaches, and the one the field report ran into: the row supplies
+    /// the leading parameters and the container supplies the trailing one. Kept as its own set of
+    /// cases because the row-count and the argument-resolution halves fail independently — the
+    /// original report attributed the whole thing to the trailing parameter, which is not where it
+    /// was.
+    /// </summary>
+    [Theory]
+    [InlineData(nameof(DataSample.TheoryDataWithContainerParameter))]
+    [InlineData(nameof(DataSample.ObjectArraysWithContainerParameter))]
+    [InlineData(nameof(DataSample.TheoryDataRowsWithContainerParameter))]
+    [InlineData(nameof(DataSample.ClassDataWithContainerParameter))]
+    [InlineData(nameof(DataSample.InlineDataWithContainerParameter))]
+    public async Task RowSupplyingFewerArgumentsThanTheMethodTakes_ProducesOneTestPerRow(string methodName) {
+        var tests = await CreateTests(methodName);
+
+        Assert.Equal(2, tests.Count);
+    }
+
+    /// <summary>
+    /// A row source that legitimately yields nothing must fail rather than pass, which is xUnit's
+    /// own default for a theory without data. Returning zero tests silently is what turned the bug
+    /// above into a green suite instead of a red one.
+    /// </summary>
+    [Fact]
+    public async Task DataAttributeYieldingNoRows_Fails() {
+        var exception = await Assert.ThrowsAnyAsync<Exception>(
+            async () => await CreateTests(nameof(DataSample.FromEmptySource)));
+
+        Assert.Contains(nameof(DataSample.FromEmptySource), exception.Message);
+    }
+
+    /// <summary>
+    /// A method with no data attribute at all is the ordinary case and still produces exactly one
+    /// test — the guard above must not catch it.
+    /// </summary>
+    [Fact]
+    public async Task NoDataAttribute_ProducesOneTest() {
+        var tests = await CreateTests(nameof(DataSample.NoRows));
+
+        Assert.Single(tests);
+    }
+
+    private static async Task<IReadOnlyCollection<IXunitTest>> CreateTests(string methodName) {
+        var testMethod = BuildTestMethod(typeof(DataSample), methodName);
+
+        var testCases = await new ModuleTestDiscoverer().Discover(
+            new DiscoveryOptions(), testMethod, new ModuleTestAttribute());
+
+        var testCase = Assert.Single(testCases);
+
+        return await testCase.CreateTests();
+    }
+
+    private static IXunitTestMethod BuildTestMethod(Type testClass, string methodName) {
+        var assembly = new XunitTestAssembly(testClass.Assembly);
+        var collection = new XunitTestCollection(assembly, null, false, "Test collection");
+        var xunitClass = new XunitTestClass(testClass, collection);
+        var method = testClass.GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance)!;
+
+        return new XunitTestMethod(xunitClass, method, []);
+    }
+
+    private class DiscoveryOptions : ITestFrameworkDiscoveryOptions {
+        private readonly Dictionary<string, object?> _values = new(StringComparer.OrdinalIgnoreCase);
+
+        public TValue? GetValue<TValue>(string name) =>
+            _values.TryGetValue(name, out var value) && value is TValue typed ? typed : default;
+
+        public void SetValue<TValue>(string name, TValue value) => _values[name] = value;
+
+        public string ToJson() => "{}";
+    }
+
+    /// <summary>
+    /// Nested and un-attributed on purpose: annotating it with [ModuleTest] would make the xUnit
+    /// analyzer treat it as a test class. The discoverer is handed the attribute directly instead.
+    /// </summary>
+    // xUnit1008 wants a [Theory] beside every data attribute. These methods are deliberately not
+    // test methods — they are reflection fixtures the discoverer is pointed at by hand — and adding
+    // [Theory] would make the outer suite run them.
+    //
+    // xUnit1037 fires on every trailing-container-parameter method below, because to xUnit a row
+    // supplying fewer arguments than the method takes is a mistake. Under [ModuleTest] it is the
+    // documented feature — the container supplies the rest — so the rule cannot hold here. Worth
+    // noting that the guide teaches this shape without mentioning that it trips an analyzer error.
+#pragma warning disable xUnit1008, xUnit1037
+    private class DataSample {
+        public static TheoryData<string> Rows => new("first", "second");
+
+        public static IEnumerable<object[]> ObjectArrayRows => [["first"], ["second"]];
+
+        public static IEnumerable<TheoryDataRow<string>> TheoryDataRows =>
+            [new TheoryDataRow<string>("first"), new TheoryDataRow<string>("second")];
+
+        public static TheoryData<string> NoRowsAtAll => new();
+
+        [MemberData(nameof(Rows))]
+        public void FromTheoryData(string value) { }
+
+        [MemberData(nameof(ObjectArrayRows))]
+        public void FromObjectArrays(string value) { }
+
+        [MemberData(nameof(TheoryDataRows))]
+        public void FromTheoryDataRows(string value) { }
+
+        [MemberData(nameof(Rows), MemberType = typeof(DataSample))]
+        public void FromExplicitMemberType(string value) { }
+
+        [ClassData(typeof(SampleClassData))]
+        public void FromClassData(string value) { }
+
+        [InlineData("first")]
+        [InlineData("second")]
+        public void FromInlineData(string value) { }
+
+        [MemberData(nameof(NoRowsAtAll))]
+        public void FromEmptySource(string value) { }
+
+        public void NoRows() { }
+
+        // The trailing parameter comes from the container, not from the row.
+
+        [MemberData(nameof(Rows))]
+        public void TheoryDataWithContainerParameter(string value, ContainerSupplied supplied) { }
+
+        [MemberData(nameof(ObjectArrayRows))]
+        public void ObjectArraysWithContainerParameter(string value, ContainerSupplied supplied) { }
+
+        [MemberData(nameof(TheoryDataRows))]
+        public void TheoryDataRowsWithContainerParameter(string value, ContainerSupplied supplied) { }
+
+        [ClassData(typeof(SampleClassData))]
+        public void ClassDataWithContainerParameter(string value, ContainerSupplied supplied) { }
+
+        [InlineData("first")]
+        [InlineData("second")]
+        public void InlineDataWithContainerParameter(string value, ContainerSupplied supplied) { }
+    }
+
+    /// <summary>
+    /// Stands in for the service a real module would register. Concrete and parameterless so the
+    /// resolver can supply it without any module being loaded.
+    /// </summary>
+    private class ContainerSupplied { }
+#pragma warning restore xUnit1008, xUnit1037
+
+    private class SampleClassData : TheoryData<string> {
+        public SampleClassData() {
+            Add("first");
+            Add("second");
+        }
+    }
+}

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -112,6 +112,7 @@ export default defineConfig({
           items: [
             { text: 'Diagnostics', link: '/reference/diagnostics' },
             { text: 'Attributes', link: '/reference/attributes' },
+            { text: 'Runtime interfaces', link: '/reference/interfaces' },
             { text: 'Convention API', link: '/reference/conventions-api' },
             { text: 'MSBuild properties', link: '/reference/msbuild' },
           ],

--- a/website/guide/decorators.md
+++ b/website/guide/decorators.md
@@ -184,10 +184,15 @@ closed registrations — the example further up — works, and is the common cas
 
 |  | Decorator | [Interception](/guide/interception) |
 |---|---|---|
-| Who writes the wrapper | you | the generator, for every member |
-| Applies to | one interface | many unrelated services |
+| Who writes the wrapper | you | the generator |
+| Declared on | the decorator, against an interface | the implementation being wrapped |
+| Covers by default | every registration of that service | the one class it is written on |
 | Member access | real signatures and parameter names | uniform, `TResult` and `IArguments` |
 | Reach for it when | caching *this* method, validating *that* one | logging, timing, retry, tracing |
+
+Either can be narrowed to the other's default. `[Decorator(Implementation = typeof(X))]` decorates one
+implementation instead of all of them; `[Intercept(Realm = …)]` and `[Intercept(Members = …)]` narrow
+an interception further still.
 
 If you need to do something specific to one member, write a decorator. If you need to do the same
 thing to every member of thirty services, read on.

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -95,6 +95,24 @@ public partial class ApplicationModule;
 `partial` is required. The generator completes the class you declared; without `partial` there is
 nothing to complete, and you get [DM0003](/reference/diagnostics#dm0003).
 
+::: tip You may already have one
+A project whose entry point is a top-level `Program.cs` gets an `ApplicationModule` generated for it,
+in the project's `RootNamespace` — so in that project the declaration above is redundant, and
+declaring it merges with the generated one rather than fighting it.
+
+If you want to add a `ConfigureServices` to that generated module, declare the partial **without**
+`[DependencyModule]` and implement `IServiceCollectionConfiguration`:
+
+```csharp
+public partial class ApplicationModule : IServiceCollectionConfiguration {
+    public void ConfigureServices(IServiceCollection services) =>
+        services.AddHttpClient();
+}
+```
+
+See [Modules](/guide/modules#you-may-not-need-to-declare-one).
+:::
+
 Now load it at your composition root:
 
 ```csharp
@@ -138,10 +156,25 @@ private static void ModuleDependencies(IServiceCollection services) {
 One line, and it is the line you would have written by hand. No reflection, no startup scan, and a
 literal `typeof()` the trimmer can follow.
 
-::: warning If you redirect the output, clear it between builds
-`CompilerGeneratedFilesOutputPath` pointing at a folder inside your project means stale files from a
-previous build compile alongside fresh ones, producing a wall of `CS0111`/`CS0579`. Delete the folder
-when you rename a module.
+::: warning If you redirect the output, exclude it from the build
+`EmitCompilerGeneratedFiles` alone writes under `obj/`, which is already excluded and is fine.
+`CompilerGeneratedFilesOutputPath` pointing at a folder **inside your project** is the trap: those
+files are then compiled as ordinary source *as well as* being generated, so every type exists twice
+and you get a wall of `CS0111`/`CS0579`.
+
+```xml
+<PropertyGroup>
+  <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+  <CompilerGeneratedFilesOutputPath>generated</CompilerGeneratedFilesOutputPath>
+</PropertyGroup>
+
+<ItemGroup>
+  <Compile Remove="generated/**" />   <!-- read them, do not compile them -->
+</ItemGroup>
+```
+
+Stale files are the other half: delete the folder when you rename a module, or the old name compiles
+alongside the new one.
 :::
 
 ## Where to go next

--- a/website/guide/interception.md
+++ b/website/guide/interception.md
@@ -17,7 +17,8 @@ In both cases you are writing forwarding code by hand, and the actual logic is f
 ## How DependencyModules helps
 
 Write the behaviour once, as an interceptor. The generator emits a type implementing the service
-interface and routes **every member** through it:
+interface and routes its members through it — every member by default, and
+[the kinds you name](#covering-some-members-and-not-others) when that is too much:
 
 ```csharp
 public class TimingInterceptor(ILogger log) : IInterceptor {
@@ -131,6 +132,83 @@ public class Repository : IRepository { }
 
 They nest in declaration order. Each is resolved from the container, so an interceptor can take
 dependencies of its own — as `TimingInterceptor` does with its `ILogger`.
+
+## How an interceptor is registered
+
+You do not register interceptors. The generated code registers each one **as its own type**, with
+`TryAdd`, so it is resolvable by the wrapper without being visible as an `IInterceptor` to anything
+else.
+
+`TryAdd` means a registration you made yourself wins. An interceptor carrying its own
+`[SingletonService]` or `[ScopedService]` keeps that lifetime, because services are applied before
+decorators and yours is already there by the time this runs.
+
+The default is singleton, and it is the wrong default for an interceptor that takes a scoped
+dependency — a singleton holding a scoped service is a captive dependency, and nothing says so unless
+`ValidateScopes` is on. Name the lifetime instead:
+
+```csharp
+[Intercept(typeof(AuditInterceptor), Lifetime = ServiceLifetime.Scoped)]
+public class Repository : IRepository { }
+```
+
+## An interception belongs to one implementation
+
+`[Intercept]` applies to **the class it is written on**, not to every implementation of the interface:
+
+```csharp
+[SingletonService] [Intercept(typeof(TimingInterceptor))]
+public class SqlRepository : IRepository { }
+
+[SingletonService]
+public class InMemoryRepository : IRepository { }   // not wrapped
+```
+
+This is the opposite of a [decorator](/guide/decorators), which is declared against the interface and
+wraps everything behind it — and the difference is the point. A decorator says "this behaviour
+belongs to the interface"; an interceptor says "this behaviour belongs to this class".
+
+Decorators can name one implementation too, with `[Decorator(Implementation = typeof(X))]`, when that
+turns out to be what you meant.
+
+## Realms
+
+An interception with no `Realm` takes the one its own class's service attribute names, so these agree
+without being told to:
+
+```csharp
+[SingletonService(Realm = typeof(DiagnosticsModule))]
+[Intercept(typeof(AuditInterceptor))]
+public class Profiler : IProfiler { }
+```
+
+The interception lands in `DiagnosticsModule`, where the registration is. Name a realm explicitly to
+override that:
+
+```csharp
+[Intercept(typeof(AuditInterceptor), Realm = typeof(DiagnosticsModule))]
+```
+
+A class registered by a **convention** takes its realm at match time, which is too late for an
+interception to inherit — so a realm-only convention module needs the realm named on `[Intercept]`.
+[DM0020](/reference/diagnostics#dm0020) reports an interception no module ends up applying.
+
+## Covering some members and not others
+
+Every member is covered by default, which is right for auditing or retry — an interceptor has no way
+to know which members matter, and leaving one out silently is worse than covering too much.
+
+It is the wrong default for an interface with properties, where a timing interceptor records a call
+per read. Name the kinds instead:
+
+```csharp
+[Intercept(typeof(TimingInterceptor), Members = InterceptedMembers.Methods)]
+public class Repository : IRepository { }
+```
+
+`InterceptedMembers` has `Methods`, `Properties`, `Indexers` and `Events`, combinable with `|`. A
+member left out is still forwarded — the wrapper implements the whole interface either way — it just
+does not run through the chain.
 
 ## What cannot be intercepted
 

--- a/website/guide/modules.md
+++ b/website/guide/modules.md
@@ -35,9 +35,10 @@ body stays empty unless you want something from the rest of this page.
 A module **must** be `partial`, or the generator has nothing to complete —
 [DM0003](/reference/diagnostics#dm0003).
 
-A module must be declared **directly in a namespace**, never nested inside another type. A nested
-module quietly generates a separate, detached class instead of completing your partial, so its
-registrations never run. Services can be nested freely; the restriction is only on modules.
+A module must be declared **directly in a namespace**, never nested inside another type —
+[DM0017](/reference/diagnostics#dm0017). A nested module quietly generates a separate, detached class
+instead of completing your partial, so its registrations never run. Services can be nested freely;
+the restriction is only on modules.
 :::
 
 ## Composing modules
@@ -46,9 +47,13 @@ Every module generates **an attribute with the same name**. Applying that attrib
 makes it a dependency:
 
 ```csharp
+// MyApp.Data — its own project
 [DependencyModule]
 public partial class DataModule;
+```
 
+```csharp
+// MyApp — references MyApp.Data
 [DependencyModule]
 [DataModule]                       // everything DataModule registers comes along
 public partial class ApplicationModule;
@@ -61,6 +66,22 @@ attribute rather than a call somebody has to remember.
 ```csharp
 services.AddModule<ApplicationModule>();   // DataModule comes too
 ```
+
+::: warning The two modules are in two projects, and that matters
+A module collects every attributed service **in its own project** — so two modules declared in one
+project each hold that project's whole registration list, and composing one into the other does not
+change what either holds. Loading `ApplicationModule` would then apply the same registrations twice.
+
+```csharp
+// one project, both modules — every service registers twice
+[DependencyModule] public partial class DataModule;
+[DependencyModule] [DataModule] public partial class ApplicationModule;
+```
+
+Composing across projects is the shape above and is what this is for. Two modules that genuinely
+belong in one project want [realms](#realms-keeping-a-registration-out-of-the-default-module)
+instead: a realm is how you say which registrations belong to which module.
+:::
 
 Dependencies are expanded **before** the module that declares them, so a module's own registrations
 are applied last and win wherever the container is last-wins. An application can therefore override
@@ -143,9 +164,12 @@ call runs it twice:
 services.AddModules(new AppModule(), new DataModule());   // every service registered twice
 ```
 
-Declaring two modules is fine; loading both is what doubles up. If they are meant to be composed
-together, give one a realm, or have one compose the other with its
-[generated attribute](#composing-modules) instead of naming both at the call site.
+Declaring two modules is fine; loading both is what doubles up. **Give one a realm** — that is what
+says which registrations belong to which module, and the only thing that removes the doubling.
+
+Composing one into the other does *not*, however it reads: both still hold the whole list, so
+loading the outer one applies it twice. Composition is for modules in [separate
+projects](#composing-modules), where each holds only its own.
 :::
 
 ## Parameters
@@ -164,6 +188,27 @@ public partial class ApplicationModule {
 [ApplicationModule(ConnectionString = "Server=…")]
 public partial class TestModule;
 ```
+
+::: warning A module with parameters needs an identity
+Modules de-duplicate **by type**, which is what stops a module reached twice from registering
+everything twice. A module carrying parameters is the case that rule does not fit: two instances
+holding different values are the same module by it, so the first one reached wins and the other is
+discarded with nothing said.
+
+```csharp
+[DependencyModule] [ApplicationModule(ConnectionString = "primary")]  public partial class A;
+[DependencyModule] [ApplicationModule(ConnectionString = "reporting")] public partial class B;
+```
+
+Load both and one connection string arrives. [DM0018](/reference/diagnostics#dm0018) reports it, and
+declaring your own `Equals` and `GetHashCode` says which answer you meant — identity by value, so
+both survive, or identity by type, so one wins deliberately.
+:::
+
+A **value-typed** parameter cannot carry a default. `public int Retries { get; set; } = 3;` is reset
+to `0` by a composition that does not name it, because `0` and "not set" are the same value and the
+generated attribute cannot tell them apart. A nullable or reference-typed parameter keeps its
+default. Name value-typed parameters at every composition, or make them nullable.
 
 ## When attributes are not enough
 

--- a/website/guide/services.md
+++ b/website/guide/services.md
@@ -106,6 +106,51 @@ provider.GetRequiredKeyedService<IConnection>("primary");
 The key is written into the registration exactly as you wrote it, so a string literal, a `const` or
 an enum member all work.
 
+A constructor asks for one with `[FromKeyedServices]`, which is the container's own attribute:
+
+```csharp
+[ScopedService]
+public class ReportBuilder(
+    [FromKeyedServices("reporting")] IConnection connection) { }
+```
+
+## Taking all of them
+
+Depend on `IEnumerable<T>` and the container hands over every **unkeyed** registration of that
+service — which is how a pipeline of validators or handlers is written:
+
+```csharp
+[SingletonService(As = typeof(IValidator), Order = 10)]
+public class RequiredFields : IValidator { }
+
+[SingletonService(As = typeof(IValidator), Order = 20)]
+public class BusinessRules : IValidator { }
+```
+
+```csharp
+[ScopedService]
+public class OrderService(IEnumerable<IValidator> validators) {
+    public void Place(Order order) {
+        foreach (var validator in validators) {   // RequiredFields, then BusinessRules
+            validator.Validate(order);
+        }
+    }
+}
+```
+
+`Order` decides the sequence, lowest first. Without it the sequence is the order the generator emits,
+which is sorted by class name — so renaming a class reorders the pipeline. Everything is `0` by
+default and the sort is stable within one order, so naming an order for some services leaves the rest
+where they are.
+
+::: warning Keyed registrations are not in the enumeration
+`GetServices<T>()` and an `IEnumerable<T>` dependency both return the unkeyed registrations only. A
+set of handlers you want to both *route to by name* and *list* therefore cannot use keys for the
+first and the enumeration for the second — register them unkeyed and carry the name on each handler.
+There is a [design note](https://github.com/ipjohnson/DependencyModules/blob/main/docs/design/dispatch-by-name.md)
+on making this first-class.
+:::
+
 ## How the registration is added
 
 By default every attribute adds unconditionally, so registering the same service type twice leaves
@@ -177,7 +222,12 @@ services.AddSingleton(
 
 Every constructor dependency becomes an explicit `GetRequiredService` call, so the container never
 reflects over the constructor. Worth it when you are chasing startup time or targeting Native AOT
-aggressively. See [MSBuild properties](/reference/msbuild) for the rest.
+aggressively.
+
+It has two costs worth reading before you turn it on project-wide: the container cannot see inside a
+factory, so `ValidateScopes` and `ValidateOnBuild` stop catching anything; and a factory registration
+cannot say what implementation it built, which is what per-implementation wrapping needs. Both are in
+[MSBuild properties](/reference/msbuild#generatefactories-and-container-validation).
 
 ## Next
 

--- a/website/guide/testing-mocking.md
+++ b/website/guide/testing-mocking.md
@@ -218,21 +218,56 @@ registers it, so the service under test gets the real implementation and your se
 nobody can see.
 :::
 
-## What wins when two things register the same service
+## What wins when two things register the same service {#precedence}
 
-The order is fixed, so it does not depend on how you declare the attributes:
+**The narrowest declaration decides.** `[Mock]` sits on a parameter and names one argument;
+`[TestExport]` applies to a method, a class or an assembly. So a `[Mock]` parameter overrides a
+`[TestExport]` naming the same service, and that is the shape having both is for — the class sets the
+default and one test opts out:
 
-1. **`[Mock]` parameters** register their doubles first.
-2. **Mock support** registers the `Mock<T>` pairs, settling any disagreement with step 1 — which is
-   what lets `[Mock] IFoo` and `Mock<IFoo>` resolve to a matched pair rather than two unrelated
-   mocks.
-3. **`[TestExport]`** and other setup attributes run last, so a
-   [`[TestExport]`](/guide/testing#when-you-want-a-real-object-not-a-mock) naming a real
-   implementation of the same service overrides both.
+```csharp
+[TestExport(typeof(IClock), Implementation = typeof(SystemClock))]   // the fixture default
+public class ExpiryTests {
 
-Registrations are last-one-wins, so that ordering is the whole rule. If you want a real object rather
-than a mock for one service in one test, `[TestExport]` gets it regardless of what is mocked around
-it.
+    [ModuleTest]
+    public void UsesTheRealClock(IClock clock) { }                   // SystemClock
+
+    [ModuleTest]
+    public void Expires([Mock] IClock clock) { }                     // the mock
+}
+```
+
+Written on the **same method** the two are contradictory rather than useful — the parameter wins and
+the `[TestExport]` beside it does nothing — so that is
+[DM0021](/reference/diagnostics#dm0021).
+
+`Mock<T>` deliberately does not get this. Asking for the mock object is not the same as declaring the
+service mocked, so a `[TestExport]` still beats it:
+
+```csharp
+[ModuleTest]
+[TestExport(typeof(IClock), Implementation = typeof(SystemClock))]
+public void RealClock(IClock clock, Mock<IClock> mock) {
+    Assert.IsType<SystemClock>(clock);      // the export won
+}
+```
+
+Underneath, registrations are last-one-wins and the order is fixed:
+
+1. **Mock support** registers the `Mock<T>` pairs.
+2. **`[TestExport]`** and other setup attributes.
+3. **`[Mock]` parameters**, last — which is what makes them win.
+
+A `[Mock]` stands aside for a type the mock library registers itself, which is what keeps
+`[Mock] IFoo` and `Mock<IFoo>` on one test resolving to a matched pair rather than two unrelated
+mocks.
+
+::: warning This changed in 1.2.0
+Before 1.2.0 `[TestExport]` won everywhere, including for a `[Mock]`-decorated parameter — so a test
+declaring `[Mock] IFoo` alongside a `[TestExport]` for `IFoo` silently held the real implementation,
+and the first arrange line threw a mocking-library error naming neither attribute. If you were
+relying on that, drop the `[Mock]`.
+:::
 
 ## When not to mock
 

--- a/website/guide/testing-xunit.md
+++ b/website/guide/testing-xunit.md
@@ -24,6 +24,19 @@ public class WeatherTests {
 Requires **xUnit v3**. `[ModuleTest]` derives from `FactAttribute` and is discovered through xUnit's
 own test case discoverer, so it is a fact as far as the rest of xUnit is concerned.
 
+::: warning `dotnet new xunit` gives you v2
+The template still creates an xUnit **v2** project — package `xunit`, not `xunit.v3` — and this
+integration cannot use it at all. Start from `dotnet new xunit3`, or replace the reference:
+
+```xml
+<PackageReference Include="xunit.v3" Version="3.2.2" />
+```
+
+Supported range is `[3.2.2, 4.0.0)`. xUnit 4.0.0 changed a discovery API this package binds to, so
+combining them fails at test discovery with a `MissingMethodException` naming an xUnit internal
+rather than this package. From 1.2.0 the dependency is bounded, so NuGet says so at restore instead.
+:::
+
 ## `[ModuleTest]` replaces `[Fact]`
 
 It replaces `[Theory]` as well. A module test with data attributes on it produces one test case per
@@ -87,6 +100,21 @@ point of it. The rest are resolved from the container.
 
 Each row is a separate test case with its own container, so state cannot carry from one row to the
 next.
+
+::: warning xUnit's analyzer objects to the shape
+`xUnit1037` counts a row's arguments against the method's parameters and finds them short, because to
+xUnit a row is meant to supply all of them. Under `[ModuleTest]` the shortfall is the feature. Silence
+it where you use it:
+
+```csharp
+#pragma warning disable xUnit1037
+```
+
+Also worth knowing: before 1.2.0, `[MemberData]` under `[ModuleTest]` produced **zero** test cases and
+the run reported a pass. `[MemberData(nameof(Cases), MemberType = typeof(MyTests))]` was the shape
+that worked. Both work now, and a row source that yields nothing is a failure rather than a silent
+green.
+:::
 
 `TheoryDataRow`'s own metadata is honoured per row, so a single row can skip or carry its own traits:
 

--- a/website/guide/testing.md
+++ b/website/guide/testing.md
@@ -112,6 +112,13 @@ namespace, and an assembly-level attribute has no namespace context to inherit �
 build fails with `CS0246: The type or namespace name 'ApplicationModuleAttribute' could not be
 found`, naming a type you never wrote. Importing the namespace or writing the attribute qualified,
 `[assembly: MyApp.Tests.ApplicationModule]`, both work.
+[DM0016](/reference/diagnostics#dm0016) reports it and names the namespace to import, for a module
+declared here or one from a referenced package.
+
+A test project has no entry point, so [DM0019](/reference/diagnostics#dm0019) — which reports an
+assembly-level module attribute in the wrong file — stays quiet here. That is deliberate: assembly
+attributes are read at run time by the test integration, and a file of their own is exactly where
+they belong.
 
 Every test in the project now gets `ApplicationModule` without saying so:
 

--- a/website/guide/troubleshooting.md
+++ b/website/guide/troubleshooting.md
@@ -97,9 +97,12 @@ used, defaulting to `"Production"`. See
 **An assertion on the concrete type fails.** An [intercepted](/guide/interception) or
 [decorated](/guide/decorators) service resolves as the wrapper, not your class.
 
-**`AddModule` called more than once.** Modules compose through
-[attributes](/guide/modules#composing-modules); calling `AddModule` inside a module, or several times
-at the root, duplicates registrations.
+**`AddModule` called more than once.** Calling it inside a module, or several times at the root,
+duplicates registrations.
+
+**Two modules declared in one project, both loaded.** Each holds that project's whole registration
+list, so loading both applies it twice — and composing one into the other does not help, since both
+still hold everything. Give one a [realm](/guide/modules#realms-keeping-a-registration-out-of-the-default-module).
 
 ## Reporting a problem
 

--- a/website/reference/attributes.md
+++ b/website/reference/attributes.md
@@ -40,6 +40,12 @@ Registers the class, or a static factory method, with that lifetime.
 | `Key` | a service key |
 | `Using` | `Add`, `Try`, `TryEnumerable` or `Replace` |
 | `Realm` | scope the registration to one module |
+| `Order` | where this registration sits among the others for the same service, lowest first |
+
+`Order` decides the sequence an `IEnumerable<T>` dependency arrives in, which is what a pipeline of
+validators or handlers reads. It decides a plain `GetService<T>()` too, since the container returns
+the last registration — so the highest order wins that. Everything is `0` by default and the sort is
+stable within one order, so naming an order for some services leaves the rest where they were.
 
 ### `[CrossWireService]`
 
@@ -61,6 +67,7 @@ A `[Decorator]` is never a convention candidate — it is not a service.
 | `Order` | nesting; lower sits closer to the implementation |
 | `Service` | the decorated interface, when it cannot be inferred |
 | `Realm` | restrict the decorator to one module, matching `Realm` on the service attributes |
+| `Implementation` | decorate one implementation rather than every registration of the service |
 
 An unrestricted decorator belongs to every module that is not `OnlyRealm`, exactly as an unrestricted
 service registration does — so a decorator with no `Realm` is not picked up by an `OnlyRealm` module.
@@ -73,6 +80,22 @@ Wraps a service so every call through its interface passes through the given int
 |---|---|
 | `Service` | the interface to intercept, when the service implements more than one |
 | `Order` | nesting relative to decorators and other interceptors |
+| `Realm` | restrict the interception to one module, matching `Realm` on the service attributes |
+| `Lifetime` | how the interceptors are registered. `Singleton` by default |
+| `Members` | which kinds of member to cover. Everything by default |
+
+An interception applies to **the one implementation it was declared on**, not to every class behind
+the interface — a sibling implementation carrying no `[Intercept]` is left alone. Decorators are the
+other way round, and deliberately so.
+
+With no `Realm` the interception takes the one its own class's service attribute names, so
+`[SingletonService(Realm = typeof(X))]` and a plain `[Intercept]` agree without being told to. Naming
+a realm explicitly still wins. An interception no module ends up applying is
+[DM0020](/reference/diagnostics#dm0020).
+
+`Members` takes `InterceptedMembers.Methods`, `.Properties`, `.Indexers`, `.Events` or any
+combination. A member left out is still forwarded — the wrapper implements the whole interface either
+way — it just does not run through the chain. See [Interception](/guide/interception).
 
 ## Environment conditions
 

--- a/website/reference/diagnostics.md
+++ b/website/reference/diagnostics.md
@@ -4,8 +4,8 @@ The generator reports what it can work out at build time as `DM####` codes, so a
 shows up in the IDE rather than as a resolution failure at startup. This page says what each one
 means and what to do about it.
 
-These are reported by a source generator rather than by an analyzer. **Silencing one works both
-ways** — through the compilation-level properties, and through `.editorconfig`:
+These are reported by a source generator rather than by an analyzer, and every way of silencing one
+works. Across a project:
 
 ```xml
 <PropertyGroup>
@@ -15,12 +15,29 @@ ways** — through the compilation-level properties, and through `.editorconfig`
 ```
 
 ```ini
-# .editorconfig — silences it, including the Error-severity codes
+# .editorconfig — including the Error-severity codes
 [*.cs]
 dotnet_diagnostic.DM0019.severity = none
 ```
 
-`#pragma warning disable DM0005` works too, for silencing one site rather than a project.
+Or at one site, which is usually what you want:
+
+```csharp
+#pragma warning disable DM0018
+[DependencyModule]
+public partial class CacheModule { public int SizeLimit { get; set; } }
+#pragma warning restore DM0018
+```
+
+::: warning `.editorconfig` and `#pragma` did not work before 1.2.0
+For most codes, in 1.0.0 and 1.1.0, only `NoWarn` and `WarningsAsErrors` had any effect. A diagnostic
+carried its file and line but was not attached to the syntax tree, and Roslyn decides both
+`.editorconfig` severity and `#pragma` filtering from the tree.
+
+The 1.1.0 release notes said `.editorconfig` worked. It worked for `DM0016` and `DM0019` and nothing
+else — and that release is what broke it, by moving ten diagnostics from the project onto the
+declaration they are about. Both mechanisms reach every code from 1.2.0.
+:::
 
 **Raising a severity is the part `.editorconfig` cannot do.** A generator's diagnostics reach the
 compilation with their severity already fixed, and Roslyn's severity *mapping* applies to analyzer
@@ -52,6 +69,9 @@ verbosity. The rest are worth reading.
 | [DM0017](#dm0017) | Error | A module is declared inside another type |
 | [DM0018](#dm0018) | Warning | A module with parameters relies on generated equality |
 | [DM0019](#dm0019) | Error | An assembly-level module attribute is outside the entry point file |
+| [DM0020](#dm0020) | Warning | An interception is applied by no module |
+| [DM0021](#dm0021) | Warning | `[Mock]` and `[TestExport]` name one service on the same method |
+| [DM0022](#dm0022) | Warning | A decorator names an implementation while factories are generated |
 
 ## DM0001 {#dm0001}
 
@@ -255,6 +275,10 @@ that message points away from the fix, which is one line:
 using MyApp.Composition;          // or write it as [assembly: MyApp.Composition.ApplicationModule]
 ```
 
+A module in a referenced package is covered too: its attribute is already in metadata by the time
+this runs, so it can be found there. What cannot be resolved is a module in *this* compilation —
+its attribute is written by the generator that is running, so nothing about it exists yet to look up.
+
 Unlike the other diagnostics here this one is read from syntax rather than from the compiler's view
 of your code, and it has to be: the attribute is written by the generator that is running, so it does
 not exist in the compilation being examined and nothing about it can be resolved. The check is
@@ -353,7 +377,100 @@ using MyApp.Library;
 Move it to the file holding the entry point, or load the module explicitly with
 `services.AddModule<LibraryModule>()`.
 
+The module can live anywhere — this compilation or a referenced package. Before 1.2.0 only a module
+declared in the same project was checked, so the shape above, which is the one worth catching,
+reported nothing.
+
 This stays quiet when nothing generated an `ApplicationModule`. A class library has no entry point,
 and neither does a test project — where assembly-level module attributes are read at *run time* by
 the test integration and are perfectly at home in a file of their own, which is the shape
 [Testing](/guide/testing#stop-repeating-the-module-list) shows.
+
+## DM0020 {#dm0020}
+
+**An interception is applied by no module, so it never runs.**
+
+Registrations and interceptions are placed by the same rule — named a realm, it belongs to that
+module; named none, it belongs to every module that is not `OnlyRealm`. The wrapper is generated
+either way, so an interception no module applies is a class nothing ever routes through.
+
+The case that reaches here is a realm-only module registering the class *by convention*:
+
+```csharp
+[Intercept(typeof(AuditInterceptor))]           // DM0020 — no realm named
+public class Greeter : IGreeter { … }
+
+[DependencyModule(OnlyRealm = true)]
+public partial class GreetingModule : IConventionModule {
+    void IConventionModule.Conventions(IConventionDefinitions conventions) =>
+        conventions.RegisterAll<IGreeter>().AsSingleton();
+}
+```
+
+A convention registration is stamped with its declaring module's realm when the convention is
+matched, which is long after the interception was read. So the registration lands in
+`GreetingModule` and the interception is offered only to modules that are *not* realm-only — of
+which there are none here.
+
+Name the module and the two meet:
+
+```csharp
+[Intercept(typeof(AuditInterceptor), Realm = typeof(GreetingModule))]
+```
+
+An interception on a class registered by a *service attribute* needs none of this: it takes the realm
+from that attribute automatically, so `[SingletonService(Realm = typeof(X))]` and a plain
+`[Intercept]` agree without being told to. See [Interception](/guide/interception#realms).
+
+## DM0021 {#dm0021}
+
+**`[Mock]` and `[TestExport]` name one service on the same test method.**
+
+A parameter attribute names one argument, which is the narrowest thing a test can say, so `[Mock]`
+wins and the `[TestExport]` beside it does nothing:
+
+```csharp
+[ModuleTest]
+[TestExport(typeof(IClock), Implementation = typeof(SystemClock))]
+public void Expires([Mock] IClock clock) { }        // DM0021 — the export does nothing
+```
+
+Only on the same method. `[TestExport]` on the class or the assembly is a default for everything
+under it, and one test overriding that for one argument is what having both scopes is for:
+
+```csharp
+[TestExport(typeof(IClock), Implementation = typeof(SystemClock))]   // the fixture default
+public class ExpiryTests {
+
+    [ModuleTest]
+    public void UsesTheRealClock(IClock clock) { }                   // SystemClock
+
+    [ModuleTest]
+    public void Expires([Mock] IClock clock) { }                     // the mock — no diagnostic
+}
+```
+
+See [Mocking frameworks](/guide/testing-mocking#precedence).
+
+## DM0022 {#dm0022}
+
+**A decorator names an implementation while factories are generated.**
+
+Reaching one registration of a service means asking each descriptor what implementation it was built
+from, and a factory registration cannot say. `DependencyModules_GenerateFactories` makes every
+registration factory-built, so the decorator would wrap *all* of them — the opposite of what naming
+one asked for.
+
+```csharp
+[Decorator(Implementation = typeof(SmtpSender))]   // DM0022 when factories are on
+public class RetryingSender(IEmailSender inner) : IEmailSender { … }
+```
+
+Turn the property off for this project, or drop `Implementation` and decorate them all.
+
+An *intercepted* service escapes the property automatically — the interception is declared on the
+class being registered, so the code emitting that registration can see it and keeps a `typeof`
+registration for it. A decorator is declared on the decorator, so the registration it targets is
+written by a pass that never learns about it. See
+[MSBuild properties](/reference/msbuild#generatefactories-and-container-validation).
+

--- a/website/reference/interfaces.md
+++ b/website/reference/interfaces.md
@@ -1,0 +1,90 @@
+# Runtime interfaces
+
+`DependencyModules.Runtime.Interfaces` holds the contracts the generated code implements and calls.
+Most projects never name one — the attributes are the surface you write against — but they turn up in
+three places: a compiler error naming a type you did not write, a generated file you opened to see
+what happened, and the seam you implement when an attribute cannot express something.
+
+They are covered by the [semantic versioning promise](https://semver.org/spec/v2.0.0.html): none of
+them breaks within 1.x.
+
+## `IDependencyModule`
+
+What every module is. The generator implements it on the partial class you declared, so you never
+write it yourself — but it is the constraint on `AddModule<TModule>()`, which is why it shows up in
+an error when a module did not get generated:
+
+```
+error CS0311: The type 'ApplicationModule' cannot be used as type parameter 'T' … no implicit
+reference conversion from 'ApplicationModule' to 'IDependencyModule'.
+```
+
+That message means the generator did not complete your class. The usual causes each have a
+diagnostic beside them — the module is not `partial`
+([DM0003](/reference/diagnostics#dm0003)), or it is nested inside another type
+([DM0017](/reference/diagnostics#dm0017)).
+
+## `IDependencyModuleProvider`
+
+What a module's **generated attribute** implements. `[DataModule]` on another module is an instance
+of `DataModuleAttribute`, and this is how the runtime gets a module out of it.
+
+You do not implement this. It is worth knowing because it is what makes a module attribute
+recognisable in a referenced package — which is how [DM0016](/reference/diagnostics#dm0016) and
+[DM0019](/reference/diagnostics#dm0019) find a module that came from a NuGet package rather than from
+your own project.
+
+## `IServiceCollectionConfiguration`
+
+The escape hatch for registration an attribute cannot express — `AddHttpClient()`, options binding,
+anything that is a method call rather than a class you own. Implement it on a module and the generator
+calls it alongside the registrations it wrote:
+
+```csharp
+[DependencyModule]
+public partial class ApplicationModule : IServiceCollectionConfiguration {
+    public void ConfigureServices(IServiceCollection services) {
+        services.AddHttpClient();
+        services.Configure<CacheOptions>(options => options.SizeLimit = 1024);
+    }
+}
+```
+
+It is also how you extend a module the generator wrote for you. A project with top-level statements
+gets an `ApplicationModule` it did not declare; adding a partial for it **without**
+`[DependencyModule]` and implementing this interface merges into that module rather than colliding
+with it:
+
+```csharp
+public partial class ApplicationModule : IServiceCollectionConfiguration {
+    public void ConfigureServices(IServiceCollection services) =>
+        services.AddHttpClient();
+}
+```
+
+See [Modules](/guide/modules#when-attributes-are-not-enough).
+
+## `IModuleEnvironment`
+
+What [`[IfEnvironment]`](/guide/environments) is evaluated against. `ModuleEnvironment` implements it,
+and `AddModules` takes one:
+
+```csharp
+services.AddModules(new ModuleEnvironment("Development"), new ApplicationModule());
+```
+
+Implement it yourself when the environment is not a name from `DOTNET_ENVIRONMENT` — a feature flag
+service, or a configuration section.
+
+## Where they live
+
+All of them are in `DependencyModules.Runtime`, which is the package you already reference:
+
+```csharp
+using DependencyModules.Runtime.Interfaces;
+```
+
+The interception contracts — `IInterceptor`, `IAsyncInterceptor`, `IAsyncEnumerableInterceptor` — are
+in `DependencyModules.Runtime.Interception` instead, and are covered in
+[Interception](/guide/interception). The convention contracts are in
+`DependencyModules.Runtime.Conventions`; see the [Convention API](/reference/conventions-api).

--- a/website/reference/msbuild.md
+++ b/website/reference/msbuild.md
@@ -57,3 +57,20 @@ checked at build either, so it throws on first resolve instead.
 The property exists for startup cost and for Native AOT, which is exactly the setting a team turns on
 late and everywhere. If you rely on `ValidateScopes` and `ValidateOnBuild` in development — and the
 standard advice is to — keep this off there and turn it on for the published build.
+
+## `GenerateFactories` and per-implementation wrapping
+
+A factory registration cannot say what implementation it built, and that is how
+[interception](/guide/interception) finds the one registration to wrap. In 1.1.0 the filter therefore
+matched nothing under this property and interception went back to wrapping every registration of the
+service type — an unmarked sibling came back inside another class's wrapper, and interceptors ran
+once per registration.
+
+From 1.2.0 a service any implementation intercepts keeps its `typeof` registration whatever this
+property says. It costs those services the property's benefit and nothing else — the wrapper around
+them is still emitted as a literal `new`, and `typeof` is the shape every registration has with the
+property off, which is what Native AOT already runs. Nothing to configure.
+
+The same limit reaches `[Decorator(Implementation = …)]`, and there it cannot be worked around the
+same way: the decorator is declared on the decorator, so the pass writing the registration it targets
+never learns about it. That combination is [DM0022](/reference/diagnostics#dm0022).


### PR DESCRIPTION
Four agents built four applications against the **published** 1.1.0 packages and filed
`reports/00-FULL-REPORT-1.1.0.md`. Every core fix in 1.1.0 held up under runtime assertion — the
lifetime fix, per-implementation interception, `OnlyRealm` isolation, module property defaults, the
ten relocated diagnostics, and Native AOT at 2.6 MB / 6 ms cold. This is everything that did not.

## Blockers for anyone adopting today

- **`DependencyModules.xUnit` could not resolve against the `xunit.v3` a new user installs.** The
  dependency had no upper bound, `dotnet add package xunit.v3` resolves 4.0.0, and 4.0.0 removed the
  discovery API the compiled discoverer binds to. Every test failed at discovery with a
  `MissingMethodException` naming an xUnit internal. Now bounded, so NuGet says so at restore.
- **`[MemberData]` under `[ModuleTest]` produced zero test cases and reported a pass.** Not an arity
  bug, as filed — the discoverer bypasses `IXunitTestMethod.DataAttributes`, so xUnit never
  back-fills `MemberType`, and `MemberDataAttributeBase` returns *empty* rather than throwing. Zero
  rows is now a failure, which is the half that stops the next one being invisible.

## Fixed

`.editorconfig` and `#pragma` silenced nothing for 16 of 18 codes — and 1.1.0 shipped a
*documentation correction* claiming they worked. 1.1.0 is also what broke it, by relocating ten
diagnostics onto locations with no syntax tree. All three mechanisms now reach every code.

`GenerateFactories` undid both 1.1.0 interception fixes. `DM0016`/`DM0019` never fired for a module
from a package, which is the case they exist for. A realm-scoped service with an unrealmed
`[Intercept]` was never intercepted. A private module property emitted uncompilable code. Declaring
`ApplicationModule` where one is already generated produced `CS8785` + `CS0311`.

**One defect nobody filed:** `[Intercept]` was matched by its written name, so a qualified or aliased
usage was silently ignored — the same bug 1.1.0 fixed for the service attributes and did not carry
across.

## Added

`[Intercept(Lifetime = …)]`, `[Intercept(Members = …)]`, `[Decorator(Implementation = …)]`, `Order`
on the service attributes, and `DM0020`–`DM0022`.

## Corrections worth reading

**Two of the report's findings were withdrawn as correct-by-design**, and both came from behaviour
the docs did not state — including one I initially "fixed" before being corrected. Both gaps are now
documented.

**Two filed findings were one bug.** T2-2 and T2-3 are a single divergence between the registration
and interception realm filters, filed separately by different agents against different applications.
The report recommends a diagnostic; a fix was available instead.

## Behaviour change

A `[Mock]` parameter now overrides a `[TestExport]` naming the same service. On the same method that
pair is contradictory and reports `DM0021`; from a class or assembly it is the default being
overridden for one test. Anyone relying on the old precedence gets the mock now.

## Not built

`docs/design/dispatch-by-name.md` and `docs/design/runtime-module-graph.md` — both public surface
that cannot be taken back inside 1.x. Dispatch-by-name is the round's strongest signal: two
applications hand-built the same per-request dictionary, neither author knowing about the other.

## Gates

898 unit, 151 + 34 integration, Release build clean at zero warnings, `verify-packages.sh` green on
net8.0 and net10.0, coverage 90.5% against the 85% threshold, and the docs build (which is the
internal link checker).

## Note on scope

This branch is based on local `main`, which was 3 commits ahead of `origin/main` when I started — the
1.1.0 release commits. Those three appear in this PR's range and are not part of this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XC2QjeviPfpj29tty2KyXL
