### PR TITLE
Cut 1.4.0: the test container source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-09-08
+
+### Added
+
+- `ITestContainerSource`, which builds a container per call from a template taken once off the
+  test's own composition. A test method's invocations all shared one container, and that models a
+  topology that need not exist: two queue handlers deployed as two functions are two processes, and
+  a handler passing only because a previous invocation warmed a singleton is a test that cannot fail
+  for the reason production will. Resolved like any other service, so anything driving an
+  application can take one. Nothing is built until something asks, so a test that never rebuilds
+  pays for none of it.
+
+- `ISharedTestRegistration`, which is how an attribute declares that what it registered is pinned
+  for the whole test rather than rebuilt with every container. The bar for taking it is that
+  isolated would be *broken* rather than merely unusual, so `[Mock]` and `[InjectValues]` take it
+  unconditionally - a substitute resolved fresh per container is one the test can assert nothing
+  about - while `[TestExport]` reads perfectly well isolated and therefore implements it with
+  `Shared` defaulting to false, asking at the use site instead. `Shared` wins over `Lifetime` there,
+  because keeping one object across containers is an instance registration whatever the
+  registration said.
+
+- `[Shared]`, the same statement for one parameter. Parameters only: at a class or an assembly the
+  obvious reading is "one container across the tests here", which would undo the per-test isolation
+  that already holds.
+
+  A minor version. Every addition is additive - no member removed, no signature changed - and a
+  suite that adopts none of it behaves exactly as it did.
+
+### Fixed
+
+- Both runners now hand every container a case built to the disposal they already ran, NUnit in
+  reverse so a container the source built goes before the one holding the instances it was handed.
+  Startup attributes run against each container, because one that skipped them is not the one the
+  test composed.
+
 ## [1.3.1] - 2026-09-05
 
 ### Fixed

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
         local and CI builds fall back to the values below.
     -->
     <PropertyGroup>
-        <VersionPrefix>1.3.1</VersionPrefix>
+        <VersionPrefix>1.4.0</VersionPrefix>
         <!--
             Empty at 1.0.0. Set it again to cut a prerelease of the next version; the file version
             carries no prerelease part, so it stays put until the version it does carry changes.
@@ -22,7 +22,7 @@
             depend on. It moves at 2.0.0.
         -->
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <FileVersion>1.3.1.0</FileVersion>
+        <FileVersion>1.4.0.0</FileVersion>
     </PropertyGroup>
 
     <!--


### PR DESCRIPTION
Release prep for 1.4.0. `VersionPrefix` and `FileVersion` move to 1.4.0, and the changelog gains its entry.

The published version comes from the `v*` tag, so this does not decide it. What it decides is what the continuous preview feed stamps: left at 1.3.1 the previews after this release would be `1.3.1-ci.N`, which sorts below both the released 1.3.1 and 1.4.0. That is the stale-line trap.

## What 1.4.0 contains

#59, and nothing else. `ITestContainerSource`, `ISharedTestRegistration`, `[Shared]`, and `[Mock]` / `[InjectValues]` / `[TestExport]` implementing the interface.

A minor version rather than a major: the public API diff is purely additive, no member removed and no signature changed, and a suite that adopts none of it behaves exactly as it did.

## Verified on this branch

- `dotnet build --configuration Release -p:ContinuousIntegrationBuild=true` — clean.
- `scripts/coverage.sh 85` — 90.6%, above the gate. `TestContainerSource` is at 100%.
- `scripts/verify-packages.sh 1.4.0` — packs the nine shipping projects and consumes them from throwaway apps on `net8.0` and `net10.0`; both resolved a generated registration at run time.

## Why now

`Hardened.Framework` needs it. Its half of this work is written and green against a local `1.4.0-isolation1` pack: 8341 tests pass in Release, and the eleven tests that changed are all ones whose subject is the reuse itself. That branch cannot reach CI until 1.4.0 is on nuget.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)