### PR TITLE
Give the interceptor wrapper its real namespace, and date 1.2.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `InterceptorFileWriter.Write` (in the source-shipped `DependencyModules.SourceGenerator.Impl`
   seam) takes the configuration model as a fourth parameter, so the wrapper file honors
   `GeneratedCodeStyle`. A framework calling it directly passes its configuration through.
+- The interceptor wrapper's self-reference is built with its real namespace, and its closed-over
+  type parameters as `TypeParameterDefinition`, instead of empty-namespace `TypeDefinition`s that
+  leaned on CSharpAuthor rendering them bare. Under the published package the only visible change
+  is a fully qualified self-reference in wrapper files; under the upcoming CSharpAuthor fix that
+  qualifies global-namespace types in `Global` mode (its migration note B13), the old spelling
+  would have rendered `global::Worker_Intercepted` for a type that lives in the module's
+  namespace.
 
 ## [1.2.0] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,35 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- A `GeneratedCodeStyle` MSBuild property choosing the brace style of every generated file:
-  `Allman` (the default, and what every prior version emitted) or `KAndR`. The name carries no
-  `DependencyModules_` prefix on purpose — it is shared with other source generators, so one csproj
-  line styles all of them. An unrecognized value falls back to `Allman`.
-
-### Changed
-
-- CSharpAuthor 1.1.1010 → 2.0.0-preview1004. Generated files change in two mechanical ways:
-  attributes are now written `global::`-qualified, so a type a consumer adds later can never
-  collide with them, and the `using` directives 1.x derived from already-qualified type references
-  are gone. Method bodies are unchanged. The upgrade also surfaced — and this release fixes — a
-  double-quoting bug in string-array attribute arguments, which 1.x rendered as `""a""`: not valid
-  C#, and never caught because nothing compiled that path.
-- `InterceptorFileWriter.Write` (in the source-shipped `DependencyModules.SourceGenerator.Impl`
-  seam) takes the configuration model as a fourth parameter, so the wrapper file honors
-  `GeneratedCodeStyle`. A framework calling it directly passes its configuration through.
-- The interceptor wrapper's self-reference is built with its real namespace, and its closed-over
-  type parameters as `TypeParameterDefinition`, instead of empty-namespace `TypeDefinition`s that
-  leaned on CSharpAuthor rendering them bare. Under the published package the only visible change
-  is a fully qualified self-reference in wrapper files; under the upcoming CSharpAuthor fix that
-  qualifies global-namespace types in `Global` mode (its migration note B13), the old spelling
-  would have rendered `global::Worker_Intercepted` for a type that lives in the module's
-  namespace.
-
-## [1.2.0] - 2026-08-27
+## [1.2.0] - 2026-08-28
 
 Four applications built against the published 1.1.0 packages, by four agents who did not read each
 other's work. Every fix 1.1.0 shipped held up under runtime assertion. What did not hold up was
@@ -50,6 +22,10 @@ See [Mocking frameworks](https://ipjohnson.github.io/DependencyModules/guide/tes
 Three new diagnostics arrive, all warnings, so `TreatWarningsAsErrors` may turn a green build red on
 code that was quietly doing nothing. Every one of them can be silenced where it is written — which
 is itself new, and the subject of the first entry below.
+
+Separately from the round, generation moves to CSharpAuthor 2.0 and gains a `GeneratedCodeStyle`
+property choosing the brace style of generated files. Generated code changes in mechanical ways —
+no method body is different — and the *Changed* entries carry the details.
 
 ### Fixed
 
@@ -156,6 +132,11 @@ is itself new, and the subject of the first entry below.
   generator emitted them, sorted by class name — renaming a class reordered a pipeline. Everything
   defaults to `0` and the sort is stable within one order.
 
+- **A `GeneratedCodeStyle` MSBuild property** choosing the brace style of every generated file:
+  `Allman` (the default, and what every prior version emitted) or `KAndR`. The name carries no
+  `DependencyModules_` prefix on purpose — it is shared with other source generators, so one csproj
+  line styles all of them. An unrecognized value falls back to `Allman`.
+
 - **`DM0020`** reports an interception no module applies, so it can never run. The case it catches is
   a realm-only module registering the class by convention, where the realm is decided at match time
   and an interception cannot inherit it.
@@ -165,6 +146,27 @@ is itself new, and the subject of the first entry below.
 
 - **`DM0022`** reports a decorator naming an implementation in a project emitting factories, where it
   would wrap all of them instead of one.
+
+### Changed
+
+- **CSharpAuthor 1.1.1010 → 2.0.0-preview1004.** Generated files change in two mechanical ways:
+  attributes are now written `global::`-qualified, so a type a consumer adds later can never
+  collide with them, and the `using` directives 1.x derived from already-qualified type references
+  are gone. Method bodies are unchanged. The upgrade also surfaced — and this release fixes — a
+  double-quoting bug in string-array attribute arguments, which 1.x rendered as `""a""`: not valid
+  C#, and never caught because nothing compiled that path.
+
+- **`InterceptorFileWriter.Write` takes the configuration model as a fourth parameter** (in the
+  source-shipped `DependencyModules.SourceGenerator.Impl` seam), so the wrapper file honors
+  `GeneratedCodeStyle`. A framework calling it directly passes its configuration through.
+
+- **The interceptor wrapper's self-reference is built with its real namespace**, and its closed-over
+  type parameters as `TypeParameterDefinition`, instead of empty-namespace `TypeDefinition`s that
+  leaned on CSharpAuthor rendering them bare. Under the published package the only visible change
+  is a fully qualified self-reference in wrapper files; under the upcoming CSharpAuthor fix that
+  qualifies global-namespace types in `Global` mode (its migration note B13), the old spelling
+  would have rendered `global::Worker_Intercepted` for a type that lives in the module's
+  namespace.
 
 ### Documentation
 

--- a/src/DependencyModules.SourceGenerator.Impl/InterceptorFileWriter.cs
+++ b/src/DependencyModules.SourceGenerator.Impl/InterceptorFileWriter.cs
@@ -59,7 +59,7 @@ public class InterceptorFileWriter {
 
         for (var index = 0; index < model.Members.Count; index++) {
             if (IsIntercepted(model, model.Members[index])) {
-                WriteState(wrapper, model, model.Members[index], index, wrapperName);
+                WriteState(wrapper, model, model.Members[index], index, wrapperName, namespaceName);
             }
         }
 
@@ -102,7 +102,9 @@ public class InterceptorFileWriter {
         var arguments = new ITypeDefinition[typeParameters.Count];
 
         for (var i = 0; i < arguments.Length; i++) {
-            arguments[i] = TypeDefinition.Get("", typeParameters[i].Name);
+            // A TypeParameterDefinition, not TypeDefinition.Get("", name): an empty namespace now
+            // means the global namespace, which Global mode qualifies - and global::T is not a type.
+            arguments[i] = new TypeParameterDefinition(typeParameters[i].Name);
         }
 
         return new GenericTypeDefinition(
@@ -117,10 +119,10 @@ public class InterceptorFileWriter {
     /// <c>Repository_Intercepted&lt;T&gt;</c> the name is <c>Repository_Intercepted&lt;T&gt;</c>, and
     /// the bare name is CS0305.
     /// </remarks>
-    private static ITypeDefinition SelfType(InterceptorModel model, string wrapperName) =>
+    private static ITypeDefinition SelfType(InterceptorModel model, string wrapperName, string namespaceName) =>
         model.IsOpenGeneric
-            ? Closed(TypeDefinition.Get("", wrapperName), model.TypeParameters!)
-            : TypeDefinition.Get("", wrapperName);
+            ? Closed(TypeDefinition.Get(namespaceName, wrapperName), model.TypeParameters!)
+            : TypeDefinition.Get(namespaceName, wrapperName);
 
     /// <summary>
     /// The constraints a member declares, which both the forwarding member and its state class have
@@ -421,7 +423,8 @@ public class InterceptorFileWriter {
         InterceptorModel model,
         InterceptedMemberModel member,
         int index,
-        string wrapperName) {
+        string wrapperName,
+        string namespaceName) {
 
         var baseType = member.Kind switch {
             InterceptorKind.Async => Interception.AsyncInvocationState(member.ResultType),
@@ -440,7 +443,7 @@ public class InterceptorFileWriter {
 
         WriteConstraints(member, state.AddConstraint);
 
-        var selfType = SelfType(model, wrapperName);
+        var selfType = SelfType(model, wrapperName, namespaceName);
 
         WriteStateFields(state, member, selfType);
         WriteStateConstructor(state, member, index, selfType);


### PR DESCRIPTION
Two commits finishing the 1.2.0 release.

The first is the follow-up to #44 that was sitting on the branch: the interceptor
wrapper's self-reference is built with its real namespace and its type parameters as
`TypeParameterDefinition`, instead of empty-namespace `TypeDefinition`s that leaned on
CSharpAuthor rendering them bare. Visible today as a fully qualified self-reference in
wrapper files; correct tomorrow when CSharpAuthor starts qualifying global-namespace
types (its migration note B13).

The second folds the `[Unreleased]` changelog entries — CSharpAuthor 2.0,
`GeneratedCodeStyle`, and the wrapper change above — into the `[1.2.0]` section and
dates it 2026-08-28. 1.2.0 was cut on the 27th and never tagged; nothing between
v1.1.0 and here has shipped, so it all goes out as one release.

Verified locally with the release workflow's own gates: Release build clean, coverage
90.6% against the 85% threshold, `verify-packages.sh 1.2.0` green for net8.0 and
net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ysVAfsbKMfGBaAkWvuRTf