### PR TITLE
Let a test build containers of its own, and say what crosses between them

### DIFF
--- a/src/DependencyModules.NUnit/Impl/ModuleTestCommand.cs
+++ b/src/DependencyModules.NUnit/Impl/ModuleTestCommand.cs
@@ -41,6 +41,13 @@ public class ModuleTestCommand(TestCommand innerCommand) : DelegatingTestCommand
 
         SetupTestCaseInfo(serviceCollection, testMethod, knownAttributes);
 
+        // Before the modules, so anything driving the application can take one through ordinary
+        // constructor injection. It answers nothing until the container below exists to take pinned
+        // instances from, which is why it is handed its composition rather than given it here.
+        var containerSource = new TestContainerSource();
+
+        serviceCollection.AddSingleton<ITestContainerSource>(containerSource);
+
         SeedEnvironment(serviceCollection, method, knownAttributes);
 
         SetupModules(serviceCollection, method, knownAttributes);
@@ -53,12 +60,26 @@ public class ModuleTestCommand(TestCommand innerCommand) : DelegatingTestCommand
 
         var serviceProvider = BuildServiceProvider(moduleContext, serviceCollection, knownAttributes);
 
+        // Every container the case built, the first and any the source was asked for, disposed
+        // together in the finally below.
+        var providers = new List<IServiceProvider> { serviceProvider };
+
         try {
-            foreach (var startupAttribute in knownAttributes.OfType<ITestStartupAttribute>()) {
-                // NUnit's command chain is synchronous — TestCommand.Execute has no async form — so
-                // an async hook is awaited here rather than up the stack.
-                startupAttribute.StartupAsync(moduleContext, serviceProvider).GetAwaiter().GetResult();
-            }
+            Start(moduleContext, knownAttributes, serviceProvider);
+
+            // Named throughout: three of these are delegates of shapes that would happily bind to
+            // one another.
+            containerSource.Initialize(
+                services: serviceCollection,
+                pinned: serviceProvider,
+                pinnedServices: SharedRegistrations.Collect(method, knownAttributes),
+                build: services => BuildServiceProvider(moduleContext, services, knownAttributes),
+                start: built => {
+                    Start(moduleContext, knownAttributes, built);
+
+                    return ValueTask.CompletedTask;
+                },
+                track: providers.Add);
 
             var arguments = resolver
                 .ResolveArgumentsAsync(serviceProvider, RowArguments(testMethod))
@@ -68,7 +89,28 @@ public class ModuleTestCommand(TestCommand innerCommand) : DelegatingTestCommand
 
             return innerCommand.Execute(context);
         } finally {
-            DisposeProvider(serviceProvider);
+            // Backwards, so a container the source built goes before the one holding the instances
+            // it was handed.
+            for (var i = providers.Count - 1; i >= 0; i--) {
+                DisposeProvider(providers[i]);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs the test's startup attributes against one container.
+    /// </summary>
+    /// <remarks>
+    /// Every container, not only the first. A framework whose startup installs middleware or a filter
+    /// provider would otherwise answer through a chain that was never assembled.
+    ///
+    /// NUnit's command chain is synchronous - TestCommand.Execute has no async form - so an async
+    /// hook is awaited here rather than up the stack.
+    /// </remarks>
+    private static void Start(
+        ITestMethodContext context, Attribute[] knownAttributes, IServiceProvider provider) {
+        foreach (var startupAttribute in knownAttributes.OfType<ITestStartupAttribute>()) {
+            startupAttribute.StartupAsync(context, provider).GetAwaiter().GetResult();
         }
     }
 

--- a/src/DependencyModules.Testing/Attributes/InjectValuesAttribute.cs
+++ b/src/DependencyModules.Testing/Attributes/InjectValuesAttribute.cs
@@ -27,7 +27,8 @@ namespace DependencyModules.Testing.Attributes;
 /// ActivatorUtilities naming the parameter's type rather than the misplaced attribute.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Parameter)]
-public class InjectValuesAttribute(params object[] value) : Attribute, IInjectValueAttribute {
+public class InjectValuesAttribute(params object[] value)
+    : Attribute, IInjectValueAttribute, ISharedTestRegistration {
 
     /// <summary>
     /// Provides the specified values for a method parameter during dependency

--- a/src/DependencyModules.Testing/Attributes/Interfaces/ISharedTestRegistration.cs
+++ b/src/DependencyModules.Testing/Attributes/Interfaces/ISharedTestRegistration.cs
@@ -1,0 +1,44 @@
+namespace DependencyModules.Testing.Attributes.Interfaces;
+
+/// <summary>
+/// Declares that what an attribute registered is pinned for the whole test, rather than rebuilt
+/// with every container the test creates.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A test that builds a container per invocation needs some things to survive the rebuild. A mock is
+/// the clear case: a substitute resolved fresh per container is one the test can assert nothing
+/// about, because the invocation recorded onto a different object. Implementing this is how an
+/// attribute says so once, in its own definition, rather than every use site remembering
+/// <c>[Shared]</c>.
+/// </para>
+/// <para>
+/// <b>The bar is narrow.</b> Implement this only where isolated would be <em>broken</em> for the
+/// attribute rather than merely unusual. Hiding a decision from the reader of a test is a cost;
+/// hiding a non-decision is not. <see cref="MockAttribute"/> clears the bar because an isolated mock
+/// has no coherent reading at all. <see cref="TestExportAttribute"/> does not, which is why it
+/// implements this with <c>Shared</c> defaulting to false and leaves the choice at the use site.
+/// </para>
+/// </remarks>
+public interface ISharedTestRegistration {
+
+    /// <summary>
+    /// Whether what this attribute registered is pinned.
+    /// </summary>
+    /// <remarks>
+    /// A <c>bool</c> rather than a bare marker interface, so an attribute whose answer depends on how
+    /// it was constructed can say so. The default suits an attribute that is always shared.
+    /// </remarks>
+    bool Shared => true;
+
+    /// <summary>
+    /// The services to pin, for an attribute that registers one without naming a parameter.
+    /// </summary>
+    /// <remarks>
+    /// Empty means the harness already knows what to pin, which is the parameter's type for an
+    /// attribute sitting on one. An <see cref="ITestServiceSetupAttribute"/> has no parameter to read,
+    /// so it answers here - which is also what lets an implementation outside this assembly join in
+    /// without the runner knowing about it.
+    /// </remarks>
+    IReadOnlyList<Type> SharedServices => [];
+}

--- a/src/DependencyModules.Testing/Attributes/Interfaces/ITestContainerSource.cs
+++ b/src/DependencyModules.Testing/Attributes/Interfaces/ITestContainerSource.cs
@@ -1,0 +1,36 @@
+namespace DependencyModules.Testing.Attributes.Interfaces;
+
+/// <summary>
+/// Builds containers for one test, on demand, from what the test composed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Resolved from the test's container like any other service, so anything driving the application -
+/// a trigger façade, a generated client, a host adapter - can take one and build a container per
+/// call. A test that wants those calls to share one container marks that parameter
+/// <see cref="SharedAttribute"/>, and the parameter is resolved once instead.
+/// </para>
+/// <para>
+/// <b>A source rather than the <c>IServiceCollection</c>.</b> A caller holding the collection could
+/// mutate it, after which the third container differs from the first with nothing recording why.
+/// Handing out a source also means every container a test built is tracked, so destroying them is
+/// the runner's business rather than a caller's - they are disposed when the test case has run,
+/// alongside the container the test itself resolved from.
+/// </para>
+/// <para>
+/// Asynchronous because <see cref="ITestStartupAttribute"/> is, and a container that skipped startup
+/// is not the one the test composed. A framework whose startup installs middleware would answer every
+/// request through a chain that was never assembled.
+/// </para>
+/// </remarks>
+public interface ITestContainerSource {
+
+    /// <summary>
+    /// A container built from the test's composition, started, and owned by the runner.
+    /// </summary>
+    /// <remarks>
+    /// Pinned services are the same objects in every container this returns. Everything else is built
+    /// again, keeping whatever lifetime it was registered with inside the container it belongs to.
+    /// </remarks>
+    ValueTask<IServiceProvider> CreateAsync();
+}

--- a/src/DependencyModules.Testing/Attributes/MockAttribute.cs
+++ b/src/DependencyModules.Testing/Attributes/MockAttribute.cs
@@ -25,11 +25,17 @@ namespace DependencyModules.Testing.Attributes;
 ///
 /// This carries no test framework dependency, so it is the same attribute whichever integration
 /// resolves the test's parameters.
+///
+/// The double is <see cref="ISharedTestRegistration">shared</see> across every container a test
+/// builds, and unconditionally: a substitute resolved fresh per container is one the test can assert
+/// nothing about, because the call it is asking after was recorded onto a different object. That is
+/// the whole bar for declaring an attribute shared - not that isolating it would be unusual, but that
+/// it would have no coherent reading.
 /// </remarks>
 [AttributeUsage(
     AttributeTargets.Parameter,
     AllowMultiple = true)]
-public class MockAttribute : Attribute, ITestParameterValueProvider {
+public class MockAttribute : Attribute, ITestParameterValueProvider, ISharedTestRegistration {
 
     /// <summary>
     /// Registers the double in place of the parameter's service.

--- a/src/DependencyModules.Testing/Attributes/SharedAttribute.cs
+++ b/src/DependencyModules.Testing/Attributes/SharedAttribute.cs
@@ -1,0 +1,35 @@
+using DependencyModules.Testing.Attributes.Interfaces;
+
+namespace DependencyModules.Testing.Attributes;
+
+/// <summary>
+/// Keeps one test parameter across every container the test builds.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One rule, covering both things a parameter can be: <b>this parameter is not rebuilt.</b>
+/// </para>
+/// <para>
+/// On a <em>value</em> parameter - a fake, a store, anything the test asserts against - that pins the
+/// instance, so every container is handed the same object.
+/// </para>
+/// <para>
+/// On an <em>invoker</em> parameter - something that drives the application, holding an
+/// <see cref="ITestContainerSource"/> to build a container per call - it pins the container instead,
+/// so every call through that parameter reaches the same one. That is the escape hatch for a test
+/// whose subject <em>is</em> the reuse: a response cache serving the second request, a rate limiter
+/// tripping on the eleventh, a connection held open.
+/// </para>
+/// <para>
+/// Parameters only, deliberately. At a class or an assembly the obvious reading is "one container
+/// across the tests here", which would undo the per-test isolation that already holds and that
+/// nothing has ever asked to change.
+/// </para>
+/// <para>
+/// On a runner or a host that builds one container anyway this is a no-op rather than an error. It
+/// still says why the test is written the way it is, and the same test may be run somewhere that
+/// rebuilds.
+/// </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Parameter)]
+public class SharedAttribute : Attribute, ISharedTestRegistration { }

--- a/src/DependencyModules.Testing/Attributes/TestExportAttribute.cs
+++ b/src/DependencyModules.Testing/Attributes/TestExportAttribute.cs
@@ -33,7 +33,7 @@ namespace DependencyModules.Testing.Attributes;
     AttributeTargets.Class |
     AttributeTargets.Method,
     AllowMultiple = true)]
-public class TestExportAttribute : Attribute, ITestServiceSetupAttribute {
+public class TestExportAttribute : Attribute, ITestServiceSetupAttribute, ISharedTestRegistration {
     /// <summary>
     /// An attribute that configures and exports services to the dependency injection container
     /// for test scenarios. This supports customized service registrations with specific lifetimes
@@ -78,6 +78,47 @@ public class TestExportAttribute : Attribute, ITestServiceSetupAttribute {
         get;
         set;
     } = ServiceLifetime.Transient;
+
+    /// <summary>
+    /// Whether this export is kept across every container the test builds, rather than registered
+    /// again in each. Off unless the test asks.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Isolated by default because it reads perfectly well isolated: a fresh fake per container is a
+    /// coherent test, and often the one wanted. That is the line for pinning something without the
+    /// use site saying so - not that isolating it would be unusual, but that it would be broken.
+    /// <see cref="MockAttribute"/> is over that line and this is not, so this asks:
+    /// </para>
+    /// <code>
+    /// [TestExport(typeof(IOrderStore), Implementation = typeof(InMemoryOrderStore), Shared = true)]
+    /// </code>
+    /// <para>
+    /// Which also keeps the default strict the whole way down. An application's services are per
+    /// container, an export is per container, and the only things kept without anyone writing a word
+    /// are the ones isolation has no reading for.
+    /// </para>
+    /// <para>
+    /// <b>This wins over <see cref="Lifetime"/>, and deliberately.</b> Keeping one object across
+    /// containers is an instance registration, so a shared export is one instance however it was
+    /// registered. Setting it beside the default <see cref="ServiceLifetime.Transient"/> is not a
+    /// contradiction to refuse - pinning one object is the only thing the pair can mean, and it is
+    /// what was asked for.
+    /// </para>
+    /// </remarks>
+    public bool Shared {
+        get;
+        set;
+    }
+
+    /// <summary>
+    /// The exported service, which is what pinning applies to when <see cref="Shared"/> is set.
+    /// </summary>
+    /// <remarks>
+    /// Answered here rather than left to the runner because this attribute names no parameter - it
+    /// sits on a method, a class or an assembly - so nothing else knows what it registered.
+    /// </remarks>
+    IReadOnlyList<Type> ISharedTestRegistration.SharedServices => [Service];
 
 
     /// <summary>

--- a/src/DependencyModules.Testing/Impl/SharedRegistrations.cs
+++ b/src/DependencyModules.Testing/Impl/SharedRegistrations.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+using DependencyModules.Testing.Attributes.Interfaces;
+
+namespace DependencyModules.Testing.Impl;
+
+/// <summary>
+/// Works out which services are pinned for one test.
+/// </summary>
+/// <remarks>
+/// Shared by every integration, because the rule is the same one wherever the test runs and only the
+/// discovery around it differs.
+/// </remarks>
+public static class SharedRegistrations {
+
+    /// <summary>
+    /// The service types to keep across every container the test builds.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two sources, and the difference is only in how each names what it registered. An attribute on
+    /// the method, the class or the assembly registers a service without naming a parameter, so it
+    /// answers <see cref="ISharedTestRegistration.SharedServices"/> - <c>[TestExport]</c> names the
+    /// service it exported. An attribute on a parameter has one by definition, so an empty
+    /// <c>SharedServices</c> is read as that parameter's type, which is what keeps <c>[Mock]</c> to a
+    /// single interface on the class and nothing else.
+    /// </para>
+    /// <para>
+    /// An attribute answering <c>Shared</c> false contributes nothing rather than un-pinning what
+    /// something else pinned. Two attributes naming one service disagreeing is a use site asking for
+    /// both, and pinning is the answer that leaves the test able to see what it asked to see.
+    /// </para>
+    /// </remarks>
+    /// <param name="method">The test method, for its parameters.</param>
+    /// <param name="knownAttributes">
+    /// The attributes in scope for the test, widest first, as the runner collected them.
+    /// </param>
+    public static IReadOnlyCollection<Type> Collect(MethodInfo method, IEnumerable<Attribute> knownAttributes) {
+        var pinned = new HashSet<Type>();
+
+        foreach (var registration in knownAttributes.OfType<ISharedTestRegistration>()) {
+            if (!registration.Shared) {
+                continue;
+            }
+
+            foreach (var service in registration.SharedServices) {
+                pinned.Add(service);
+            }
+        }
+
+        foreach (var parameter in method.GetParameters()) {
+            foreach (var registration in parameter.GetCustomAttributes().OfType<ISharedTestRegistration>()) {
+                if (!registration.Shared) {
+                    continue;
+                }
+
+                if (registration.SharedServices.Count == 0) {
+                    pinned.Add(parameter.ParameterType);
+
+                    continue;
+                }
+
+                foreach (var service in registration.SharedServices) {
+                    pinned.Add(service);
+                }
+            }
+        }
+
+        return pinned;
+    }
+}

--- a/src/DependencyModules.Testing/Impl/TestContainerSource.cs
+++ b/src/DependencyModules.Testing/Impl/TestContainerSource.cs
@@ -1,0 +1,144 @@
+using System.Collections;
+using DependencyModules.Testing.Attributes.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DependencyModules.Testing.Impl;
+
+/// <summary>
+/// The runner's <see cref="ITestContainerSource"/>: builds a container per call from a template
+/// taken once off the test's own composition.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered into the collection before the test's container is built, because anything that wants
+/// one resolves it like any other service, and filled in afterwards - the source cannot describe how
+/// to rebuild a container until the first one exists to take the pinned instances from. Registered as
+/// an instance, so it belongs to the test case rather than to any container and is never disposed by
+/// one.
+/// </para>
+/// <para>
+/// <b>Nothing happens until something asks.</b> The template is built on the first
+/// <see cref="CreateAsync"/> and not before, so a test that never rebuilds - which is nearly all of
+/// them - pays for none of this.
+/// </para>
+/// </remarks>
+public sealed class TestContainerSource : ITestContainerSource {
+    private readonly object _gate = new();
+
+    private Composition? _composition;
+    private IServiceCollection? _template;
+
+    /// <summary>
+    /// What the runner knows and this does not, handed over once the test's container exists.
+    /// </summary>
+    /// <param name="services">The collection the test's container was built from.</param>
+    /// <param name="pinned">The container to take pinned instances out of.</param>
+    /// <param name="pinnedServices">The service types to keep, from <see cref="SharedRegistrations"/>.</param>
+    /// <param name="build">Builds a provider the same way the runner built the first one.</param>
+    /// <param name="start">Runs the test's startup attributes against a newly built provider.</param>
+    /// <param name="track">Hands a built provider to the runner, which disposes it when the case has run.</param>
+    public void Initialize(
+        IServiceCollection services,
+        IServiceProvider pinned,
+        IReadOnlyCollection<Type> pinnedServices,
+        Func<IServiceCollection, IServiceProvider> build,
+        Func<IServiceProvider, ValueTask> start,
+        Action<IServiceProvider> track) {
+        _composition = new Composition(services, pinned, pinnedServices, build, start, track);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IServiceProvider> CreateAsync() {
+        var composition = _composition
+                          ?? throw new InvalidOperationException(
+                              $"This {nameof(TestContainerSource)} was never initialized, so there is " +
+                              "nothing to build a container from. The runner does that once the test's " +
+                              "own container exists.");
+
+        var provider = composition.Build(Template(composition));
+
+        composition.Track(provider);
+
+        await composition.Start(provider);
+
+        return provider;
+    }
+
+    /// <remarks>
+    /// Under a lock because a test is free to drive two calls at once, and building the template
+    /// twice would take a second set of pinned instances out of the first container - leaving two
+    /// objects where the whole point is one.
+    /// </remarks>
+    private IServiceCollection Template(Composition composition) {
+        if (_template != null) {
+            return _template;
+        }
+
+        lock (_gate) {
+            return _template ??= BuildTemplate(composition);
+        }
+    }
+
+    /// <summary>
+    /// The test's collection with every pinned service replaced by the instance the first container
+    /// produced.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>An instance registration rather than a factory returning the instance</b>, which is the
+    /// difference between a shared object surviving the test and being disposed once per container.
+    /// A provider disposes what it created, and a factory registration counts as created; an instance
+    /// it was handed does not. The first disposal would otherwise land while other containers were
+    /// still running.
+    /// </para>
+    /// <para>
+    /// Resolved through <c>IEnumerable&lt;T&gt;</c> rather than as a single service, so a type
+    /// registered more than once keeps every registration and its order. Taking the single service
+    /// would collapse the set to its last member and leave anything injecting the sequence one
+    /// element long.
+    /// </para>
+    /// <para>
+    /// A descriptor that already carries an instance is left alone: it is the same object in every
+    /// container built from this collection already, which is how the module environment is shared
+    /// without anyone asking. An open generic is left alone too, having no closed type to resolve.
+    /// </para>
+    /// </remarks>
+    private static IServiceCollection BuildTemplate(Composition composition) {
+        IServiceCollection template = new ServiceCollection();
+        var taken = new HashSet<Type>();
+
+        foreach (var descriptor in composition.Services) {
+            var serviceType = descriptor.ServiceType;
+
+            if (!composition.PinnedServices.Contains(serviceType) ||
+                descriptor.ImplementationInstance != null ||
+                serviceType.IsGenericTypeDefinition) {
+                template.Add(descriptor);
+
+                continue;
+            }
+
+            if (!taken.Add(serviceType)) {
+                continue;
+            }
+
+            var sequence = typeof(IEnumerable<>).MakeGenericType(serviceType);
+
+            foreach (var instance in (IEnumerable)composition.Pinned.GetRequiredService(sequence)) {
+                if (instance != null) {
+                    template.Add(new ServiceDescriptor(serviceType, instance));
+                }
+            }
+        }
+
+        return template;
+    }
+
+    private sealed record Composition(
+        IServiceCollection Services,
+        IServiceProvider Pinned,
+        IReadOnlyCollection<Type> PinnedServices,
+        Func<IServiceCollection, IServiceProvider> Build,
+        Func<IServiceProvider, ValueTask> Start,
+        Action<IServiceProvider> Track);
+}

--- a/src/DependencyModules.xUnit/Impl/ModuleTestCase.cs
+++ b/src/DependencyModules.xUnit/Impl/ModuleTestCase.cs
@@ -99,6 +99,13 @@ public class ModuleTestCase : XunitTestCase, ISelfExecutingXunitTestCase {
 
         SetupTestCaseInfo(serviceCollection, knownAttributes);
 
+        // Before the modules, so anything driving the application can take one through ordinary
+        // constructor injection. It answers nothing until the container below exists to take pinned
+        // instances from, which is why it is handed its composition rather than given it here.
+        var containerSource = new TestContainerSource();
+
+        serviceCollection.AddSingleton<ITestContainerSource>(containerSource);
+
         SeedEnvironment(serviceCollection, knownAttributes);
 
         SetupModules(serviceCollection, knownAttributes);
@@ -118,11 +125,34 @@ public class ModuleTestCase : XunitTestCase, ISelfExecutingXunitTestCase {
         // run; see the remarks on the class.
         _providers.Add(provider);
 
+        await StartAsync(context, knownAttributes, provider);
+
+        // Named throughout, for the reason the base constructor above gives: three of these are
+        // delegates of shapes that would happily bind to one another.
+        containerSource.Initialize(
+            services: serviceCollection,
+            pinned: provider,
+            pinnedServices: SharedRegistrations.Collect(TestMethod.Method, knownAttributes),
+            build: services => BuildServiceProvider(context, services, knownAttributes),
+            start: built => StartAsync(context, knownAttributes, built),
+            track: _providers.Add);
+
+        return new StartupValues(provider, resolver);
+    }
+
+    /// <summary>
+    /// Runs the test's startup attributes against one container.
+    /// </summary>
+    /// <remarks>
+    /// Every container, not only the first. A framework whose startup installs middleware or a filter
+    /// provider would otherwise answer through a chain that was never assembled, which is a container
+    /// that looks composed and is not.
+    /// </remarks>
+    private static async ValueTask StartAsync(
+        ITestMethodContext context, Attribute[] knownAttributes, IServiceProvider provider) {
         foreach (var startupAttribute in knownAttributes.OfType<ITestStartupAttribute>()) {
             await startupAttribute.StartupAsync(context, provider);
         }
-
-        return new StartupValues(provider, resolver);
     }
 
     private void SetupTestCaseInfo(ServiceCollection serviceCollection, Attribute[] knownAttributes) {
@@ -143,7 +173,7 @@ public class ModuleTestCase : XunitTestCase, ISelfExecutingXunitTestCase {
     /// which is the reverse of how every other attribute here resolves.
     /// </remarks>
     private IServiceProvider BuildServiceProvider(
-        ITestMethodContext context, ServiceCollection serviceCollection, Attribute[] knownAttributes) {
+        ITestMethodContext context, IServiceCollection serviceCollection, Attribute[] knownAttributes) {
         var serviceProviderBuilderAttribute =
             knownAttributes.OfType<IServiceProviderBuilderAttribute>().LastOrDefault();
 
@@ -169,7 +199,7 @@ public class ModuleTestCase : XunitTestCase, ISelfExecutingXunitTestCase {
     /// mocked, which is what <c>[Mock]</c> is for.
     /// </remarks>
     private void SetupServiceSetupAttributes(
-        ITestMethodContext context, ServiceCollection serviceCollection, Attribute[] knownAttributes) {
+        ITestMethodContext context, IServiceCollection serviceCollection, Attribute[] knownAttributes) {
         var setupAttributes = knownAttributes
             .OfType<ITestServiceSetupAttribute>()
             .OrderBy(attribute => attribute is IMockSupportAttribute ? 0 : 1);

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.TestingApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.TestingApi.verified.txt
@@ -1,25 +1,31 @@
 namespace DependencyModules.Testing.Attributes
 {
     [System.AttributeUsage(System.AttributeTargets.Parameter)]
-    public class InjectValuesAttribute : System.Attribute, DependencyModules.Testing.Attributes.Interfaces.IInjectValueAttribute
+    public class InjectValuesAttribute : System.Attribute, DependencyModules.Testing.Attributes.Interfaces.IInjectValueAttribute, DependencyModules.Testing.Attributes.Interfaces.ISharedTestRegistration
     {
         public InjectValuesAttribute(params object[] value) { }
         public object[] ProvideValue(System.IServiceProvider serviceProvider, System.Reflection.ParameterInfo parameter) { }
     }
     [System.AttributeUsage(System.AttributeTargets.Parameter, AllowMultiple=true)]
-    public class MockAttribute : System.Attribute, DependencyModules.Testing.Attributes.Interfaces.ITestParameterValueProvider
+    public class MockAttribute : System.Attribute, DependencyModules.Testing.Attributes.Interfaces.ISharedTestRegistration, DependencyModules.Testing.Attributes.Interfaces.ITestParameterValueProvider
     {
         public MockAttribute() { }
         public System.Threading.Tasks.Task<object?> GetParameterValueAsync(DependencyModules.Testing.Attributes.Interfaces.ITestMethodContext testMethod, System.IServiceProvider serviceProvider, System.Reflection.ParameterInfo parameter) { }
         public void SetupServiceCollection(DependencyModules.Testing.Attributes.Interfaces.ITestMethodContext testMethod, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection, System.Reflection.ParameterInfo parameter) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Parameter)]
+    public class SharedAttribute : System.Attribute, DependencyModules.Testing.Attributes.Interfaces.ISharedTestRegistration
+    {
+        public SharedAttribute() { }
+    }
     [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true)]
-    public class TestExportAttribute : System.Attribute, DependencyModules.Testing.Attributes.Interfaces.ITestServiceSetupAttribute
+    public class TestExportAttribute : System.Attribute, DependencyModules.Testing.Attributes.Interfaces.ISharedTestRegistration, DependencyModules.Testing.Attributes.Interfaces.ITestServiceSetupAttribute
     {
         public TestExportAttribute(System.Type service) { }
         public System.Type? Implementation { get; set; }
         public Microsoft.Extensions.DependencyInjection.ServiceLifetime Lifetime { get; set; }
         public System.Type Service { get; }
+        public bool Shared { get; set; }
         public void SetupServiceCollection(DependencyModules.Testing.Attributes.Interfaces.ITestMethodContext testMethod, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
     }
 }
@@ -45,6 +51,15 @@ namespace DependencyModules.Testing.Attributes.Interfaces
     public interface IServiceProviderBuilderAttribute
     {
         System.IServiceProvider BuildServiceProvider(DependencyModules.Testing.Attributes.Interfaces.ITestMethodContext testMethod, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection);
+    }
+    public interface ISharedTestRegistration
+    {
+        bool Shared { get; }
+        System.Collections.Generic.IReadOnlyList<System.Type> SharedServices { get; }
+    }
+    public interface ITestContainerSource
+    {
+        System.Threading.Tasks.ValueTask<System.IServiceProvider> CreateAsync();
     }
     public interface ITestMethodContext
     {
@@ -77,6 +92,16 @@ namespace DependencyModules.Testing.Impl
             where T :  class { }
         public static System.Collections.Generic.IEnumerable<T> GetTestAttributes<T>(this System.Reflection.ParameterInfo parameterInfo)
             where T :  class { }
+    }
+    public static class SharedRegistrations
+    {
+        public static System.Collections.Generic.IReadOnlyCollection<System.Type> Collect(System.Reflection.MethodInfo method, System.Collections.Generic.IEnumerable<System.Attribute> knownAttributes) { }
+    }
+    public sealed class TestContainerSource : DependencyModules.Testing.Attributes.Interfaces.ITestContainerSource
+    {
+        public TestContainerSource() { }
+        public System.Threading.Tasks.ValueTask<System.IServiceProvider> CreateAsync() { }
+        public void Initialize(Microsoft.Extensions.DependencyInjection.IServiceCollection services, System.IServiceProvider pinned, System.Collections.Generic.IReadOnlyCollection<System.Type> pinnedServices, System.Func<Microsoft.Extensions.DependencyInjection.IServiceCollection, System.IServiceProvider> build, System.Func<System.IServiceProvider, System.Threading.Tasks.ValueTask> start, System.Action<System.IServiceProvider> track) { }
     }
     public sealed class TestParameterResolver
     {

--- a/tests/DependencyModules.Tests/TestingTests/SharedRegistrationsTests.cs
+++ b/tests/DependencyModules.Tests/TestingTests/SharedRegistrationsTests.cs
@@ -1,0 +1,103 @@
+using System.Reflection;
+using DependencyModules.Testing.Attributes;
+using DependencyModules.Testing.Attributes.Interfaces;
+using DependencyModules.Testing.Impl;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DependencyModules.Tests.TestingTests;
+
+/// <summary>
+/// Which services a test pins, decided without a container or a test framework in the way.
+/// </summary>
+public class SharedRegistrationsTests {
+
+    private interface IThing;
+
+    private interface IOther;
+
+    private class Thing : IThing;
+
+    /// <summary>An attribute that answers no, to prove declining is not the same as not implementing.</summary>
+    private class NotSharedAttribute : Attribute, ISharedTestRegistration {
+        public bool Shared => false;
+
+        public IReadOnlyList<Type> SharedServices => [typeof(IOther)];
+    }
+
+    private static IReadOnlyCollection<Type> Collect(string method, params Attribute[] known) =>
+        SharedRegistrations.Collect(
+            typeof(SharedRegistrationsTests).GetMethod(method, BindingFlags.NonPublic | BindingFlags.Static)!,
+            known);
+
+    private static void Plain(IThing thing) { }
+
+    private static void Marked([Shared] IThing thing) { }
+
+    private static void Mocked([Mock] IThing thing) { }
+
+    private static void Declined([NotShared] IThing thing) { }
+
+    private static void Several([Shared] IThing thing, [Mock] IOther other, string plain) { }
+
+    /// <summary>A parameter says nothing on its own, which is what keeps the default isolated.</summary>
+    [Fact]
+    public void AnUnmarkedParameterIsNotPinned() {
+        Assert.Empty(Collect(nameof(Plain)));
+    }
+
+    [Fact]
+    public void SharedPinsTheParametersType() {
+        Assert.Equal([typeof(IThing)], Collect(nameof(Marked)));
+    }
+
+    /// <summary>
+    /// The point of the interface: [Mock] pins without the use site writing [Shared].
+    /// </summary>
+    [Fact]
+    public void MockPinsWithoutBeingAsked() {
+        Assert.Equal([typeof(IThing)], Collect(nameof(Mocked)));
+    }
+
+    [Fact]
+    public void AnAttributeAnsweringNoPinsNothing() {
+        Assert.Empty(Collect(nameof(Declined)));
+    }
+
+    [Fact]
+    public void EveryMarkedParameterIsCollected() {
+        Assert.Equal([typeof(IThing), typeof(IOther)], Collect(nameof(Several)));
+    }
+
+    /// <summary>
+    /// An attribute with no parameter names what it registered, which is how [TestExport] joins in
+    /// from the method, the class or the assembly.
+    /// </summary>
+    [Fact]
+    public void AnExportAskingToBeSharedNamesItsOwnService() {
+        var shared = new TestExportAttribute(typeof(IThing)) {
+            Implementation = typeof(Thing), Shared = true
+        };
+
+        Assert.Equal([typeof(IThing)], Collect(nameof(Plain), shared));
+    }
+
+    /// <summary>The default, and the reason the default is what it is.</summary>
+    [Fact]
+    public void AnExportIsNotPinnedUnlessItAsks() {
+        var isolated = new TestExportAttribute(typeof(IThing)) { Implementation = typeof(Thing) };
+
+        Assert.Empty(Collect(nameof(Plain), isolated));
+    }
+
+    /// <summary>
+    /// Two attributes naming one service and disagreeing is a use site asking for both. Pinning is
+    /// the answer that leaves the test able to see what it asked to see.
+    /// </summary>
+    [Fact]
+    public void OneAttributeAskingIsEnough() {
+        var isolated = new TestExportAttribute(typeof(IThing)) { Implementation = typeof(Thing) };
+
+        Assert.Equal([typeof(IThing)], Collect(nameof(Marked), isolated));
+    }
+}

--- a/tests/DependencyModules.Tests/TestingTests/TestContainerSourceTests.cs
+++ b/tests/DependencyModules.Tests/TestingTests/TestContainerSourceTests.cs
@@ -1,0 +1,185 @@
+using DependencyModules.NSubstitute;
+using DependencyModules.Runtime.Attributes;
+using DependencyModules.Testing.Attributes;
+using DependencyModules.Testing.Attributes.Interfaces;
+using DependencyModules.xUnit.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace DependencyModules.Tests.TestingTests;
+
+/// <summary>
+/// A test that builds containers of its own, and what crosses between them.
+/// </summary>
+/// <remarks>
+/// The whole of the contract in one file: everything is rebuilt, pinned services are not, and both
+/// halves of that are asserted against real containers rather than against the collector's answer.
+/// </remarks>
+[DependencyModule]
+public partial class ContainerSourceModule { }
+
+public interface ICounter {
+    int Value { get; }
+
+    void Bump();
+}
+
+[SingletonService]
+public class Counter : ICounter {
+    public int Value { get; private set; }
+
+    public void Bump() => Value++;
+}
+
+public interface IAudit {
+    void Record(string what);
+}
+
+[NSubstituteSupport]
+public class TestContainerSourceTests {
+
+    /// <summary>
+    /// A singleton is a singleton inside one container and nothing more, which is the property the
+    /// whole design turns on.
+    /// </summary>
+    [ModuleTest(typeof(ContainerSourceModule))]
+    public async Task EachContainerGetsItsOwnApplicationSingleton(ITestContainerSource source) {
+        var first = await source.CreateAsync();
+        var second = await source.CreateAsync();
+
+        first.GetRequiredService<ICounter>().Bump();
+        first.GetRequiredService<ICounter>().Bump();
+        second.GetRequiredService<ICounter>().Bump();
+
+        Assert.Equal(2, first.GetRequiredService<ICounter>().Value);
+        Assert.Equal(1, second.GetRequiredService<ICounter>().Value);
+        Assert.NotSame(first.GetRequiredService<ICounter>(), second.GetRequiredService<ICounter>());
+    }
+
+    /// <summary>
+    /// The counterpart, and the reason [Mock] declares itself shared: the substitute the test holds
+    /// is the one every container was built against, so what a container did is visible here.
+    /// </summary>
+    [ModuleTest(typeof(ContainerSourceModule))]
+    public async Task AMockIsTheSameObjectInEveryContainer(ITestContainerSource source, [Mock] IAudit audit) {
+        var first = await source.CreateAsync();
+        var second = await source.CreateAsync();
+
+        Assert.Same(audit, first.GetRequiredService<IAudit>());
+        Assert.Same(audit, second.GetRequiredService<IAudit>());
+
+        first.GetRequiredService<IAudit>().Record("one");
+        second.GetRequiredService<IAudit>().Record("two");
+
+        Received.InOrder(() => {
+            audit.Record("one");
+            audit.Record("two");
+        });
+    }
+
+    /// <summary>
+    /// The container the test itself resolves from is one of the set, not something beside it.
+    /// </summary>
+    [ModuleTest(typeof(ContainerSourceModule))]
+    public async Task TheTestsOwnContainerHoldsTheSameMock(
+        ITestContainerSource source, IServiceProvider own, [Mock] IAudit audit) {
+        var built = await source.CreateAsync();
+
+        Assert.Same(audit, own.GetRequiredService<IAudit>());
+        Assert.Same(audit, built.GetRequiredService<IAudit>());
+        Assert.NotSame(own, built);
+    }
+
+    /// <summary>
+    /// Asking twice gives two containers. Nothing caches, because a caller asking again is a caller
+    /// that wants a cold one.
+    /// </summary>
+    [ModuleTest(typeof(ContainerSourceModule))]
+    public async Task EveryCallBuildsAContainer(ITestContainerSource source) {
+        var first = await source.CreateAsync();
+        var second = await source.CreateAsync();
+
+        Assert.NotSame(first, second);
+    }
+
+    /// <summary>
+    /// [Shared] does for anything what [Mock] does for a substitute, which is the escape hatch for a
+    /// value the test holds and asserts on.
+    /// </summary>
+    [ModuleTest(typeof(ContainerSourceModule))]
+    public async Task SharedPinsAPlainParameter(ITestContainerSource source, [Shared] ICounter counter) {
+        var first = await source.CreateAsync();
+        var second = await source.CreateAsync();
+
+        first.GetRequiredService<ICounter>().Bump();
+        second.GetRequiredService<ICounter>().Bump();
+
+        Assert.Same(counter, first.GetRequiredService<ICounter>());
+        Assert.Same(counter, second.GetRequiredService<ICounter>());
+        Assert.Equal(2, counter.Value);
+    }
+}
+
+/// <summary>
+/// An export is per container until the use site says otherwise.
+/// </summary>
+/// <remarks>
+/// The pair below is the whole argument for the default. Both read perfectly well, which is why
+/// neither is chosen for the test: isolating an export is coherent rather than broken, so it does not
+/// clear the bar for sharing without a word at the use site.
+/// </remarks>
+[NSubstituteSupport]
+[TestExport(typeof(ICounter), Implementation = typeof(Counter), Lifetime = ServiceLifetime.Singleton)]
+public class IsolatedTestExportTests {
+
+    [ModuleTest]
+    public async Task AnExportIsRebuiltWithEachContainer(ITestContainerSource source) {
+        var first = await source.CreateAsync();
+        var second = await source.CreateAsync();
+
+        first.GetRequiredService<ICounter>().Bump();
+
+        Assert.NotSame(first.GetRequiredService<ICounter>(), second.GetRequiredService<ICounter>());
+        Assert.Equal(1, first.GetRequiredService<ICounter>().Value);
+        Assert.Equal(0, second.GetRequiredService<ICounter>().Value);
+    }
+}
+
+[NSubstituteSupport]
+[TestExport(typeof(ICounter), Implementation = typeof(Counter), Lifetime = ServiceLifetime.Singleton,
+    Shared = true)]
+public class SharedTestExportTests {
+
+    [ModuleTest]
+    public async Task AnExportAskingToBeSharedCrossesEveryContainer(ITestContainerSource source) {
+        var first = await source.CreateAsync();
+        var second = await source.CreateAsync();
+
+        first.GetRequiredService<ICounter>().Bump();
+        second.GetRequiredService<ICounter>().Bump();
+
+        Assert.Same(first.GetRequiredService<ICounter>(), second.GetRequiredService<ICounter>());
+        Assert.Equal(2, first.GetRequiredService<ICounter>().Value);
+    }
+
+    /// <summary>
+    /// Shared wins over Lifetime, because keeping one object is an instance registration whatever the
+    /// registration said.
+    /// </summary>
+    [ModuleTest]
+    [TestExport(typeof(IAudit), Implementation = typeof(RecordingAudit),
+        Lifetime = ServiceLifetime.Transient, Shared = true)]
+    public async Task SharedOverridesATransientLifetime(ITestContainerSource source) {
+        var built = await source.CreateAsync();
+
+        Assert.Same(built.GetRequiredService<IAudit>(), built.GetRequiredService<IAudit>());
+    }
+}
+
+public class RecordingAudit : IAudit {
+    public List<string> Records { get; } = [];
+
+    public void Record(string what) => Records.Add(what);
+}
+

--- a/tests/DependencyModules.Tests/TestingTests/TestContainerSourceUnitTests.cs
+++ b/tests/DependencyModules.Tests/TestingTests/TestContainerSourceUnitTests.cs
@@ -1,0 +1,151 @@
+using DependencyModules.Testing.Attributes.Interfaces;
+using DependencyModules.Testing.Impl;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace DependencyModules.Tests.TestingTests;
+
+/// <summary>
+/// The source driven directly, for the parts a test running through a framework cannot observe.
+/// </summary>
+public class TestContainerSourceUnitTests {
+
+    private interface IThing;
+
+    private class Thing : IThing;
+
+    private sealed class Tracked : IDisposable {
+        public int Disposals { get; private set; }
+
+        public void Dispose() => Disposals++;
+    }
+
+    private sealed class Harness {
+        public List<IServiceProvider> Tracked { get; } = [];
+
+        public List<IServiceProvider> Started { get; } = [];
+
+        public TestContainerSource Source { get; } = new();
+
+        public IServiceProvider Pin { get; }
+
+        public Harness(Action<IServiceCollection> compose, params Type[] pinned) {
+            var services = new ServiceCollection();
+
+            services.AddSingleton<ITestContainerSource>(Source);
+
+            compose(services);
+
+            Pin = services.BuildServiceProvider();
+
+            Source.Initialize(
+                services,
+                Pin,
+                pinned,
+                collection => collection.BuildServiceProvider(),
+                provider => {
+                    Started.Add(provider);
+
+                    return ValueTask.CompletedTask;
+                },
+                Tracked.Add);
+        }
+    }
+
+    /// <summary>
+    /// Every container goes to the runner, which is what makes destroying them the runner's business
+    /// rather than the caller's.
+    /// </summary>
+    [Fact]
+    public async Task EveryContainerBuiltIsHandedToTheRunner() {
+        var harness = new Harness(services => services.AddSingleton<IThing, Thing>());
+
+        var first = await harness.Source.CreateAsync();
+        var second = await harness.Source.CreateAsync();
+
+        Assert.Equal([first, second], harness.Tracked);
+    }
+
+    /// <summary>
+    /// Startup runs against each one. A container that skipped it is not the one the test composed.
+    /// </summary>
+    [Fact]
+    public async Task StartupRunsForEveryContainer() {
+        var harness = new Harness(services => services.AddSingleton<IThing, Thing>());
+
+        var first = await harness.Source.CreateAsync();
+        var second = await harness.Source.CreateAsync();
+
+        Assert.Equal([first, second], harness.Started);
+    }
+
+    /// <summary>
+    /// A pinned service survives its container being disposed, which is the whole reason the template
+    /// uses an instance registration rather than a factory returning the same object.
+    /// </summary>
+    [Fact]
+    public async Task APinnedDisposableIsNotDisposedByTheContainersItIsHandedTo() {
+        var tracked = new Tracked();
+
+        var harness = new Harness(
+            services => services.AddSingleton(_ => tracked),
+            typeof(Tracked));
+
+        var first = await harness.Source.CreateAsync();
+        var second = await harness.Source.CreateAsync();
+
+        Assert.Same(tracked, first.GetRequiredService<Tracked>());
+        Assert.Same(tracked, second.GetRequiredService<Tracked>());
+
+        ((IDisposable)first).Dispose();
+        ((IDisposable)second).Dispose();
+
+        Assert.Equal(0, tracked.Disposals);
+    }
+
+    /// <summary>
+    /// A type registered more than once keeps every registration, because collapsing the set to its
+    /// last member would leave anything injecting the sequence one element long.
+    /// </summary>
+    [Fact]
+    public async Task PinningKeepsEveryRegistrationOfAService() {
+        var harness = new Harness(
+            services => {
+                services.AddSingleton<IThing, Thing>();
+                services.AddSingleton<IThing, Thing>();
+            },
+            typeof(IThing));
+
+        var built = await harness.Source.CreateAsync();
+
+        Assert.Equal(2, built.GetServices<IThing>().Count());
+        Assert.Equal(
+            harness.Pin.GetServices<IThing>(),
+            built.GetServices<IThing>());
+    }
+
+    /// <summary>
+    /// Nothing is built until something asks, so a test that never rebuilds pays for none of this.
+    /// </summary>
+    [Fact]
+    public void NothingIsBuiltUntilAsked() {
+        var harness = new Harness(services => services.AddSingleton<IThing, Thing>());
+
+        Assert.Empty(harness.Tracked);
+        Assert.Empty(harness.Started);
+    }
+
+    /// <summary>
+    /// A source nobody initialized says so, rather than answering with a container built from
+    /// nothing.
+    /// </summary>
+    [Fact]
+    public async Task AnUninitializedSourceRefuses() {
+        var source = new TestContainerSource();
+
+        var refused = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await source.CreateAsync());
+
+        Assert.Contains("never initialized", refused.Message);
+    }
+}


### PR DESCRIPTION
The DependencyModules half of [the container isolation plan](https://claude.ai/code/artifact/edfa53db-a5e4-4ab6-84a8-75a9dfbab8e3). Mechanism only. Nothing here changes what any existing test does, and no policy about when to rebuild lives in this repository.

## Why

A test method's invocations all share one container. That models a topology that need not exist: two queue handlers deployed as two functions are two processes, and a handler that passes only because a previous invocation warmed a singleton is a test that cannot fail for the reason production will.

## What this adds

`ITestContainerSource` builds a container per call from a template taken once off the test's own composition. It is registered into the collection like any other service, so anything driving the application can take one through constructor injection.

Nothing happens until something asks. The template is built on the first `CreateAsync` and not before, so a test that never rebuilds pays for none of this. Across the suite in the consuming framework that is roughly 90% of tests.

## What crosses between containers is declared

`ISharedTestRegistration` is how an attribute says so once, in its own definition, rather than every use site remembering `[Shared]`. The bar for taking it is narrow and is the whole of the reasoning:

> Implement it only where isolated would be broken for that attribute rather than merely unusual.

`[Mock]` clears it. A substitute resolved fresh per container is one the test can assert nothing about, because the call it is asking after was recorded onto a different object. So it is shared unconditionally and no use site writes a word.

`[TestExport]` does not clear it. A fresh fake per container is a coherent test and often the wanted one, so it implements the interface with `Shared` defaulting to **false** and asks at the use site:

```csharp
[TestExport(typeof(IOrderStore), Implementation = typeof(InMemoryOrderStore), Shared = true)]
```

`Shared` wins over `Lifetime`, deliberately. Keeping one object across containers is an instance registration, so setting it beside the default `Transient` is not a contradiction to refuse.

`[Shared]` is the same statement for one parameter, and parameters only. At a class or an assembly the obvious reading is "one container across the tests here", which would undo per-test isolation that already holds.

## Two details that are load-bearing

**The template uses `AddSingleton(instance)`, not a factory returning the instance.** Measured on MEDI 8.0.1: resolving one `IDisposable` from two containers gives 0 disposals for the instance overload and 2 for the factory, because a provider disposes what it created and a factory registration counts as created. The factory form would dispose a shared object once per container, the first landing while the others were still running.

**Pinning resolves through `IEnumerable<T>`.** Taking the single service would collapse a type registered more than once to its last member and leave anything injecting the sequence one element long.

## Both runners

xUnit and NUnit both hand every container they built to the disposal they already ran, NUnit in reverse so a built container goes before the one holding the instances it was handed. Startup attributes run against each container, because one that skipped them is not the one the test composed. That is also why `CreateAsync` is asynchronous: `ITestStartupAttribute` is.

## Tests

22 new, in three files. `SharedRegistrationsTests` pins the collection rule without a container or a framework. `TestContainerSourceUnitTests` covers the plumbing a running test cannot observe: every container reaching the runner, startup per container, a pinned disposable surviving its containers, multiple registrations kept, and nothing built until asked. `TestContainerSourceTests` asserts the contract end to end through real `[ModuleTest]` runs, including the `[TestExport]` default-isolated and `Shared = true` pair.

Full suite green in Release with `ContinuousIntegrationBuild=true`: 925 unit, 159 + 36 + 2 integration, both `net8.0` and `net10.0`.

The public API diff is purely additive. No member removed, no signature changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)