### PR TITLE
Release 1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,19 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.2] - 2026-08-28
 
 ### Fixed
 
-- The package icon is now the logo as chosen: ink structure with the violet module on white.
-  1.2.1 shipped a white-on-violet tile cut that was never the agreed colorway. The icon on
-  nuget.org updates with the next published version; the README picks the fix up on merge.
+- The package icon is now the logo as chosen: a solid D of four modules — ink structure, the
+  violet module — on white, with the glyph properly centered in the tile. 1.2.1 shipped a
+  white-on-violet tile cut that was never the agreed colorway.
+
+### Documentation
+
+- The README header carries the mark beside the title: theme-aware via `<picture>`, referenced
+  by relative path so branch views render it, and aligned against GitHub's actual rendering
+  geometry rather than a local approximation.
 
 ## [1.2.1] - 2026-08-28
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
         local and CI builds fall back to the values below.
     -->
     <PropertyGroup>
-        <VersionPrefix>1.2.1</VersionPrefix>
+        <VersionPrefix>1.2.2</VersionPrefix>
         <!--
             Empty at 1.0.0. Set it again to cut a prerelease of the next version; the file version
             carries no prerelease part, so it stays put until the version it does carry changes.
@@ -22,7 +22,7 @@
             depend on. It moves at 2.0.0.
         -->
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <FileVersion>1.2.1.0</FileVersion>
+        <FileVersion>1.2.2.0</FileVersion>
     </PropertyGroup>
 
     <!--


### PR DESCRIPTION
Cuts 1.2.2 — the release that puts the corrected icon on the nuget.org package pages.

Version and changelog only: `VersionPrefix`/`FileVersion` to 1.2.2, and the
`[Unreleased]` entries folded into a dated `[1.2.2]` section. The substance shipped in
#48–#50 (icon as chosen and centered; README header aligned and theme-aware).

On your merge I'll tag `v1.2.2` — the tag is already authorized — and the release
workflow publishes to nuget.org and GitHub Packages and creates the GitHub release.

**Not merging — that's yours.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ysVAfsbKMfGBaAkWvuRTf