### PR TITLE
Cut 1.3.1: the container's lifetime under xUnit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2026-09-05
+
+### Fixed
+
+- Under xUnit, a test's container is disposed when its case has run. `ModuleTestCase` handed
+  the provider to the case's `DisposalTracker`, and xUnit disposes a test case only once every
+  case in the assembly has run, so every container a run built stayed alive, with every
+  singleton in it, until the run ended. The case now executes itself and disposes what it built
+  in a `finally` once its run returns; NUnit's `ModuleTestCommand` has always done this in its
+  own `finally`. Per case, which for every test but a data-driven one is per test.
+
 ## [1.3.0] - 2026-09-01
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
         local and CI builds fall back to the values below.
     -->
     <PropertyGroup>
-        <VersionPrefix>1.3.0</VersionPrefix>
+        <VersionPrefix>1.3.1</VersionPrefix>
         <!--
             Empty at 1.0.0. Set it again to cut a prerelease of the next version; the file version
             carries no prerelease part, so it stays put until the version it does carry changes.
@@ -22,7 +22,7 @@
             depend on. It moves at 2.0.0.
         -->
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <FileVersion>1.3.0.0</FileVersion>
+        <FileVersion>1.3.1.0</FileVersion>
     </PropertyGroup>
 
     <!--


### PR DESCRIPTION
Version and changelog for #56, the way #55 cut 1.3.0. A patch: no public API changes shape.

After the merge, the `v1.3.1` tag is what publishes; Hardened takes the bump in a follow-up that also adds the assembly-end leak test the fix makes possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
