### PR TITLE
Put the logo beside the README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# DependencyModules
-
-<img align="right" width="110" src="https://raw.githubusercontent.com/ipjohnson/DependencyModules/main/assets/icon.png" alt="DependencyModules logo: a letter D assembled from four modules">
+# <img src="https://raw.githubusercontent.com/ipjohnson/DependencyModules/main/assets/icon.png" alt="" width="48"> DependencyModules
 
 [![NuGet](https://img.shields.io/nuget/v/DependencyModules.Runtime.svg)](https://www.nuget.org/packages/DependencyModules.Runtime/)
 [![build](https://github.com/ipjohnson/DependencyModules/actions/workflows/build-package.yaml/badge.svg)](https://github.com/ipjohnson/DependencyModules/actions/workflows/build-package.yaml)


### PR DESCRIPTION
Follow-up to #48 — this commit was pushed to that branch moments after the merge, so it
rides again here. The mark moves from a right-floated image to inline in the h1, left of
the name, at 48px. Empty alt on purpose: the title text follows immediately, so the image
is decorative.

Note for review: the image URL points at `main`, which now serves the corrected icon, so
the preview here renders the final look (modulo a few minutes of raw.githubusercontent
CDN cache). nuget.org strips raw HTML from READMEs, so the logo does not appear there —
the package pages get the mark through `PackageIcon`.

**Not merging — that's yours.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ysVAfsbKMfGBaAkWvuRTf