### PR TITLE
Pin every test parameter, and let a harness name the ones that drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-09-08
+
+### Changed
+
+- **A test parameter is now pinned without being asked.** 1.4.0 pinned only what an attribute
+  declared, and that is the wrong default: a parameter exists to be looked at, so handing the test
+  one container's instance while the invocation runs against another makes the assertion
+  meaningless. That is as true of a plain application class a handler appends to as it is of a
+  `[Mock]`, and no attribute is what makes it so.
+
+  1.4.0's rule failed on the first test a scaffolded project runs, which takes a plain class and
+  asserts on what the handler recorded. A rule that needs an attribute to work is a rule most tests
+  will not get.
+
+  The rule is now two sentences. A test parameter is one instance for the whole test, unless it is
+  something the harness supplies to drive the application. A registration nothing holds is per
+  container, unless the harness pins it by name.
+
+### Added
+
+- `ISharedTestRegistration.IsolatedServices(MethodInfo)`, which names the parameters that must *not*
+  be pinned because they build containers rather than live in one - a trigger façade, a test web
+  application, an `HttpClient`, a generated client. Only the harness supplying them can know which
+  they are, and it answers per test method because the answer is a property of the signature. It
+  wins over every other answer, including an explicit `[Shared]`: pinning one of these is not a
+  preference, it turns the isolation off while the test believes it is on.
+
+  A default implementation returning empty, so it is additive.
+
+- `IServiceProvider` is never pinned. A test asking for one is asking which container it is in,
+  which is the one question pinning cannot answer.
+
+### Note
+
+1.4.0 was released the same day and is superseded by this. Its only difference is the default above,
+and nothing consumed it.
+
 ## [1.4.0] - 2026-09-08
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
         local and CI builds fall back to the values below.
     -->
     <PropertyGroup>
-        <VersionPrefix>1.4.0</VersionPrefix>
+        <VersionPrefix>1.5.0</VersionPrefix>
         <!--
             Empty at 1.0.0. Set it again to cut a prerelease of the next version; the file version
             carries no prerelease part, so it stays put until the version it does carry changes.
@@ -22,7 +22,7 @@
             depend on. It moves at 2.0.0.
         -->
         <AssemblyVersion>1.0.0.0</AssemblyVersion>
-        <FileVersion>1.4.0.0</FileVersion>
+        <FileVersion>1.5.0.0</FileVersion>
     </PropertyGroup>
 
     <!--

--- a/src/DependencyModules.Testing/Attributes/Interfaces/ISharedTestRegistration.cs
+++ b/src/DependencyModules.Testing/Attributes/Interfaces/ISharedTestRegistration.cs
@@ -1,23 +1,36 @@
+using System.Reflection;
 namespace DependencyModules.Testing.Attributes.Interfaces;
 
 /// <summary>
-/// Declares that what an attribute registered is pinned for the whole test, rather than rebuilt
-/// with every container the test creates.
+/// Adjusts which objects survive a test's container being rebuilt.
 /// </summary>
 /// <remarks>
 /// <para>
-/// A test that builds a container per invocation needs some things to survive the rebuild. A mock is
-/// the clear case: a substitute resolved fresh per container is one the test can assert nothing
-/// about, because the invocation recorded onto a different object. Implementing this is how an
-/// attribute says so once, in its own definition, rather than every use site remembering
-/// <c>[Shared]</c>.
+/// The default needs no attribute, and is two sentences:
 /// </para>
 /// <para>
-/// <b>The bar is narrow.</b> Implement this only where isolated would be <em>broken</em> for the
-/// attribute rather than merely unusual. Hiding a decision from the reader of a test is a cost;
-/// hiding a non-decision is not. <see cref="MockAttribute"/> clears the bar because an isolated mock
-/// has no coherent reading at all. <see cref="TestExportAttribute"/> does not, which is why it
-/// implements this with <c>Shared</c> defaulting to false and leaves the choice at the use site.
+/// <b>A test parameter is one instance for the whole test, unless it is something the harness
+/// supplies to drive the application. A registration nothing holds is per container, unless the
+/// harness pins it by name.</b>
+/// </para>
+/// <para>
+/// A parameter exists to be looked at - the test was handed it so it could assert on it, or
+/// configure it and then assert on something else - so handing the test one container's instance
+/// while the invocation runs against another makes the assertion meaningless. That is true of a
+/// <c>[Mock]</c>, of a plain application class a handler appends to, and of a registry a test
+/// registers a filter on, and no attribute is what makes it so.
+/// </para>
+/// <para>
+/// <b>This interface is for the two exceptions.</b> <see cref="IsolatedServices"/> names the
+/// parameters that must <em>not</em> be pinned because they build containers rather than live in
+/// one, and <see cref="SharedServices"/> names services no parameter holds that should be kept
+/// anyway. <see cref="Shared"/> answering false declines the default for one parameter.
+/// </para>
+/// <para>
+/// An earlier version of this pinned only what an attribute declared. It failed on the first thing
+/// a new user runs: a scaffolded test taking a plain application class and asserting on what the
+/// handler recorded, which was rebuilt with the container the send ran on. A rule that needs an
+/// attribute to work is a rule most tests will not get.
 /// </para>
 /// </remarks>
 public interface ISharedTestRegistration {
@@ -27,18 +40,49 @@ public interface ISharedTestRegistration {
     /// </summary>
     /// <remarks>
     /// A <c>bool</c> rather than a bare marker interface, so an attribute whose answer depends on how
-    /// it was constructed can say so. The default suits an attribute that is always shared.
+    /// it was constructed can say so. On a parameter attribute this is only worth answering to
+    /// decline, since a parameter is pinned without being asked.
     /// </remarks>
     bool Shared => true;
 
     /// <summary>
-    /// The services to pin, for an attribute that registers one without naming a parameter.
+    /// Services to pin that no test parameter holds.
     /// </summary>
     /// <remarks>
-    /// Empty means the harness already knows what to pin, which is the parameter's type for an
-    /// attribute sitting on one. An <see cref="ITestServiceSetupAttribute"/> has no parameter to read,
-    /// so it answers here - which is also what lets an implementation outside this assembly join in
-    /// without the runner knowing about it.
+    /// The second exception. A parameter is pinned because the test holds it; something nothing holds
+    /// needs naming, which is how a harness keeps its own per-test services - a cancellation token, an
+    /// environment - one object across every container, and how
+    /// <c>[TestExport(Shared = true)]</c> keeps a fake a handler resolves and the test never sees.
     /// </remarks>
     IReadOnlyList<Type> SharedServices => [];
+
+    /// <summary>
+    /// Parameters this attribute supplies that must <em>not</em> be pinned, because they build
+    /// containers rather than live in one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The exception to the rule that a test parameter is one instance. A trigger façade, a test web
+    /// application, an <c>HttpClient</c> and a generated client are handed to a test so it can drive
+    /// the application, and each builds a container per call - so pinning one would pin the very
+    /// thing that is supposed to be rebuilt, and every call would run against one container while
+    /// the test believed otherwise.
+    /// </para>
+    /// <para>
+    /// Named by the attribute that supplies them, because nothing else can know. They are ordinary
+    /// types in an ordinary signature, indistinguishable from a service the application registered
+    /// until you know which harness put them there.
+    /// </para>
+    /// <para>
+    /// Takes the test method, unlike <see cref="SharedServices"/>, because the answer is a property
+    /// of the signature: an attribute supplies a façade for <em>this</em> test's parameters and has
+    /// no fixed list of its own.
+    /// </para>
+    /// <para>
+    /// This wins over every other answer here, including an explicit <c>[Shared]</c>. Pinning one of
+    /// these is not a preference that could go either way; it silently turns the isolation off.
+    /// </para>
+    /// </remarks>
+    /// <param name="testMethod">The test whose parameters are being supplied.</param>
+    IReadOnlyList<Type> IsolatedServices(MethodInfo testMethod) => [];
 }

--- a/src/DependencyModules.Testing/Impl/SharedRegistrations.cs
+++ b/src/DependencyModules.Testing/Impl/SharedRegistrations.cs
@@ -4,7 +4,7 @@ using DependencyModules.Testing.Attributes.Interfaces;
 namespace DependencyModules.Testing.Impl;
 
 /// <summary>
-/// Works out which services are pinned for one test.
+/// Works out which services survive a test's container being rebuilt.
 /// </summary>
 /// <remarks>
 /// Shared by every integration, because the rule is the same one wherever the test runs and only the
@@ -13,21 +13,43 @@ namespace DependencyModules.Testing.Impl;
 public static class SharedRegistrations {
 
     /// <summary>
+    /// Types the harness itself can never pin, whatever anything else says.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="IServiceProvider"/> is the container. A test asking for one is asking which
+    /// container it is in, which is the one question pinning cannot answer.
+    /// </remarks>
+    private static readonly Type[] NeverPinned = [typeof(IServiceProvider)];
+
+    /// <summary>
     /// The service types to keep across every container the test builds.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Two sources, and the difference is only in how each names what it registered. An attribute on
-    /// the method, the class or the assembly registers a service without naming a parameter, so it
-    /// answers <see cref="ISharedTestRegistration.SharedServices"/> - <c>[TestExport]</c> names the
-    /// service it exported. An attribute on a parameter has one by definition, so an empty
-    /// <c>SharedServices</c> is read as that parameter's type, which is what keeps <c>[Mock]</c> to a
-    /// single interface on the class and nothing else.
+    /// The rule, in the order it is applied:
     /// </para>
     /// <para>
-    /// An attribute answering <c>Shared</c> false contributes nothing rather than un-pinning what
-    /// something else pinned. Two attributes naming one service disagreeing is a use site asking for
-    /// both, and pinning is the answer that leaves the test able to see what it asked to see.
+    /// <b>Every parameter the test is handed is pinned.</b> A parameter exists to be looked at, so
+    /// handing the test one container's instance while the invocation runs against another makes the
+    /// assertion meaningless. That is as true of a plain application class the handler appends to as
+    /// it is of a <c>[Mock]</c>, which is why no attribute is required and why an earlier version of
+    /// this that required one failed on the first test a scaffolded project runs.
+    /// </para>
+    /// <para>
+    /// <b>Except the ones that drive the application.</b> A façade, a test web application, an
+    /// <c>HttpClient</c> and a generated client build a container per call, so pinning one pins the
+    /// thing meant to be rebuilt. Only the harness that supplies them knows which they are, so it
+    /// names them through <see cref="ISharedTestRegistration.IsolatedServices"/>, and that answer
+    /// wins over everything else here - it is correctness rather than preference.
+    /// </para>
+    /// <para>
+    /// <b>Plus what no parameter holds but something asked for.</b> A harness's own per-test
+    /// services, and <c>[TestExport(Shared = true)]</c>.
+    /// </para>
+    /// <para>
+    /// A type nothing registered can end up in this set - a value from a data row, a concrete class
+    /// the resolver constructs - and that is inert rather than wrong. Pinning rewrites descriptors,
+    /// and there are none to rewrite.
     /// </para>
     /// </remarks>
     /// <param name="method">The test method, for its parameters.</param>
@@ -35,9 +57,41 @@ public static class SharedRegistrations {
     /// The attributes in scope for the test, widest first, as the runner collected them.
     /// </param>
     public static IReadOnlyCollection<Type> Collect(MethodInfo method, IEnumerable<Attribute> knownAttributes) {
+        var attributes = knownAttributes as IReadOnlyCollection<Attribute> ?? knownAttributes.ToArray();
+
+        var isolated = new HashSet<Type>(NeverPinned);
+
+        foreach (var registration in attributes.OfType<ISharedTestRegistration>()) {
+            foreach (var service in registration.IsolatedServices(method)) {
+                isolated.Add(service);
+            }
+        }
+
         var pinned = new HashSet<Type>();
 
-        foreach (var registration in knownAttributes.OfType<ISharedTestRegistration>()) {
+        foreach (var parameter in method.GetParameters()) {
+            var declarations = parameter.GetCustomAttributes()
+                .OfType<ISharedTestRegistration>()
+                .ToArray();
+
+            // Declining is the only thing worth saying on a parameter, since one is pinned without
+            // being asked. A second attribute asking cannot undo it: two attributes on one parameter
+            // disagreeing is a use site asking for both, and pinned is the answer that leaves the
+            // test able to see what it was asserting on.
+            if (declarations.Any(declaration => !declaration.Shared)) {
+                continue;
+            }
+
+            pinned.Add(parameter.ParameterType);
+
+            foreach (var declaration in declarations) {
+                foreach (var service in declaration.SharedServices) {
+                    pinned.Add(service);
+                }
+            }
+        }
+
+        foreach (var registration in attributes.OfType<ISharedTestRegistration>()) {
             if (!registration.Shared) {
                 continue;
             }
@@ -47,23 +101,7 @@ public static class SharedRegistrations {
             }
         }
 
-        foreach (var parameter in method.GetParameters()) {
-            foreach (var registration in parameter.GetCustomAttributes().OfType<ISharedTestRegistration>()) {
-                if (!registration.Shared) {
-                    continue;
-                }
-
-                if (registration.SharedServices.Count == 0) {
-                    pinned.Add(parameter.ParameterType);
-
-                    continue;
-                }
-
-                foreach (var service in registration.SharedServices) {
-                    pinned.Add(service);
-                }
-            }
-        }
+        pinned.ExceptWith(isolated);
 
         return pinned;
     }

--- a/src/DependencyModules.Testing/Impl/TestContainerSource.cs
+++ b/src/DependencyModules.Testing/Impl/TestContainerSource.cs
@@ -104,15 +104,16 @@ public sealed class TestContainerSource : ITestContainerSource {
     /// </para>
     /// </remarks>
     private static IServiceCollection BuildTemplate(Composition composition) {
+        var instances = Resolve(composition);
+
         IServiceCollection template = new ServiceCollection();
         var taken = new HashSet<Type>();
 
         foreach (var descriptor in composition.Services) {
             var serviceType = descriptor.ServiceType;
 
-            if (!composition.PinnedServices.Contains(serviceType) ||
-                descriptor.ImplementationInstance != null ||
-                serviceType.IsGenericTypeDefinition) {
+            if (!instances.TryGetValue(serviceType, out var pinned) ||
+                descriptor.ImplementationInstance != null) {
                 template.Add(descriptor);
 
                 continue;
@@ -122,16 +123,70 @@ public sealed class TestContainerSource : ITestContainerSource {
                 continue;
             }
 
-            var sequence = typeof(IEnumerable<>).MakeGenericType(serviceType);
-
-            foreach (var instance in (IEnumerable)composition.Pinned.GetRequiredService(sequence)) {
-                if (instance != null) {
-                    template.Add(new ServiceDescriptor(serviceType, instance));
-                }
+            foreach (var instance in pinned) {
+                template.Add(new ServiceDescriptor(serviceType, instance));
             }
         }
 
         return template;
+    }
+
+    /// <summary>
+    /// The instances to keep, for the pinned services the first container can actually produce.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>A service that cannot be produced is left alone rather than being an error.</b> Pinning is
+    /// a statement about identity, not a reason to construct something the test never asked for, and
+    /// a pinned set drawn from a signature holds types nothing registered - a value from a data row,
+    /// a concrete class the resolver builds on the spot - alongside the ones that matter.
+    /// </para>
+    /// <para>
+    /// The case that made this necessary is sharper than an absent registration. A harness may
+    /// register a <em>deliberately failing</em> factory for a parameter it cannot supply, so that
+    /// resolving it fails with a message naming the fix. Resolving eagerly here turned that message
+    /// into a failure at container build for every test that took such a parameter and never
+    /// resolved it - a data-driven test whose row supplies a string, for one. Leaving the descriptor
+    /// alone means the test either never resolves it, or resolves it and gets the error the harness
+    /// wrote.
+    /// </para>
+    /// <para>
+    /// Resolved through <c>IEnumerable&lt;T&gt;</c> rather than as a single service, so a type
+    /// registered more than once keeps every registration and its order. Taking the single service
+    /// would collapse the set to its last member and leave anything injecting the sequence one
+    /// element long.
+    /// </para>
+    /// <para>
+    /// An open generic is skipped, having no closed type to resolve.
+    /// </para>
+    /// </remarks>
+    private static Dictionary<Type, object[]> Resolve(Composition composition) {
+        var instances = new Dictionary<Type, object[]>();
+
+        foreach (var serviceType in composition.PinnedServices) {
+            if (serviceType.IsGenericTypeDefinition || serviceType.IsByRef || serviceType.IsPointer) {
+                continue;
+            }
+
+            object[] resolved;
+
+            try {
+                var sequence = typeof(IEnumerable<>).MakeGenericType(serviceType);
+
+                resolved = ((IEnumerable)composition.Pinned.GetRequiredService(sequence))
+                    .Cast<object>()
+                    .Where(instance => instance != null)
+                    .ToArray();
+            } catch (Exception) {
+                continue;
+            }
+
+            if (resolved.Length > 0) {
+                instances[serviceType] = resolved;
+            }
+        }
+
+        return instances;
     }
 
     private sealed record Composition(

--- a/tests/DependencyModules.Tests/Snapshots/PublicApiTests.TestingApi.verified.txt
+++ b/tests/DependencyModules.Tests/Snapshots/PublicApiTests.TestingApi.verified.txt
@@ -56,6 +56,7 @@ namespace DependencyModules.Testing.Attributes.Interfaces
     {
         bool Shared { get; }
         System.Collections.Generic.IReadOnlyList<System.Type> SharedServices { get; }
+        System.Collections.Generic.IReadOnlyList<System.Type> IsolatedServices(System.Reflection.MethodInfo testMethod);
     }
     public interface ITestContainerSource
     {

--- a/tests/DependencyModules.Tests/TestingTests/SharedRegistrationsTests.cs
+++ b/tests/DependencyModules.Tests/TestingTests/SharedRegistrationsTests.cs
@@ -10,6 +10,10 @@ namespace DependencyModules.Tests.TestingTests;
 /// <summary>
 /// Which services a test pins, decided without a container or a test framework in the way.
 /// </summary>
+/// <remarks>
+/// One test per row of the rule, because the rule has been wrong once already and the way it was
+/// wrong was a case nobody had written down.
+/// </remarks>
 public class SharedRegistrationsTests {
 
     private interface IThing;
@@ -18,11 +22,21 @@ public class SharedRegistrationsTests {
 
     private class Thing : IThing;
 
-    /// <summary>An attribute that answers no, to prove declining is not the same as not implementing.</summary>
+    /// <summary>Stands for a façade or a client: something the harness supplies to drive with.</summary>
+    private interface IDriver;
+
+    /// <summary>An attribute that declines, which is the only thing worth saying on a parameter.</summary>
     private class NotSharedAttribute : Attribute, ISharedTestRegistration {
         public bool Shared => false;
+    }
 
-        public IReadOnlyList<Type> SharedServices => [typeof(IOther)];
+    /// <summary>A harness naming what it supplies, the way the trigger and web attributes do.</summary>
+    private class DrivenByAttribute : Attribute, ISharedTestRegistration {
+        public IReadOnlyList<Type> IsolatedServices(MethodInfo testMethod) =>
+            testMethod.GetParameters()
+                .Where(parameter => parameter.ParameterType == typeof(IDriver))
+                .Select(parameter => parameter.ParameterType)
+                .ToArray();
     }
 
     private static IReadOnlyCollection<Type> Collect(string method, params Attribute[] known) =>
@@ -32,72 +46,117 @@ public class SharedRegistrationsTests {
 
     private static void Plain(IThing thing) { }
 
+    private static void Bare(IThing thing, IOther other) { }
+
     private static void Marked([Shared] IThing thing) { }
 
     private static void Mocked([Mock] IThing thing) { }
 
     private static void Declined([NotShared] IThing thing) { }
 
-    private static void Several([Shared] IThing thing, [Mock] IOther other, string plain) { }
+    private static void Driving(IDriver driver, IThing thing) { }
 
-    /// <summary>A parameter says nothing on its own, which is what keeps the default isolated.</summary>
-    [Fact]
-    public void AnUnmarkedParameterIsNotPinned() {
-        Assert.Empty(Collect(nameof(Plain)));
-    }
+    private static void DrivingAndMarked([Shared] IDriver driver) { }
 
-    [Fact]
-    public void SharedPinsTheParametersType() {
-        Assert.Equal([typeof(IThing)], Collect(nameof(Marked)));
-    }
+    private static void Container(IServiceProvider provider, IThing thing) { }
+
+    private static void None() { }
+
+    // ---------------------------------------------------------------- the default
 
     /// <summary>
-    /// The point of the interface: [Mock] pins without the use site writing [Shared].
+    /// The row the first version of this rule got wrong, and the one a scaffolded project hits
+    /// first: a plain application service the handler writes to and the test reads.
     /// </summary>
     [Fact]
-    public void MockPinsWithoutBeingAsked() {
+    public void AnUnmarkedParameterIsPinned() {
+        Assert.Equal([typeof(IThing)], Collect(nameof(Plain)));
+    }
+
+    [Fact]
+    public void EveryParameterIsPinned() {
+        Assert.Equal([typeof(IThing), typeof(IOther)], Collect(nameof(Bare)));
+    }
+
+    /// <summary>A mock needs no attribute to be pinned, which is what makes the rule general.</summary>
+    [Fact]
+    public void AMockIsPinnedLikeAnythingElse() {
         Assert.Equal([typeof(IThing)], Collect(nameof(Mocked)));
     }
 
+    /// <summary>Redundant now, and still allowed: it is how a driving parameter asks for reuse.</summary>
     [Fact]
-    public void AnAttributeAnsweringNoPinsNothing() {
+    public void SharedOnAValueParameterChangesNothing() {
+        Assert.Equal(Collect(nameof(Plain)), Collect(nameof(Marked)));
+    }
+
+    [Fact]
+    public void ATestWithNoParametersPinsNothing() {
+        Assert.Empty(Collect(nameof(None)));
+    }
+
+    // ---------------------------------------------------------------- the exceptions
+
+    /// <summary>
+    /// The parameter that drives the application is not pinned, because it builds the containers.
+    /// </summary>
+    [Fact]
+    public void AParameterTheHarnessDrivesWithIsNotPinned() {
+        var pinned = Collect(nameof(Driving), new DrivenByAttribute());
+
+        Assert.Equal([typeof(IThing)], pinned);
+    }
+
+    /// <summary>
+    /// And it stays unpinned even asked to be. Pinning a driver is not a preference that could go
+    /// either way; it turns the isolation off while the test believes it is on.
+    /// </summary>
+    [Fact]
+    public void IsolatedWinsOverAnExplicitShared() {
+        Assert.Empty(Collect(nameof(DrivingAndMarked), new DrivenByAttribute()));
+    }
+
+    [Fact]
+    public void AnAttributeDecliningUnpinsItsParameter() {
         Assert.Empty(Collect(nameof(Declined)));
     }
 
+    /// <summary>The container itself is the one question pinning cannot answer.</summary>
     [Fact]
-    public void EveryMarkedParameterIsCollected() {
-        Assert.Equal([typeof(IThing), typeof(IOther)], Collect(nameof(Several)));
+    public void TheServiceProviderIsNeverPinned() {
+        Assert.Equal([typeof(IThing)], Collect(nameof(Container)));
     }
 
+    // ---------------------------------------------------------------- what no parameter holds
+
     /// <summary>
-    /// An attribute with no parameter names what it registered, which is how [TestExport] joins in
-    /// from the method, the class or the assembly.
+    /// A harness keeps its own per-test services by naming them, since no parameter holds them.
     /// </summary>
     [Fact]
-    public void AnExportAskingToBeSharedNamesItsOwnService() {
-        var shared = new TestExportAttribute(typeof(IThing)) {
+    public void AnAttributeCanPinWhatNoParameterHolds() {
+        var shared = new TestExportAttribute(typeof(IOther)) {
             Implementation = typeof(Thing), Shared = true
         };
 
-        Assert.Equal([typeof(IThing)], Collect(nameof(Plain), shared));
+        Assert.Equal([typeof(IThing), typeof(IOther)], Collect(nameof(Plain), shared));
     }
 
-    /// <summary>The default, and the reason the default is what it is.</summary>
+    /// <summary>An export nothing holds stays per container until it asks.</summary>
     [Fact]
     public void AnExportIsNotPinnedUnlessItAsks() {
-        var isolated = new TestExportAttribute(typeof(IThing)) { Implementation = typeof(Thing) };
+        var isolated = new TestExportAttribute(typeof(IOther)) { Implementation = typeof(Thing) };
 
-        Assert.Empty(Collect(nameof(Plain), isolated));
+        Assert.Equal([typeof(IThing)], Collect(nameof(Plain), isolated));
     }
 
     /// <summary>
-    /// Two attributes naming one service and disagreeing is a use site asking for both. Pinning is
-    /// the answer that leaves the test able to see what it asked to see.
+    /// The parameter is the narrower statement and wins, which is how every other precedence in the
+    /// harness resolves. Isolating it would recreate the bug the rule exists to fix.
     /// </summary>
     [Fact]
-    public void OneAttributeAskingIsEnough() {
+    public void AnExportTheTestHoldsIsPinnedEvenWhenItDeclined() {
         var isolated = new TestExportAttribute(typeof(IThing)) { Implementation = typeof(Thing) };
 
-        Assert.Equal([typeof(IThing)], Collect(nameof(Marked), isolated));
+        Assert.Equal([typeof(IThing)], Collect(nameof(Plain), isolated));
     }
 }

--- a/tests/DependencyModules.Tests/TestingTests/TestContainerSourceTests.cs
+++ b/tests/DependencyModules.Tests/TestingTests/TestContainerSourceTests.cs
@@ -40,9 +40,36 @@ public interface IAudit {
 public class TestContainerSourceTests {
 
     /// <summary>
+    /// A parameter the test holds crosses every container, with nothing said about it.
+    /// </summary>
+    /// <remarks>
+    /// The row an earlier rule got wrong, and the shape of the scaffolded test that caught it: a
+    /// plain application class a handler writes to and the test reads. Pinning it is the default
+    /// because a parameter exists to be looked at, and looking at one container's instance while the
+    /// work ran in another says nothing.
+    /// </remarks>
+    [ModuleTest(typeof(ContainerSourceModule))]
+    public async Task ABareParameterIsTheSameObjectInEveryContainer(
+        ITestContainerSource source, ICounter counter) {
+        var first = await source.CreateAsync();
+        var second = await source.CreateAsync();
+
+        first.GetRequiredService<ICounter>().Bump();
+        second.GetRequiredService<ICounter>().Bump();
+
+        Assert.Same(counter, first.GetRequiredService<ICounter>());
+        Assert.Equal(2, counter.Value);
+    }
+
+    /// <summary>
     /// A singleton is a singleton inside one container and nothing more, which is the property the
     /// whole design turns on.
     /// </summary>
+    /// <remarks>
+    /// Asserted on a service the test does <em>not</em> take as a parameter, because taking one
+    /// pins it. That is the rule, and this is the test that would otherwise quietly stop testing
+    /// anything.
+    /// </remarks>
     [ModuleTest(typeof(ContainerSourceModule))]
     public async Task EachContainerGetsItsOwnApplicationSingleton(ITestContainerSource source) {
         var first = await source.CreateAsync();
@@ -104,11 +131,16 @@ public class TestContainerSourceTests {
     }
 
     /// <summary>
-    /// [Shared] does for anything what [Mock] does for a substitute, which is the escape hatch for a
-    /// value the test holds and asserts on.
+    /// [Shared] on a value parameter is redundant rather than wrong, and says the same thing the
+    /// default already says.
     /// </summary>
+    /// <remarks>
+    /// Kept working on purpose. The attribute earns its place on a parameter that drives the
+    /// application, where it asks for one container across the calls, and a reader should not have
+    /// to know which kind of parameter they are looking at before writing it.
+    /// </remarks>
     [ModuleTest(typeof(ContainerSourceModule))]
-    public async Task SharedPinsAPlainParameter(ITestContainerSource source, [Shared] ICounter counter) {
+    public async Task SharedOnAValueParameterIsRedundant(ITestContainerSource source, [Shared] ICounter counter) {
         var first = await source.CreateAsync();
         var second = await source.CreateAsync();
 

--- a/tests/DependencyModules.Tests/TestingTests/TestContainerSourceUnitTests.cs
+++ b/tests/DependencyModules.Tests/TestingTests/TestContainerSourceUnitTests.cs
@@ -148,4 +148,49 @@ public class TestContainerSourceUnitTests {
 
         Assert.Contains("never initialized", refused.Message);
     }
+
+    /// <summary>
+    /// A pinned service the first container cannot produce is left alone rather than failing the
+    /// build.
+    /// </summary>
+    /// <remarks>
+    /// The case that made this necessary: a harness registers a deliberately failing factory for a
+    /// parameter it cannot supply, so resolving it fails with a message naming the fix. Resolving
+    /// eagerly here turned that message into a failure at container build for every test that took
+    /// such a parameter and never resolved it.
+    /// </remarks>
+    [Fact]
+    public async Task APinnedServiceThatCannotBeBuiltIsLeftAlone() {
+        var harness = new Harness(
+            services => {
+                services.AddSingleton<IThing, Thing>();
+                services.AddSingleton<string>(_ => throw new InvalidOperationException("name the fix"));
+            },
+            typeof(IThing), typeof(string));
+
+        var built = await harness.Source.CreateAsync();
+
+        Assert.NotNull(built.GetRequiredService<IThing>());
+
+        var refused = Assert.Throws<InvalidOperationException>(() => built.GetRequiredService<string>());
+
+        Assert.Equal("name the fix", refused.Message);
+    }
+
+    /// <summary>
+    /// A pinned type nothing registered is inert, which is what lets the set be drawn from a
+    /// signature without filtering it first.
+    /// </summary>
+    [Fact]
+    public async Task APinnedTypeNothingRegisteredIsInert() {
+        var harness = new Harness(
+            services => services.AddSingleton<IThing, Thing>(),
+            typeof(IThing), typeof(int), typeof(Uri));
+
+        var built = await harness.Source.CreateAsync();
+
+        Assert.NotNull(built.GetRequiredService<IThing>());
+        Assert.Null(built.GetService<Uri>());
+    }
 }
+


### PR DESCRIPTION
1.4.0 shipped the wrong default. This fixes it, and writes the rule down so it does not move a third time: [What gets pinned](https://claude.ai/code/artifact/87062bb1-66fc-4c6e-849f-7e442f047bb0).

## What was wrong

1.4.0 pinned only what an attribute declared: `[Mock]` and `[InjectValues]` implement `ISharedTestRegistration`, `[Shared]` marks the rest. Coherent, and it survived every unit test here and 8341 in the consuming framework.

It failed on the first test a scaffolded project runs. That test takes a plain application class the handler appends to and asserts on what it recorded; with no attribute on it, it was rebuilt with the container the send ran on and the test read an empty one.

**A rule that needs an attribute to work is a rule most tests will not get.** A bare parameter is the common case, not the exception.

## The rule now

> A test parameter is one instance for the whole test, unless it is something the harness supplies to drive the application.
>
> A registration nothing holds is per container, unless the harness pins it by name.

A parameter exists to be looked at, so pinning it needs no attribute. `[Shared]` on a value parameter still works and is now redundant, deliberately: it earns its place on a parameter that drives the application, where it asks for one container across the calls, and a reader should not have to know which kind of parameter they are looking at before writing it.

## The one new member

`ISharedTestRegistration.IsolatedServices(MethodInfo)` names the parameters that must **not** be pinned, because they build containers rather than live in one: a trigger façade, `ITestWebApp`, `HttpClient`, a generated client. Only the harness supplying them can know which they are — they are ordinary types in an ordinary signature — and it answers per test method because the answer is a property of the signature rather than of the attribute.

It wins over an explicit `[Shared]`. Pinning one of these is not a preference that could go either way; it turns the isolation off while the test believes it is on.

`IServiceProvider` is never pinned either. A test asking for one is asking which container it is in, which is the one question pinning cannot answer.

Default implementation returning empty, so the public API diff is a single added member. Nothing removed, no signature changed.

## Tests

`SharedRegistrationsTests` is rewritten as one test per row of the rule, twelve of them, because the way it was wrong last time was a case nobody had written down. The container-level tests gain `ABareParameterIsTheSameObjectInEveryContainer`, which is the shape that caught this.

`EachContainerGetsItsOwnApplicationSingleton` now asserts on a service the test does **not** take as a parameter, since taking one pins it. Without that change it would have quietly stopped testing anything.

## Verified

- `dotnet build --configuration Release -p:ContinuousIntegrationBuild=true` — clean.
- `scripts/coverage.sh 85` — 90.7%.
- `scripts/verify-packages.sh 1.5.0` — real consumers on net8.0 and net10.0.
- Full suite green on both target frameworks.

1.4.0 was released hours ago and nothing consumed it, so the cost of superseding it is nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)