### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.1] - 2026-08-28
 
 ### Added
 
 - A logo: a D assembled from four modules, one carrying the accent. It replaces the placeholder
   favicon on the docs site, appears in the site nav (light and dark cuts), heads the README, and
-  ships as the `PackageIcon` on every package from the next release on. The violet is `#6d5bd5`,
+  ships as the `PackageIcon` on every package from this release on. The violet is `#6d5bd5`,
   the color the docs site already declared.
 
 ## [1.2.0] - 2026-08-28

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
         local and CI builds fall back to the values below.
     -->
     <PropertyGroup>
-        <VersionPrefix>1.2.0</VersionPrefix>
+        <VersionPrefix>1.2.1</VersionPrefix>
         <!--
             Empty at 1.0.0. Set it again to cut a prerelease of the next version; the file version
             carries no prerelease part, so it stays put until the version it does carry changes.
@@ -22,7 +22,7 @@
             depend on. It moves at 2.0.0.
         -->
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <FileVersion>1.2.0.0</FileVersion>
+        <FileVersion>1.2.1.0</FileVersion>
     </PropertyGroup>
 
     <!--


### PR DESCRIPTION
Cuts 1.2.1 — the release that puts the logo on nuget.org.

A package icon is shown per published version and 1.2.0 is immutable, so the
`PackageIcon` that landed with #46 needs a release to appear on the package pages.
This PR is version and changelog only: `VersionPrefix`/`FileVersion` to 1.2.1, and the
`[Unreleased]` logo entry folded into a dated `[1.2.1]` section. `AssemblyVersion`
stays pinned at 1.0.0.0 for all of 1.x, as documented in Directory.Build.props.

After merge: tag `v1.2.1` on main triggers the release workflow (build, tests,
coverage gate, package verification, publish to nuget.org and GitHub Packages,
GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ysVAfsbKMfGBaAkWvuRTf