### PR TITLE
Cut 1.2.3: the README header that renders on nuget.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.3] - 2026-08-29
 
 ### Fixed
 
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   relative image paths could never resolve outside the repository. The mark is now one
   self-sized SVG (the icon artwork at an intrinsic 40px, its white tile serving light and
   dark themes alike) referenced with plain markdown from raw.githubusercontent.com, a
-  domain nuget.org allowlists. The license badge links absolutely for the same reason.
-  The package pages pick this up with the next published version.
+  domain nuget.org allowlists, with alt text so nuget.org has nothing to nag about. The
+  license badge links absolutely for the same reason. Verified rendering on the
+  1.2.3-preview.1 package page before this release.
 
 ## [1.2.2] - 2026-08-28
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
         local and CI builds fall back to the values below.
     -->
     <PropertyGroup>
-        <VersionPrefix>1.2.2</VersionPrefix>
+        <VersionPrefix>1.2.3</VersionPrefix>
         <!--
             Empty at 1.0.0. Set it again to cut a prerelease of the next version; the file version
             carries no prerelease part, so it stays put until the version it does carry changes.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ![](https://raw.githubusercontent.com/ipjohnson/DependencyModules/main/assets/logo-readme.svg) DependencyModules
+# ![logo](https://raw.githubusercontent.com/ipjohnson/DependencyModules/main/assets/logo-readme.svg) DependencyModules
 
 [![NuGet](https://img.shields.io/nuget/v/DependencyModules.Runtime.svg)](https://www.nuget.org/packages/DependencyModules.Runtime/)
 [![build](https://github.com/ipjohnson/DependencyModules/actions/workflows/build-package.yaml/badge.svg)](https://github.com/ipjohnson/DependencyModules/actions/workflows/build-package.yaml)


### PR DESCRIPTION
Version bump + changelog date, plus one word: `![logo]` instead of `![]`, because nuget.org substitutes a nag string ("alternate text is missing from this package README image") into empty-alt images, and screen readers get it read to them.

The header fix landed in #52 and is verified rendering on the [1.2.3-preview.1 package page](https://www.nuget.org/packages/DependencyModules.Runtime/1.2.3-preview.1). Merging this is inert — nothing publishes until the `v1.2.3` tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUBuxPxvyctDSNQNqNo6e5