### PR TITLE
Cut 1.3.0: the test environment hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-09-01
+
+### Added
+
+- `IModuleEnvironmentProvider`, the hook a test framework integration uses to put a test under
+  the environment it declares. Module conditions - `[IfEnvironment]` and its siblings - are
+  evaluated as registrations are applied, and both runners load modules before the service-setup
+  pass by design, so an environment registered there arrived after every condition had been
+  decided against the process default. The runners now consult the new interface before any
+  module is applied, widest scope first, narrowest answer deciding. A minor version, because the
+  Runtime package gains public API.
+
 ## [1.2.3] - 2026-08-29
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
         local and CI builds fall back to the values below.
     -->
     <PropertyGroup>
-        <VersionPrefix>1.2.3</VersionPrefix>
+        <VersionPrefix>1.3.0</VersionPrefix>
         <!--
             Empty at 1.0.0. Set it again to cut a prerelease of the next version; the file version
             carries no prerelease part, so it stays put until the version it does carry changes.
@@ -22,7 +22,7 @@
             depend on. It moves at 2.0.0.
         -->
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <FileVersion>1.2.2.0</FileVersion>
+        <FileVersion>1.3.0.0</FileVersion>
     </PropertyGroup>
 
     <!--


### PR DESCRIPTION
Version and changelog for #54. A minor version rather than a patch, because `IModuleEnvironmentProvider` is new public API on the Runtime package.

`FileVersion` catches up two releases while here: the 1.2.3 cut moved `VersionPrefix` and left it at 1.2.2.0, though its own comment says it carries the real version for anyone inspecting the binary.

On merge, tagging `v1.3.0` runs the release workflow and publishes to nuget.org; the Hardened side of the fix (the F14 queue entry) bumps `DependencyModulesVersion` to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)